### PR TITLE
Hard Set Type for the disk.size value to int

### DIFF
--- a/governance/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/vmware/restrict-vm-disk-size.sentinel
@@ -15,7 +15,7 @@ disk_size_limit = rule {
   all vms as _, instances {
     all instances as index, r {
       all r.applied.disk as disk {
-        disk.size < 100
+        int(disk.size) < 100
       }
     }
   }


### PR DESCRIPTION
In my testing of this policy, the disk.size value was being returned as a string. By specifying it to be an int, the policy works.