### PR TITLE
governance/aws: enforce-ami-owners.sentinel, fix join error handling

### DIFF
--- a/governance/aws/enforce-ami-owners.sentinel
+++ b/governance/aws/enforce-ami-owners.sentinel
@@ -33,7 +33,7 @@ join = func(l, sep) {
 	s = ""
 
 	if types.type_of(l) is not "list" {
-		error("not a list: " + l)
+		error("not a list:", l)
 	}
 
 	if length(l) < 1 {
@@ -52,7 +52,7 @@ join = func(l, sep) {
 		if types.type_of(e) is "list" {
 			s += join(e, sep)
 		} else {
-			s += string(e)
+			s += string(e) else error("no implicit conversion of", e, "to string")
 		}
 	}
 


### PR DESCRIPTION
* Fixed the error string concatenation so that it was more `print`-like.
This is probably necessary, and wasn't tested so much as `join` is very
general purpose, while its use case was narrow in the policy.
* Fixed implicit conversion error handling. Bad type conversions in
Sentinel return undefined, not an explicit error, so an `else` clause is
necessary here.