### PR TITLE
Initial commit for terraform-gcp-cloudsql

### DIFF
--- a/infrastructure-as-code/terraform-gcp-cloudsql/.gitignore
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/.gitignore
@@ -1,0 +1,12 @@
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# .tfvars files
+*.tfvars
+
+# Emacs backup files
+*~

--- a/infrastructure-as-code/terraform-gcp-cloudsql/LICENSE
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 kawsark-git-org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/infrastructure-as-code/terraform-gcp-cloudsql/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/README.md
@@ -1,0 +1,70 @@
+# Provision a Cloud SQL instance for PostgreSQL on Google Cloud Platform.
+
+[Cloud SQL for PostgreSQL(https://cloud.google.com/sql/docs/postgres/) is a fully-managed PostgreSQL relational database service on Google Cloud Platform. This Terraform configuration will create a Cloud SQL PostgreSQL V9.6 instance in Google Cloud. It can also be used as a Module to instantiate one or more instances quickly.
+
+### Pre-requisites:
+- A [Google Cloud](https://cloud.google.com/) account and [project](https://cloud.google.com/docs/overview/#projects).
+- `Google Cloud SQL` and `Cloud SQL Admin API` APIs must be enabled on the project. This can be enabled on [Google cloud console](https://support.google.com/cloud/answer/6158841?hl=en) or CLI.
+- Google Cloud credentials `.json` file from a Service Account is required. This can be obtained by generating a [Service Account Key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+- Terraform installed on a machine where this configuration will be downloaded and run: [Terraform install instructions](https://www.terraform.io/intro/getting-started/install.html)
+
+### Module Examples:
+- [Simple](examples/simple/README.md): Provisions an example Cloud SQL instance.
+- [Prod and Dev](examples/prod-and-dev/README.md): Provisions example Prod and Dev CloudSQL instances.
+
+### Usage:
+
+**Download and configure provider:**
+- Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql`.
+- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+```
+export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
+export GOOGLE_PROJECT=<name-of-project>
+```
+
+**Set Configuration variables:**
+- Set the following [Terraform Configuration variables](https://www.terraform.io/docs/configuration/variables.html) specified as environment variables with `TF_VAR` prefix.
+```
+export TF_VAR_gcp_sql_root_user_pw=<pw>
+export TF_VAR_authorized_network="$(curl whatismyip.akamai.com)/32"
+```
+- Note: the `authorized_network` variable above should be set to the system you will access PostgreSQL from. In this we are assuming Terraform will run from the same machine that PostgreSQL will be accessed from. This assumption will not hold true in case of Terraform Enterprise or a separate Terraform build server.
+- Adjust any other Terraform configuration variables in [variables.tf](variables.tf).
+
+**Run terraform:**
+- Run the terraform commands below to initialize the configuration:
+```
+terraform init
+terraform plan
+```
+- If everything looks good, go ahead with apply: `terraform apply`.
+- To view outputs issue: `terraform output`.
+
+**(Optional) Connect to PostgreSQL instance**:
+- To connect to PostgreSQL using the `psql` CLI, please install it on your system (if not already available).
+- Make a note of the IP address from terraform output: `terraform output`. If you have `jq` installed, you can export it to a variable: `export sql_ip=$(terraform output -json | jq -r .ip.value)`
+- Adjust the `hostaddr` parameter to connect using `psql`:
+```
+psql "sslmode=disable dbname=postgres user=root hostaddr=${sql_ip}"
+```
+- (Optional): run some sql statements from the `psql` prompt:
+```
+CREATE TABLE cities (
+	name            varchar(80),
+	location        char(2)
+	);
+INSERT INTO cities VALUES ('San Francisco', 'CA');
+INSERT INTO cities VALUES ('Buffalo', 'NY');
+SELECT * from cities;
+\q
+```
+
+**Cleanup:**
+- To destroy the Cloud SQL instance, issue: `terraform destroy`.
+- Unset environment variables:
+```
+unset GOOGLE_CLOUD_KEYFILE_JSON
+unset GOOGLE_PROJECT
+unset TF_VAR_gcp_sql_root_user_pw
+unset GOOGLE_PROJECT
+```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/README.md
@@ -1,0 +1,66 @@
+## Provision PostgreSQL Google Cloud SQL instance using modules.
+
+This Terraform Configuration provisions 2 Google Cloud SQL PostgreSQL instances on Google Cloud using the  `terraform-gcp-cloudsql` module. The example modules are named as `prod-gcp-cloudsql` and `dev-gcp-cloudsql`.
+
+**Download and configure provider:**
+- Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql/examples/prod-and-dev`.
+- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+```
+export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
+export GOOGLE_PROJECT=<name-of-project>
+```
+
+**Set Configuration variables:**
+- Set the following [Terraform Configuration variables](https://www.terraform.io/docs/configuration/variables.html) specified as environment variables with `TF_VAR` prefix.
+```
+export TF_VAR_gcp_sql_root_user_pw=<pw>
+export TF_VAR_authorized_network="$(curl whatismyip.akamai.com)/32"
+```
+- Note: the `authorized_network` variable above should be set to the system you will access PostgreSQL from. In this we are assuming Terraform will run from the same machine that PostgreSQL will be accessed from. This assumption will not hold true in case of Terraform Enterprise or a separate Terraform build server.
+- Adjust any other Terraform configuration variables in [variables.tf](variables.tf).
+
+**Run terraform:**
+- Run the terraform commands below to initialize the configuration:
+```
+terraform init
+terraform plan
+```
+- Note: if you made any changes to the module, obtain the latest version using: `terraform get -update=true`.
+- If everything looks good, go ahead with apply: `terraform apply`.
+- To view module outputs issue the following commands:
+```
+terraform output -module=prod-gcp-cloudsql
+terraform output -module=dev-gcp-cloudsql
+```
+
+
+**(Optional) Connect to PostgreSQL instance**:
+- To connect to PostgreSQL using the `psql` CLI, please install it on your system (if not already available).
+- Make a note of the IP addresses from terraform output commands above.
+  - If you have `jq` installed, you can export these addresses to variables:
+  - For the `prod-gcp-cloudsql`, issue: `export prod_sql_ip=$(terraform output -module=prod-gcp-cloudsql -json | jq -r .ip.value)`
+  - For the `dev-gcp-cloudsql`, issue: `export dev_sql_ip=$(terraform output -module=dev-gcp-cloudsql -json | jq -r .ip.value)`
+- Adjust the `hostaddr` parameter to connect using `psql`:
+  - Prod instance: `psql "sslmode=disable dbname=postgres user=root hostaddr=${prod_sql_ip}"`
+  - Dev instance: `psql "sslmode=disable dbname=postgres user=root hostaddr=${dev_sql_ip}"`
+- (Optional): run some sql statements from the `psql` prompt:
+```
+CREATE TABLE cities (
+	name            varchar(80),
+	location        char(2)
+	);
+INSERT INTO cities VALUES ('San Francisco', 'CA');
+INSERT INTO cities VALUES ('Buffalo', 'NY');
+SELECT * from cities;
+\q
+```
+
+**Cleanup:**
+- To destroy the Cloud SQL instance, issue: `terraform destroy`.
+- Unset environment variables:
+```
+unset GOOGLE_CLOUD_KEYFILE_JSON
+unset GOOGLE_PROJECT
+unset TF_VAR_gcp_sql_root_user_pw
+unset GOOGLE_PROJECT
+```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/main.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  default = "us-central1"
+}
+
+variable "gcp_sql_root_user_pw" {}
+
+variable "authorized_network" {}
+
+module "prod-gcp-cloudsql" {
+  source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql" 
+  region  = "${var.region}"
+  database_name = "prod-gcp-cloudsql"
+  gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
+  authorized_network = "${var.authorized_network}"
+}
+
+module "dev-gcp-cloudsql" {
+  source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql" 
+  region  = "${var.region}"
+  database_name = "dev-gcp-cloudsql"
+  gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
+  authorized_network = "${var.authorized_network}"
+}

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/README.md
@@ -1,0 +1,57 @@
+## Provision PostgreSQL Google Cloud SQL instance using a module.
+
+This Terraform Configuration provisions a Google Cloud SQL PostgreSQL instance on Google Cloud using the  `terraform-gcp-cloudsql` module. The example module is named `example-gcp-cloudsql`.
+
+**Download and configure provider:**
+- Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql/examples/simple`.
+- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+```
+export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
+export GOOGLE_PROJECT=<name-of-project>
+```
+
+**Set Configuration variables:**
+- Set the following [Terraform Configuration variables](https://www.terraform.io/docs/configuration/variables.html) specified as environment variables with `TF_VAR` prefix.
+```
+export TF_VAR_gcp_sql_root_user_pw=<pw>
+export TF_VAR_authorized_network="$(curl whatismyip.akamai.com)/32"
+```
+- Note: the `authorized_network` variable above should be set to the system you will access PostgreSQL from. In this we are assuming Terraform will run from the same machine that PostgreSQL will be accessed from. This assumption will not hold true in case of Terraform Enterprise or a separate Terraform build server.
+- Adjust any other Terraform configuration variables in [variables.tf](variables.tf).
+
+**Run terraform:**
+- Run the terraform commands below to initialize the configuration:
+```
+terraform init
+terraform plan
+```
+- Note: if you made any changes to the module, obtain the latest version using: `terraform get -update=true`.
+- If everything looks good, go ahead with apply: `terraform apply`.
+- To view module outputs issue the following commands: `terraform output -module=example-gcp-cloudsql`
+
+**(Optional) Connect to PostgreSQL instance**:
+- To connect to PostgreSQL using the `psql` CLI, please install it on your system (if not already available).
+- Make a note of the IP address from terraform output command: `terraform output -module=example-gcp-cloudsql`.
+  - If you have `jq` installed, you can export it to a variable: `export sql_ip=$(terraform output -module=example-gcp-cloudsql -json | jq -r .ip.value)`
+- Adjust the `hostaddr` parameter to connect using `psql`: `psql "sslmode=disable dbname=postgres user=root hostaddr=${sql_ip}"`
+- (Optional): run some sql statements from the `psql` prompt:
+```
+CREATE TABLE cities (
+	name            varchar(80),
+	location        char(2)
+	);
+INSERT INTO cities VALUES ('San Francisco', 'CA');
+INSERT INTO cities VALUES ('Buffalo', 'NY');
+SELECT * from cities;
+\q
+```
+
+**Cleanup:**
+- To destroy the Cloud SQL instance, issue: `terraform destroy`.
+- Unset environment variables:
+```
+unset GOOGLE_CLOUD_KEYFILE_JSON
+unset GOOGLE_PROJECT
+unset TF_VAR_gcp_sql_root_user_pw
+unset GOOGLE_PROJECT
+```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/main.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  default = "us-central1"
+}
+
+variable "gcp_sql_root_user_pw" {}
+
+variable "authorized_network" {}
+
+module "example-gcp-cloudsql" {
+  source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql"
+  region  = "${var.region}"
+  database_name = "example-gcp-cloudsql"
+  gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
+  authorized_network = "${var.authorized_network}"
+}
+

--- a/infrastructure-as-code/terraform-gcp-cloudsql/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/main.tf
@@ -1,0 +1,31 @@
+provider "google" {
+  # Google provider credentials via environment variable: GOOGLE_CLOUD_KEYFILE_JSON
+  # Google project name configured via environment variable: GOOGLE_PROJECT
+  region  = "${var.region}"
+}
+
+resource "google_sql_database_instance" "cloudsql-postgres-master" {
+  name = "${var.database_name}"
+  database_version = "${var.database_version}"
+  region = "${var.region}"
+
+  settings {
+    # Second-generation instance tiers are based on the machine
+    # type. See argument reference below.
+    tier = "db-f1-micro"
+    ip_configuration {
+            ipv4_enabled = true
+            require_ssl = false
+            authorized_networks = {
+                name = "terraform-server-IP-whitelist"
+                value = "${var.authorized_network}"
+            }
+        }
+  }
+}
+
+resource "google_sql_user" "users" {
+  name     = "${var.gcp_sql_root_user_name}"
+  instance = "${google_sql_database_instance.cloudsql-postgres-master.name}"
+  password = "${var.gcp_sql_root_user_pw}"
+}

--- a/infrastructure-as-code/terraform-gcp-cloudsql/outputs.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/outputs.tf
@@ -1,0 +1,8 @@
+output "connection_name" {
+  value = "${google_sql_database_instance.cloudsql-postgres-master.connection_name}"
+}
+
+output "ip" {
+  value = "${google_sql_database_instance.cloudsql-postgres-master.ip_address.0.ip_address}"
+}
+

--- a/infrastructure-as-code/terraform-gcp-cloudsql/variables.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/variables.tf
@@ -1,0 +1,20 @@
+variable "region" {
+  default = "us-central1"
+}
+
+variable "gcp_sql_root_user_name" {
+	 default = "root"
+}
+
+variable "gcp_sql_root_user_pw" {}
+
+variable "authorized_network" {}
+
+variable "database_name" {
+  default = "master-instance"
+}
+
+variable "database_version" {
+  default = "POSTGRES_9_6"
+}
+


### PR DESCRIPTION
Added terraform-gcp-cloudsql/ under infrastructure-as-code/ for provisioning Google Cloud SQL for PostgreSQL instances. Provided example module code as well.