### PR TITLE
Updated README.md and Google provider variable

### DIFF
--- a/infrastructure-as-code/terraform-gcp-cloudsql/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/README.md
@@ -1,6 +1,6 @@
 # Provision a Cloud SQL instance for PostgreSQL on Google Cloud Platform.
 
-[Cloud SQL for PostgreSQL(https://cloud.google.com/sql/docs/postgres/) is a fully-managed PostgreSQL relational database service on Google Cloud Platform. This Terraform configuration will create a Cloud SQL PostgreSQL V9.6 instance in Google Cloud. It can also be used as a Module to instantiate one or more instances quickly.
+[Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres/) is a fully-managed PostgreSQL relational database service on Google Cloud Platform. This Terraform configuration will create a Cloud SQL PostgreSQL V9.6 instance in Google Cloud. It can also be used as a Module to instantiate one or more instances quickly.
 
 ### Pre-requisites:
 - A [Google Cloud](https://cloud.google.com/) account and [project](https://cloud.google.com/docs/overview/#projects).
@@ -16,10 +16,10 @@
 
 **Download and configure provider:**
 - Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql`.
-- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+- Set the following Terraform configuration variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
 ```
-export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
-export GOOGLE_PROJECT=<name-of-project>
+export TF_VAR_gcp_credentials=$(cat <path-to-gcp-service-account-json>)
+export TF_VAR_gcp_project="<gcp-project-name>"
 ```
 
 **Set Configuration variables:**
@@ -63,8 +63,7 @@ SELECT * from cities;
 - To destroy the Cloud SQL instance, issue: `terraform destroy`.
 - Unset environment variables:
 ```
-unset GOOGLE_CLOUD_KEYFILE_JSON
-unset GOOGLE_PROJECT
+unset TF_VAR_gcp_credentials
+unset TF_VAR_gcp_project
 unset TF_VAR_gcp_sql_root_user_pw
-unset GOOGLE_PROJECT
 ```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/README.md
@@ -4,10 +4,10 @@ This Terraform Configuration provisions 2 Google Cloud SQL PostgreSQL instances 
 
 **Download and configure provider:**
 - Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql/examples/prod-and-dev`.
-- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+- Set the following Terraform configuration variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
 ```
-export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
-export GOOGLE_PROJECT=<name-of-project>
+export TF_VAR_gcp_credentials=$(cat <path-to-gcp-service-account-json>)
+export TF_VAR_gcp_project="<gcp-project-name>"
 ```
 
 **Set Configuration variables:**
@@ -59,8 +59,8 @@ SELECT * from cities;
 - To destroy the Cloud SQL instance, issue: `terraform destroy`.
 - Unset environment variables:
 ```
-unset GOOGLE_CLOUD_KEYFILE_JSON
-unset GOOGLE_PROJECT
 unset TF_VAR_gcp_sql_root_user_pw
-unset GOOGLE_PROJECT
+unset TF_VAR_gcp_credentials
+unset TF_VAR_gcp_project
+
 ```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/prod-and-dev/main.tf
@@ -1,3 +1,11 @@
+variable "gcp_credentials" {
+  description = "GCP credentials needed by Google Terraform provider"
+}
+
+variable "gcp_project" {
+  description = "GCP project name needed by Google Terraform provider"
+}
+
 variable "region" {
   default = "us-central1"
 }
@@ -8,16 +16,20 @@ variable "authorized_network" {}
 
 module "prod-gcp-cloudsql" {
   source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql" 
+  gcp_credentials = "${var.gcp_credentials}"
+  gcp_project = "${var.gcp_project}"
   region  = "${var.region}"
-  database_name = "prod-gcp-cloudsql"
+  database_name_prefix = "prod-cloudsql"
   gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
   authorized_network = "${var.authorized_network}"
 }
 
 module "dev-gcp-cloudsql" {
   source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql" 
+  gcp_credentials = "${var.gcp_credentials}"
+  gcp_project = "${var.gcp_project}"
   region  = "${var.region}"
-  database_name = "dev-gcp-cloudsql"
+  database_name_prefix = "dev-cloudsql"
   gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
   authorized_network = "${var.authorized_network}"
 }

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/README.md
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/README.md
@@ -4,10 +4,10 @@ This Terraform Configuration provisions a Google Cloud SQL PostgreSQL instance o
 
 **Download and configure provider:**
 - Clone this repository via `git` or HTTP and change to working directory: `cd terraform-gcp-cloudsql/examples/simple`.
-- Set the following environment variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
+- Set the following Terraform configuration variables appropriately to setup the [Terraform Google Provider](https://www.terraform.io/docs/providers/google/index.html).
 ```
-export GOOGLE_CLOUD_KEYFILE_JSON=<path-to-service-account-keyfile>
-export GOOGLE_PROJECT=<name-of-project>
+export TF_VAR_gcp_credentials=$(cat <path-to-gcp-service-account-json>)
+export TF_VAR_gcp_project="<gcp-project-name>"
 ```
 
 **Set Configuration variables:**
@@ -50,8 +50,7 @@ SELECT * from cities;
 - To destroy the Cloud SQL instance, issue: `terraform destroy`.
 - Unset environment variables:
 ```
-unset GOOGLE_CLOUD_KEYFILE_JSON
-unset GOOGLE_PROJECT
 unset TF_VAR_gcp_sql_root_user_pw
-unset GOOGLE_PROJECT
+unset TF_VAR_gcp_credentials
+unset TF_VAR_gcp_project
 ```

--- a/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/examples/simple/main.tf
@@ -1,3 +1,11 @@
+variable "gcp_credentials" {
+  description = "GCP credentials needed by Google Terraform provider"
+}
+
+variable "gcp_project" {
+  description = "GCP project name needed by Google Terraform provider"
+}
+
 variable "region" {
   default = "us-central1"
 }
@@ -8,8 +16,10 @@ variable "authorized_network" {}
 
 module "example-gcp-cloudsql" {
   source = "github.com/hashicorp/terraform-guides/tree/terraform-gcp-cloudsql/infrastructure-as-code/terraform-gcp-cloudsql"
+  gcp_credentials = "${var.gcp_credentials}"
+  gcp_project = "${var.gcp_project}"
   region  = "${var.region}"
-  database_name = "example-gcp-cloudsql"
+  database_name_prefix = "simple-cloudsql"
   gcp_sql_root_user_pw = "${var.gcp_sql_root_user_pw}"
   authorized_network = "${var.authorized_network}"
 }

--- a/infrastructure-as-code/terraform-gcp-cloudsql/main.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/main.tf
@@ -1,11 +1,17 @@
 provider "google" {
-  # Google provider credentials via environment variable: GOOGLE_CLOUD_KEYFILE_JSON
-  # Google project name configured via environment variable: GOOGLE_PROJECT
-  region  = "${var.region}"
+  credentials = "${var.gcp_credentials}"
+  project     = "${var.gcp_project}"
+  region      = "${var.region}"
+}
+
+# Random identifier for Database name
+resource "random_pet" "database_name" {
+  prefix = "${var.database_name_prefix}"
+  separator = "-"
 }
 
 resource "google_sql_database_instance" "cloudsql-postgres-master" {
-  name = "${var.database_name}"
+  name = "${random_pet.database_name.id}"
   database_version = "${var.database_version}"
   region = "${var.region}"
 

--- a/infrastructure-as-code/terraform-gcp-cloudsql/variables.tf
+++ b/infrastructure-as-code/terraform-gcp-cloudsql/variables.tf
@@ -1,17 +1,25 @@
+variable "gcp_credentials" {
+  description = "GCP credentials needed by Google Terraform provider"
+}
+
+variable "gcp_project" {
+  description = "GCP project name needed by Google Terraform provider"
+}
+
 variable "region" {
   default = "us-central1"
 }
 
 variable "gcp_sql_root_user_name" {
-	 default = "root"
+  default = "root"
 }
 
 variable "gcp_sql_root_user_pw" {}
 
 variable "authorized_network" {}
 
-variable "database_name" {
-  default = "master-instance"
+variable "database_name_prefix" {
+  default = "cloudsql-master"
 }
 
 variable "database_version" {


### PR DESCRIPTION
- Tested all changes in [Personal repo](https://github.com/kawsark-git-org/terraform-gcp-cloudsql)
- Fixed typos in README.md
- Changed all Google provider variables to be Terraform vars. Previously it was a mix of Environment and terraform).
- Added random string in CloudSQL instance name to allow for subsequent operations. GCP doesn't allow delete and create of same CloudSQL instance name right away.