### PR TITLE
clone code from git repo and delete workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.tfstate.backup
 *.tfstate.lock.info
 
+# logs
+*.log
+
 # Directories
 .terraform/
 .vagrant/

--- a/operations/README.md
+++ b/operations/README.md
@@ -2,7 +2,7 @@
 This directory contains artifacts that can be used by operations teams using Terraform Enterprise.
 
 ## Automation-Script
-The automation-script directory contains a bash script and associated files that illustrate how the Terraform Enterprise REST API can be used to automate interactions with Terraform Enterprise. It simulates what an operations team might do with Jenkins or other tools. In particular, it creates a workspace, uploads a Terraform configuration to it, sets variables in it, triggers a run, checks the result of Sentinel policy checks, and even does an apply against the workspace if permitted.
+The automation-script directory contains a bash script and associated files that illustrate how the Terraform Enterprise REST API can be used to automate interactions with Terraform Enterprise. It simulates what an operations team might do with Jenkins or other tools. In particular, it clones a git repository, creates a workspace (if it does not already exist), uploads a Terraform configuration to it, sets variables in it, triggers a run, checks the results of Sentinel policy checks, and even does an apply against the workspace if permitted. There is also a script to delete the workspace.
 
 ## Scripts to Export, Import, and Delete Sentinel Policies
 The sentinel-policies-scripts directory contains scripts that can be used to export, import, and delete Sentinel policies.

--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -1,15 +1,22 @@
 # TFE Automation Script
-Script to automate interactions with Terraform Enterprise, including the creation of a workspace, uploading of Terraform code, setting of variables, and triggering of plan and apply.
+Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted.
 
 ## Introduction
 This script uses curl to interact with Terraform Enterprise via the Terraform Enterprise REST API. The same APIs could be used from Jenkins or other solutions to incorporate Terraform Enterprise into your CI/CD pipeline.
 
+Two arguments can be provided on the command line when calling the script:
+1. The first, git_url, is an optional URL for a git repository from which the script should clone some Terraform code.
+1. The second, override, is used in two ways:
+    1. to automatically do an apply when no Sentinel policies exist or none of them are applicable to the workspace, and
+    1. to override any soft-mandatory Sentinel policies that failed.
+
 The script does the following steps:
-1. Packages main.tf into the myconfig.tar.gz file.
-1. Creates the workspace.
+1. Clones a git repository containing Terraform configuration code.
+1. Packages the Terraform code into a tar file.
+1. Creates the workspace if it does not already exist.
 1. Creates a new configuration version.
-1. Uploads the myconfig.tar.gz file as a new configuration. (This step used to trigger an initial run which caused an error because we had not yet set the name variable in the workspace. But we now have configversion.json configured to use auto-queue-runs set to false. So, this run is no longer triggered.)
-1. Adds one Terraform variable called "name" and one Environment variable called "CONFIRM_DESTROY" to the workspace, getting their values from the variables.csv file. You can edit this file to add as many variables as you want.
+1. Uploads the tar file as a new configuration.
+1. Adds Terraform and environment variables from the file variables.csv that was included in the cloned repository if it exists. Otherwise, it adds one Terraform variable called "name" and one Environment variable called "CONFIRM_DESTROY" to the workspace, getting their values from the variables.csv file in the same directory as the script. You can edit this file to add as many variables as you want and then add it to your repository.
 1. Determines the number of Sentinel policies.
 1. Starts a new run.
 1. Enters a loop to check the run results periodically.
@@ -25,13 +32,15 @@ Note that some json template files are included from which other json files are 
 
 In addition to the loadAndRunWorkspace.sh script, this example includes the following files:
 
-1. config/main.tf: the file with some Terraform code that says "Hello" to the person whose name is given and generates a random number.
+1. config/main.tf: the file with some Terraform code that says "Hello" to the person whose name is given and generates a random number. This is used if no git URL is provided to the script.
 1. workspace.template.json which is used to generate workspace.json which is used when creating the workspace.
 1. configversion.json which is used to generate a new configuration version.
 1. variable.template.json which is used to generate variable.json which is used when creating a variable called "name" in the workspace.
 1. run.template.json which is used to generate run.json which is used when triggering a run against the workspace.
 1. apply.json which is used when doing the apply against the workspace.
-1. variables.csv which contains the variables you want to upload to the workspace. The columns are key, value, category, hcl, and sensitive with the last two corresponding to the hcl and sensitive checkboxes of TFE variables.
+1. variables.csv which contains the variables that are uploaded to the workspace if no file with the same name is found in the root directory of the cloned repository. The columns are key, value, category, hcl, and sensitive with the last two corresponding to the hcl and sensitive checkboxes of TFE variables.
+1. deleteWorkspace.sh: a script used to delete the workspace.
+1. restrict-name-variable.sentinel: a Sentinel policy you can add to your TFE organization in order to see how the script can check Sentinel policies and even override soft-mandatory failures.
 
 ## Preparation
 Do the following before using this script:
@@ -39,6 +48,8 @@ Do the following before using this script:
 1. `git clone https://github.com/hashicorp/terraform-guides.git`
 1. `cd operations/automation-script`
 1. Make sure [python](https://www.python.org/downloads/) is installed on your machine and in your path since the script uses python to parse JSON documents returned by the Terraform Enterprise REST API.
+1. If you want the script to use a variables.csv file stored in the git repository containing your Terraform code, edit the sample file with that name and add it to the root of your repostiory.
+1. To see how the script can check Sentinel policies and even override soft-mandatory failures, add the included restrict-name-variable.sentinel policy to your TFE organization. See the [Managing Sentinel Policies](https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html) documentation for instructions.
 
 ## Using with Private Terraform Enteprise Server using private CA
 If you use this script with a Private Terraform Enterprise (PTFE) server that uses a private CA instead of a public CA, you will need to ensure that the curl commands run by the script will trust the private CA.  There are several ways to do this.  The first is easiest for enabling the automation script to run, but it only affects curl. The second and third are useful for using the Terraform and TFE CLIs against your PTFE server. The third is a permanent solution.
@@ -47,25 +58,30 @@ If you use this script with a Private Terraform Enterprise (PTFE) server that us
 1. Copy your certificate bundle to /etc/pki/ca-trust/source/anchors and then run `update-ca-trust extract`.
 
 ## Instructions
-Follow these instructions to run the script with the included main.tf and variables.csv files:
+Follow these instructions to run the script with with the included main.tf and variables.csv files or with your own git repository:
 
 1. If you are using a private Terraform Enterprise server, edit the script and set the address variable to the address of your server. Otherwise, you would leave the address set to "app.terraform.io" which is the address of the SaaS Terraform Enterprise server.
 1. Edit the script and set the organization variable to the name of your Terraform Enterprise organization.
 1. Generate a [team token](https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html#team-service-accounts) for the owners team in your organization in the Terraform Enterprise UI by selecting your organization settings, then Teams, then owners, and then clicking the Generate button and saving the token that is displayed.
 1. `export ATLAS_TOKEN=<owners_token>` where \<owners_token\> is the token generated in the previous step.
 1. If you want, you can also change the name of the workspace that will be created and the sleep_duration variable which controls how often the script checks the status of the triggered run (in seconds).
-1. Edit variables.csv to specify the name you would like to set the name variable to by replacing "Roger" with some other name.
-1. Run `./loadAndRunWorkspace.sh` or `./loadAndRunWorkspace.sh <override>` where \<override\> is "yes" or "no". If you do not specify a value for \<override\>, the script will set it to "no". The override variable is used in two ways: a) to automatically do an apply when no Sentinel policies exist or none of them are applicable to the workspace, and b) to override any soft-mandatory Sentinel policies that failed.
+1. Edit variables.csv to specify the name you would like to set the name variable to by replacing "Roger" with some other name. If you are providing a URL to clone a git repository, you can also add Terraform and environment variables needed by your Terraform code and remove the "name" variable. You can also add the edited file to your repository.
+1. If you want to use the sample main.tf or other code you place in the config directory, run  `./loadAndRunWorkspace.sh` or `./loadAndRunWorkspace.sh "" <override>` where \<override\> is "yes" or "no". (The empty quotes are needed in the second case so that override is the second variable.) If you do not specify a value for \<override\>, the script will set it to "no".
+1. If you want the script to clone some Terraform code from a git repository, run `./loadAndRunWorkspace.sh <git_url>` or `./loadAndRunWorkspace.sh <git_url> <override>` where \<git_url\> is the URL used to clone your git repository.
 
 ### Examples
 `./loadAndRunWorkspace` (no override will be done)
 
-`./loadAndRunWorkspace yes` (override will be done)
+`./loadAndRunWorkspace  "" yes` (override will be done)
 
-`./loadAndRunWorkspace no` (no override will be done)
+`./loadAndRunWorkspace "" no` (no override will be done)
 
-### Running with other Terraform code
-If you would like to load other Terraform code into a workspace with the script, replace main.tf in the config directory with your own Terraform code.  All files in the config directory will be uploaded to your TFE server.  Also edit variables.csv to remove the first row with the name variable and add rows for any Terraform and Environment variables that are required by your Terraform code.  If your code has a terraform.tfvars file, please rename it to terraform.auto.tfvars since TFE overwrites any instance of terraform.tfvars with the variables set in the workspace. Adding variables already in a `*.auto.tfvars` file is not strictly necessary, but is recommended so that users looking at the workspace can see the values set on the variables.
+`./loadAndRunWorkspace https://github.com/rberlind/basic-enterprise-backend.git` (clones the sample main.tf file, no override will be done)
+
+`./loadAndRunWorkspace https://github.com/rberlind/basic-enterprise-backend.git "yes"` (clones the sample main.tf file, override will be done)
+
+### Running With Other Terraform Code and Variables
+As mentioned above, you can replace the main.tf file in the config directory with your own Terraform code or clone Terraform code from a git repository. In the fist case, all files in the config directory will be uploaded to your TFE server.  In the second case, the entire git repository will be uploaded except for the .git directory. Edit variables.csv to remove the name variable and add rows for any Terraform and Environment variables that are required by your Terraform code.  If your code has a terraform.tfvars file, please rename it to terraform.auto.tfvars or some other file with a name matching `*.auto.tfvars` since TFE overwrites any instance of terraform.tfvars with the variables set in the workspace. Note that variables added via a `*.auto.tfvars` file will not show up on the variables tab of the workspace in the TFE UI. Additionally, you cannot add environment variables in a tfvars file. In contrast, you can add both Terraform and environment variables to the variables.csv file and they will show up on the variables tab of the workspace.
 
 ## Cleaning Up
-If you want to run the script again, delete the workspace from the Settings tab of the workspace in the TFE UI. You do not need to delete or touch any of the files in the directory containing the script and other files.
+You can run `./deleteWorkspace.sh` to delete the workspace. Be sure to set the same address, organization, and workspace variables that you set in the loadAndRunWorkspace.sh script.

--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -1,23 +1,26 @@
 # TFE Automation Script
-Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted.
+Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted. If an apply is done, the script waits for it to finish and then downloads the apply log and the before and after state files.
 
 ## Introduction
 This script uses curl to interact with Terraform Enterprise via the Terraform Enterprise REST API. The same APIs could be used from Jenkins or other solutions to incorporate Terraform Enterprise into your CI/CD pipeline.
 
-Two arguments can be provided on the command line when calling the script:
+Three arguments can be provided on the command line when calling the script:
 1. The first, git_url, is an optional URL for a git repository from which the script should clone some Terraform code.
-1. The second, override, is used in two ways:
-    1. to automatically do an apply when no Sentinel policies exist or none of them are applicable to the workspace, and
+1. The second, workspace, is the name of the workspace to use or create if it does not already exist.
+1. The third, override, is used in two ways:
+    1. to automatically do an apply when no Sentinel policies exist or none of them are applicable to the workspace.
     1. to override any soft-mandatory Sentinel policies that failed.
 
+If you only want to set override to "yes" without passing values for the first two arguments, please use `./loadAndRunWorkspace.sh "" "" yes` to run the script.
+
 The script does the following steps:
-1. Clones a git repository containing Terraform configuration code.
+1. Clones a git repository containing Terraform configuration code or uses the code in the config directory if no git URL was provided.
 1. Packages the Terraform code into a tar file.
 1. Creates the workspace if it does not already exist.
 1. Creates a new configuration version.
 1. Uploads the tar file as a new configuration.
-1. Adds Terraform and environment variables from the file variables.csv that was included in the cloned repository if it exists. Otherwise, it adds one Terraform variable called "name" and one Environment variable called "CONFIRM_DESTROY" to the workspace, getting their values from the variables.csv file in the same directory as the script. You can edit this file to add as many variables as you want and then add it to your repository.
-1. Determines the number of Sentinel policies.
+1. Adds Terraform and environment variables from the file variables.csv that was included in the cloned repository if it exists or from the local copy in the same directory as the script. That local version adds one Terraform variable called "name" and two Environment variables to the workspace. The first of the environment variables is "CONFIRM_DESTROY" with value 1; it allows a destroy to be done against the workspace. The second is "TF_CLI_ARGS" with value "-no-color"; it supresses color codes from the apply log output. You can edit this file to add as many variables as you want and then add it to your repository.
+1. Determines the number of Sentinel policies so that it knows whether it needs to check them.
 1. Starts a new run.
 1. Enters a loop to check the run results periodically.
     - If $run_status is "planned", $is_confirmable is "True", and $override is "no", the script stops. In this case, no Sentinel policies existed or none of them were applicable to this workspace. The script will stop.  The user should can apply the run in the Terraform Enterprise UI.
@@ -27,20 +30,22 @@ The script does the following steps:
     - If $run_status is "policy_override" and $override is "no", it prints out a message indicating that some policies failed and are not being overridden.
     - If $run_status is "errored", either the plan failed or a Sentinel policy marked "hard-mandatory" failed. The script terminates.
     - Other values of $run_status cause the loop to repeat after a brief sleep.
+1. If any apply was done, the script goes into a second loop to wait for it to finish.
+1. When the apply is finished, the script downloads the apply log and the state files from before and after the apply.
 
 Note that some json template files are included from which other json files are generated so that they can be passed to the curl commands.
 
 In addition to the loadAndRunWorkspace.sh script, this example includes the following files:
 
-1. config/main.tf: the file with some Terraform code that says "Hello" to the person whose name is given and generates a random number. This is used if no git URL is provided to the script.
-1. workspace.template.json which is used to generate workspace.json which is used when creating the workspace.
-1. configversion.json which is used to generate a new configuration version.
-1. variable.template.json which is used to generate variable.json which is used when creating a variable called "name" in the workspace.
-1. run.template.json which is used to generate run.json which is used when triggering a run against the workspace.
-1. apply.json which is used when doing the apply against the workspace.
+1. [config/main.tf](./config/main.tf): the file with some Terraform code that says "Hello" to the person whose name is given and generates a random number. This is used if no git URL is provided to the script.
+1. [workspace.template.json](./workspace.template.json) which is used to generate workspace.json which is used when creating the workspace.
+1. [configversion.json](./configversion.json) which is used to generate a new configuration version.
+1. [variable.template.json](./variable.template.json) which is used to generate variable.json which is used when creating a variable called "name" in the workspace.
+1. [run.template.json](./run.template.json) which is used to generate run.json which is used when triggering a run against the workspace.
+1. [apply.json](./apply.json) which is used when doing the apply against the workspace.
 1. variables.csv which contains the variables that are uploaded to the workspace if no file with the same name is found in the root directory of the cloned repository. The columns are key, value, category, hcl, and sensitive with the last two corresponding to the hcl and sensitive checkboxes of TFE variables.
-1. deleteWorkspace.sh: a script used to delete the workspace.
-1. restrict-name-variable.sentinel: a Sentinel policy you can add to your TFE organization in order to see how the script can check Sentinel policies and even override soft-mandatory failures.
+1. [deleteWorkspace.sh](./deleteWorkspace.sh): a script that can be used to delete the workspace.
+1. [restrict-name-variable.sentinel](./restrict-name-variable.sentinel): a Sentinel policy you can add to your TFE organization in order to see how the script can check Sentinel policies and even override soft-mandatory failures.
 
 ## Preparation
 Do the following before using this script:
@@ -48,7 +53,7 @@ Do the following before using this script:
 1. `git clone https://github.com/hashicorp/terraform-guides.git`
 1. `cd operations/automation-script`
 1. Make sure [python](https://www.python.org/downloads/) is installed on your machine and in your path since the script uses python to parse JSON documents returned by the Terraform Enterprise REST API.
-1. If you want the script to use a variables.csv file stored in the git repository containing your Terraform code, edit the sample file with that name and add it to the root of your repostiory.
+1. If you want the script to use a variables.csv file stored in the git repository containing your Terraform code, edit the sample file with that name and add it to the root of your repository.
 1. To see how the script can check Sentinel policies and even override soft-mandatory failures, add the included restrict-name-variable.sentinel policy to your TFE organization. See the [Managing Sentinel Policies](https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html) documentation for instructions.
 
 ## Using with Private Terraform Enteprise Server using private CA
@@ -64,24 +69,15 @@ Follow these instructions to run the script with with the included main.tf and v
 1. Edit the script and set the organization variable to the name of your Terraform Enterprise organization.
 1. Generate a [team token](https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html#team-service-accounts) for the owners team in your organization in the Terraform Enterprise UI by selecting your organization settings, then Teams, then owners, and then clicking the Generate button and saving the token that is displayed.
 1. `export ATLAS_TOKEN=<owners_token>` where \<owners_token\> is the token generated in the previous step.
-1. If you want, you can also change the name of the workspace that will be created and the sleep_duration variable which controls how often the script checks the status of the triggered run (in seconds).
-1. Edit variables.csv to specify the name you would like to set the name variable to by replacing "Roger" with some other name. If you are providing a URL to clone a git repository, you can also add Terraform and environment variables needed by your Terraform code and remove the "name" variable. You can also add the edited file to your repository.
-1. If you want to use the sample main.tf or other code you place in the config directory, run  `./loadAndRunWorkspace.sh` or `./loadAndRunWorkspace.sh "" <override>` where \<override\> is "yes" or "no". (The empty quotes are needed in the second case so that override is the second variable.) If you do not specify a value for \<override\>, the script will set it to "no".
-1. If you want the script to clone some Terraform code from a git repository, run `./loadAndRunWorkspace.sh <git_url>` or `./loadAndRunWorkspace.sh <git_url> <override>` where \<git_url\> is the URL used to clone your git repository.
-
-### Examples
-`./loadAndRunWorkspace` (no override will be done)
-
-`./loadAndRunWorkspace  "" yes` (override will be done)
-
-`./loadAndRunWorkspace "" no` (no override will be done)
-
-`./loadAndRunWorkspace https://github.com/rberlind/basic-enterprise-backend.git` (clones the sample main.tf file, no override will be done)
-
-`./loadAndRunWorkspace https://github.com/rberlind/basic-enterprise-backend.git "yes"` (clones the sample main.tf file, override will be done)
+1. If you want, you can also change the name of the workspace that will be created by editing the workspace variable. Note that you can also pass the workspace as the second argument to the script.
+1. If you want, you can change the sleep_duration variable which controls how often the script checks the status of the triggered run (in seconds). Setting a longer value would make sense if using Terraform code that takes longer to apply.
+1. If you are providing a URL to clone a git repository, you can add Terraform and environment variables needed by your Terraform code to [variables.csv](./variables.csv) and remove the "name" variable. You can also add the edited variables.csv file to your repository.
+1. If you want to use the sample main.tf or other code you place in the config directory, run  `./loadAndRunWorkspace.sh` or `./loadAndRunWorkspace.sh "" "" <override>` where \<override\> is "yes" or "no". (The empty quotes are needed in the second case so that override is the third variable.) If you do not specify a value for \<override\>, the script will set it to "no".
+1. If you want the script to clone some Terraform code from a git repository, run `./loadAndRunWorkspace.sh <git_url>` or `./loadAndRunWorkspace.sh <git_url> "" <override>` where \<git_url\> is the URL used to clone your git repository. To use the same code that is in the config directory but load it from a git URL, use https://github.com/rberlind/basic-enterprise-backend.git.
+1. If you want to specify a workspace name in your command, run `./loadAndRunWorkspace.sh <git_url> <workspace>`, `./loadAndRunWorkspace.sh "" <workspace>`, `./loadAndRunWorkspace.sh <git_url> <workspace> <override>`, or `./loadAndRunWorkspace.sh "" <workspace> <override>` where \<workspace\> is the name of the workspace.
 
 ### Running With Other Terraform Code and Variables
-As mentioned above, you can replace the main.tf file in the config directory with your own Terraform code or clone Terraform code from a git repository. In the fist case, all files in the config directory will be uploaded to your TFE server.  In the second case, the entire git repository will be uploaded except for the .git directory. Edit variables.csv to remove the name variable and add rows for any Terraform and Environment variables that are required by your Terraform code.  If your code has a terraform.tfvars file, please rename it to terraform.auto.tfvars or some other file with a name matching `*.auto.tfvars` since TFE overwrites any instance of terraform.tfvars with the variables set in the workspace. Note that variables added via a `*.auto.tfvars` file will not show up on the variables tab of the workspace in the TFE UI. Additionally, you cannot add environment variables in a tfvars file. In contrast, you can add both Terraform and environment variables to the variables.csv file and they will show up on the variables tab of the workspace.
+As mentioned above, you can replace the main.tf file in the config directory with your own Terraform code or clone Terraform code from a git repository. In the fist case, all files in the config directory will be uploaded to your TFE server.  In the second case, the entire git repository will be cloned and uploaded except for the .git directory. Edit variables.csv to remove the name variable and add rows for any Terraform and Environment variables that are required by your Terraform code.  If your code has a terraform.tfvars file, please rename it to terraform.auto.tfvars or some other file with a name matching `*.auto.tfvars` since TFE overwrites any instance of terraform.tfvars with the variables set in the workspace. Note that variables added via a `*.auto.tfvars` file will not show up on the variables tab of the workspace in the TFE UI. Additionally, you cannot add environment variables in a tfvars file. In contrast, you can add both Terraform and environment variables to the variables.csv file and they will show up on the variables tab of the workspace.
 
 ## Cleaning Up
-You can run `./deleteWorkspace.sh` to delete the workspace. Be sure to set the same address, organization, and workspace variables that you set in the loadAndRunWorkspace.sh script.
+You can run `./deleteWorkspace.sh` or `./deleteWorkspace.sh <workspace>` to delete the workspace. Be sure to set the same address, organization, and workspace variables that you set in the loadAndRunWorkspace.sh script or use the same \<workspace\> variable you used when you created the workspace with the `loadAndRunWorkspace.sh script`.

--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -6,12 +6,14 @@ This script uses curl to interact with Terraform Enterprise via the Terraform En
 
 Three arguments can be provided on the command line when calling the script:
 1. The first, git_url, is an optional URL for a git repository from which the script should clone some Terraform code.
-1. The second, workspace, is the name of the workspace to use or create if it does not already exist.
+1. The second, workspace, is the name of the workspace to use or create if it does not already exist. Note that TFE workspace names are not allowed to contain spaces. The script checks for this and will exit if workspace contains any spaces.
 1. The third, override, is used in two ways:
     1. to automatically do an apply when no Sentinel policies exist or none of them are applicable to the workspace.
     1. to override any soft-mandatory Sentinel policies that failed.
 
 If you only want to set override to "yes" without passing values for the first two arguments, please use `./loadAndRunWorkspace.sh "" "" yes` to run the script.
+
+The script uses several json templates which must be placed in the same directory as the script itself.
 
 The script does the following steps:
 1. Clones a git repository containing Terraform configuration code or uses the code in the config directory if no git URL was provided.
@@ -46,6 +48,8 @@ In addition to the loadAndRunWorkspace.sh script, this example includes the foll
 1. variables.csv which contains the variables that are uploaded to the workspace if no file with the same name is found in the root directory of the cloned repository. The columns are key, value, category, hcl, and sensitive with the last two corresponding to the hcl and sensitive checkboxes of TFE variables.
 1. [deleteWorkspace.sh](./deleteWorkspace.sh): a script that can be used to delete the workspace.
 1. [restrict-name-variable.sentinel](./restrict-name-variable.sentinel): a Sentinel policy you can add to your TFE organization in order to see how the script can check Sentinel policies and even override soft-mandatory failures.
+
+Note that the json templates file need to be in the same directory as the script itself. The variables.csv file should also be in the same directory as the script unless you include a file with the same name in your git repository.
 
 ## Preparation
 Do the following before using this script:

--- a/operations/automation-script/config/main.tf
+++ b/operations/automation-script/config/main.tf
@@ -1,4 +1,5 @@
 variable "name" {
+  default = "Walter"
 }
 
 resource "random_id" "random" {

--- a/operations/automation-script/deleteWorkspace.sh
+++ b/operations/automation-script/deleteWorkspace.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Script to delete the workspace created by the loadAndRunWorkspace.sh script
+
+# Make sure ATLAS_TOKEN environment variable is set
+# to owners team token for organization
+
+# Set address if using private Terraform Enterprise server.
+# Set organization and workspace to create.
+# You should edit these before running.
+address="app.terraform.io"
+#organization="<your_organization>"
+organization="RogerBerlind"
+workspace="workspace-from-api"
+
+# Try to delete the workspace.
+echo "Attempting to delete the workspace"
+delete_workspace_result=$(curl --header "Authorization: Bearer $ATLAS_TOKEN" --header "Content-Type: application/vnd.api+json" --request DELETE "https://${address}/api/v2/organizations/${organization}/workspaces/${workspace}")
+
+# Get the response from the TFE server
+# Note that successful deletion will give a null response.
+# Only errors result in data.
+echo "Response from TFE: ${delete_workspace_result}

--- a/operations/automation-script/deleteWorkspace.sh
+++ b/operations/automation-script/deleteWorkspace.sh
@@ -26,4 +26,4 @@ delete_workspace_result=$(curl --header "Authorization: Bearer $ATLAS_TOKEN" --h
 # Get the response from the TFE server
 # Note that successful deletion will give a null response.
 # Only errors result in data.
-echo "Response from TFE: ${delete_workspace_result}
+echo "Response from TFE: ${delete_workspace_result}"

--- a/operations/automation-script/deleteWorkspace.sh
+++ b/operations/automation-script/deleteWorkspace.sh
@@ -8,9 +8,16 @@
 # Set organization and workspace to create.
 # You should edit these before running.
 address="app.terraform.io"
-#organization="<your_organization>"
-organization="RogerBerlind"
+organization="<your_organization>"
 workspace="workspace-from-api"
+
+# Set workspace if provided as the second argument
+if [ ! -z $1 ]; then
+  workspace=$1
+  echo "Using workspace provided as argument: " $workspace
+else
+  echo "Using workspace set in the script."
+fi
 
 # Try to delete the workspace.
 echo "Attempting to delete the workspace"

--- a/operations/automation-script/restrict-name-variable.sentinel
+++ b/operations/automation-script/restrict-name-variable.sentinel
@@ -1,0 +1,11 @@
+import "tfplan"
+
+# Rule to restrict name variable
+name_allowed = rule {
+  tfplan.variables.name != "Roger"
+}
+  
+# Main rule that requires other rules to be true
+main = rule {
+  (name_allowed) else true
+}

--- a/operations/automation-script/variables.csv
+++ b/operations/automation-script/variables.csv
@@ -1,2 +1,3 @@
 name,Roger,terraform,false,false
 CONFIRM_DESTROY,1,env,false,false
+TF_CLI_ARGS,-no-color,env,false,false

--- a/operations/sentinel-policies-scripts/README.md
+++ b/operations/sentinel-policies-scripts/README.md
@@ -23,7 +23,7 @@ Note that you will get errors if any of the policies you are importing already e
 
 The script uses curl to interact with Terraform Enterprise via the TFE API. It performs the following steps:
 
-1. It iterates across all files in the current directory with the "*.sentinel" extension.
+1. It iterates across all files in the current directory with the `*.sentinel` extension.
 1. For each file, it generates a file create-policy.json from the template create-policy.template.json, substituting the name of the policy and the file name and setting a description based on the name.
 1. It uses curl to invoke the [Create a Policy API](https://www.terraform.io/docs/enterprise/api/policies.html#create-a-policy), passing the generated create-policy.json file in the --data argument of the curl command.
 1. It uses curl to invoke the [Upload a Policy API](https://www.terraform.io/docs/enterprise/api/policies.html#upload-a-policy).


### PR DESCRIPTION
I enhanced the loadAndRunWorkspace.sh script in several ways:
1. It now can clone Terraform code from a git repository. Before doing that, it deletes the existing directory that git will try to create.
2. It checks to see if the workspace already exists before trying to create it.
3. It names the tar file after the configuration directory containing the code which will be extracted from the git URL if one is provided.
4. It checks for a variables.csv file in the clone code and uses it if found.

I also added a deleteWorkspace.sh script to delete the workspace that the other script creates.