### PR TITLE
openshift 3.11

### DIFF
--- a/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
@@ -64,14 +64,14 @@ EOF
 
 1. If you do not already have a Terraform Enterprise (TFE) account, self-register for an evaluation at https://app.terraform.io/account/new.
 1. After getting access to your TFE account, create an organization for yourself. You might also want to review the [Getting Started](https://www.terraform.io/docs/enterprise/getting-started/index.html) documentation.
-1. Connect your TFE organization to GitHub. See the [Configuring Github Access](https://www.terraform.io/docs/enterprise/vcs/github.html)documentation.
+1. Connect your TFE organization to GitHub. See the [Configuring GitHub Access](https://www.terraform.io/docs/enterprise/vcs/github.html) documentation.
 
 If you want to use open source Terraform instead of TFE, you can create a copy of the included openshift.tfvars.example file, calling it openshift.auto.tfvars, set values for the variables in it, run `terraform init`, and then run `terraform apply`.
 
 ### Step 3: Configure a Terraform Enterprise Workspace
 1. Fork this repository by clicking the Fork button in the upper right corner of the screen and selecting your own personal GitHub account or organization.
 1. Create a workspace in your TFE organization called k8s-cluster-openshift.
-1. Configure the workspace to connect to the fork of this repository in your own Github account.
+1. Configure the workspace to connect to the fork of this repository in your own GitHub account.
 1. Set the Terraform Working Directory to "infrastructure-as-code/k8s-cluster-openshift-aws".
 1. On the Variables tab of your workspace, add the following variables to the Terraform variables: key_name, private_key_data, vault_addr, vault_user, and vault_k8s_auth_path. The first of these must be the name of the key pair you created above. The second must be the actual contents of the private key you downloaded as a pem file.  Be sure to mark this variable as sensitive so that it will not be visible after you save your variables. Set vault_addr to the address of your Vault server (e.g., "http://<your_vault_dns>:8200") and vault_user to your username on your Vault server. Finally, set vault_k8s_auth_path to something like "\<your username\>-openshift".
 1. HashiCorp SEs should also set the owner and ttl variables which are used by the AWS Lambda reaper function that terminates old EC2 instances.

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
@@ -1,12 +1,12 @@
 # Openshift Cluster in AWS
-This guide provisions an OpenShift Origin 3.7 cluster in AWS with 1 master node, 1 client node, and 1 bastion host. It uses ansible-playbook to deploy OpenShift to the master and client nodes from the bastion host after using Terraform to provision the AWS infrastructure. It is based on a [terraform-aws-openshift](https://github.com/dwmkerr/terraform-aws-openshift) repository created by Dave Kerr.
+This guide provisions an OpenShift Origin 3.11 cluster in AWS with 1 master node, 1 client node, and 1 bastion host. It uses ansible-playbook to deploy OpenShift to the master and client nodes from the bastion host after using Terraform to provision the AWS infrastructure. It is based on a [terraform-aws-openshift](https://github.com/dwmkerr/terraform-aws-openshift) repository created by Dave Kerr.
 
 While the original repository required the user to manually run ansible-playbook after provisioning the AWS infrastructure with Terraform, this guide uses a Terraform [remote-exec provisioner](https://www.terraform.io/docs/provisioners/remote-exec.html) to do that. It also uses several additional remote-exec and local-exec provisioners to automate the rest of the deployment, retrieve the OpenShift cluster keys, and write them to outputs. This is important since it allows workspaces that deploy pods and services to the cluster do that via workspace state sharing without any manual copying of the cluster keys.
 
 ## Reference Material
 * [OpenShift Origin](https://www.openshift.org/): the open source version of OpenShift, Red Hat's commercial implementation of Kubernetes.
 * [Kubernetes](https://kubernetes.io/): the open source system for automating deployment and management of containerized applications.
-* [openshift-ansible](https://github.com/openshift/openshift-ansible/tree/release-3.7): Ansible roles and playbooks for installing and managing OpenShift 3.7 clusters with Ansible.
+* [openshift-ansible](https://github.com/openshift/openshift-ansible/tree/release-3.11): Ansible roles and playbooks for installing and managing OpenShift 3.11 clusters with Ansible.
 * [ansible-playbook](https://docs.ansible.com/ansible/2.4/ansible-playbook.html): the actual ansible tool used to deploy the OpenShift cluster. This is used in the install-from-bastion.sh script.
 
 ## Estimated Time to Complete
@@ -16,7 +16,7 @@ While the original repository required the user to manually run ansible-playbook
 Our target persona is a developer or operations engineer who wants to provision an OpenShift cluster into AWS.
 
 ## Challenge
-The [advanced installation method](https://docs.openshift.com/container-platform/3.7/install_config/install/advanced_install.html) for OpenShift uses ansible-playbook to deploy OpenShift. Before doing that, the deployer must first provision some infrastructure and then configure an Ansible inventory file with suitable settings. Typically, ansible-playbook would be manually run on a bastion host even if a tool like Terraform had been used to provision the infrastructure.
+The [installation method](https://docs.openshift.com/container-platform/3.11/install/index.html) for OpenShift uses ansible-playbook to deploy OpenShift. Before doing that, the deployer must first provision some infrastructure and then configure an Ansible inventory file with suitable settings. Typically, ansible-playbook would be manually run on a bastion host even if a tool like Terraform had been used to provision the infrastructure.
 
 ## Solution
 This guide combines and completely automates the two steps mentioned above:

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/main.tf
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/main.tf
@@ -131,6 +131,7 @@ resource "null_resource" "configure_k8s" {
 
   provisioner "remote-exec" {
     inline = [
+      "sleep 180",
       "kubectl create -f vault-reviewer.yaml",
       "kubectl create -f vault-reviewer-rbac.yaml",
       "kubectl get serviceaccount vault-reviewer -o yaml > vault-reviewer-service.yaml",

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/01-amis.tf
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/01-amis.tf
@@ -1,6 +1,6 @@
 # Define the RHEL 7.2 AMI by:
-# RedHat, Latest, x86_64, EBS, HVM, RHEL 7.2
-data "aws_ami" "rhel7_2" {
+# RedHat, Latest, x86_64, EBS, HVM, RHEL 7.5
+data "aws_ami" "rhel7_5" {
   most_recent = true
 
   owners = ["309956199498"] // Red Hat's account ID.
@@ -22,7 +22,7 @@ data "aws_ami" "rhel7_2" {
 
   filter {
     name   = "name"
-    values = ["RHEL-7.2*"]
+    values = ["RHEL-7.5*"]
   }
 }
 

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/05-nodes.tf
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/05-nodes.tf
@@ -7,7 +7,7 @@ data "template_file" "setup-master" {
 
 //  Launch configuration for the master
 resource "aws_instance" "master" {
-  ami                  = "${data.aws_ami.rhel7_2.id}"
+  ami                  = "${data.aws_ami.rhel7_5.id}"
   # Master nodes require at least 16GB of memory.
   instance_type        = "m4.xlarge"
   subnet_id            = "${aws_subnet.public-subnet.id}"
@@ -51,7 +51,7 @@ data "template_file" "setup-node" {
 
 //  Create the two nodes.
 resource "aws_instance" "node1" {
-  ami                  = "${data.aws_ami.rhel7_2.id}"
+  ami                  = "${data.aws_ami.rhel7_5.id}"
   instance_type        = "${var.amisize}"
   subnet_id            = "${aws_subnet.public-subnet.id}"
   iam_instance_profile = "${aws_iam_instance_profile.openshift-instance-profile.id}"

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/07-bastion.tf
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/07-bastion.tf
@@ -12,6 +12,7 @@ data "template_file" "inventory" {
     master_ip = "${aws_instance.master.public_ip}"
     private_key = "${var.private_key_data}"
     name_tag_prefix = "${var.name_tag_prefix}"
+    region = "${var.region}"
   }
 }
 

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/files/install-from-bastion.sh
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/modules/openshift/files/install-from-bastion.sh
@@ -8,7 +8,14 @@ sudo yum install -y "@Development Tools" python2-pip openssl-devel python-devel 
 sudo pip install -Iv ansible==2.6.5
 
 # Clone the openshift-ansible repo, which contains the installer.
-git clone -b release-3.11 https://github.com/openshift/openshift-ansible
+#git clone -b release-3.11 https://github.com/openshift/openshift-ansible
+
+# Using specific commit since later one made it illegal to use the openshift_hostname variable
+git clone -n https://github.com/openshift/openshift-ansible
+cd openshift-ansible
+git checkout 7c8b4f07a46089640bc61b8a9b35fd8b5ed86245
+cd ..
+
 
 # Set up bastion to SSH to other servers
 echo "${private_key}" > /home/ec2-user/.ssh/private-key.pem

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/scripts/postinstall-master.sh
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/scripts/postinstall-master.sh
@@ -6,6 +6,7 @@
 sleep 120
 
 # Create an htpasswd file, we'll use htpasswd auth for OpenShift.
+sudo mkdir -p /etc/origin/master
 sudo htpasswd -cb /etc/origin/master/htpasswd admin 123
 oc adm policy add-cluster-role-to-user cluster-admin admin
 


### PR DESCRIPTION
Updated k8s-cluster-openshift-aws to use OpenShift 3.11 (from previous 3.7).  This was actually forced upon us because the code for OpenShift 3.7 could no longer successfully deploy the OpenShift router that is needed for the route that exposes the cats-and-dogs application in the self-serve-infrastructure/k8s-services-openshift directory of this repository.

I was not able to figure out why OpenShift 3.7 broke, but upgrading to 3.11 fixed the problem with the Router.  Adding an extra 3 minute sleep in the configure_k8s remote-exec provisioner fixed a second problem with the kubectl commands in that provisioner failing because the OpenShift API server was not yet fully running.