### PR TITLE
add-gov-aws-tags: adding in tags enforcement example

### DIFF
--- a/governance/aws/enforce-mandatory-tags.sentinel
+++ b/governance/aws/enforce-mandatory-tags.sentinel
@@ -1,6 +1,8 @@
 import "tfplan"
 
-# Warning, this is case sensitive.  This is on purpose especially for organizations that do cost analysis on tag names.   Case sensitivity enforcements allow you to not have duplicates by case 
+# Warning, this is case sensitive.  
+# This is on purpose especially for organizations that do cost analysis on tag names.
+# where case sensitivity will cause grouping issues
 
 mandatory_tags = [
   "TTL", 

--- a/governance/aws/enforce-mandatory-tags.sentinel
+++ b/governance/aws/enforce-mandatory-tags.sentinel
@@ -1,0 +1,34 @@
+import "tfplan"
+
+# Warning, this is case sensitive.  This is on purpose especially for organizations that do cost analysis on tag names.   Case sensitivity enforcements allow you to not have duplicates by case 
+
+mandatory_tags = [
+  "TTL", 
+  "Owner",
+]
+
+# Get all AWS instances contained in all modules being used
+get_aws_instances = func() {
+    instances = []
+    for tfplan.module_paths as path {
+        instances += values(tfplan.module(path).resources.aws_instance) else []
+    }
+    return instances
+}
+    
+aws_instances = get_aws_instances()
+
+# Instance tag rule
+instance_tags = rule {
+    all aws_instances as _, instances {
+    	all instances as index, r {
+            all mandatory_tags as t {
+                r.applied.tags contains t
+            }
+        }
+    }
+}
+
+main = rule {
+    (instance_tags) else true
+}


### PR DESCRIPTION
Shamelessly copied from other work, but creating an easy to use  policy for examples and usage with our N.E.P.T.R.