### PR TITLE
set resource group in modules

### DIFF
--- a/infrastructure-as-code/azure-vm/main.tf
+++ b/infrastructure-as-code/azure-vm/main.tf
@@ -20,6 +20,7 @@ module "windowsserver" {
   source              = "Azure/compute/azurerm"
   version             = "1.1.5"
   location            = "${var.location}"
+  resource_group_name = "${var.windows_dns_prefix}-rc"
   vm_hostname         = "pwc-ptfe"
   admin_password      = "${var.admin_password}"
   vm_os_simple        = "WindowsServer"
@@ -31,7 +32,7 @@ module "network" {
   source              = "Azure/network/azurerm"
   version             = "1.1.1"
   location            = "${var.location}"
-  resource_group_name = "terraform-compute"
+  resource_group_name = "${var.windows_dns_prefix}-rc"
   allow_ssh_traffic   = true
 }
 


### PR DESCRIPTION
Setting resource group in all modules will avoid conflicts in cases where multiple SEs use this code at the same time.  Previously, resource group was set to "terraform-compute"