### PR TITLE
fixed naming of vault k8s auth method

### DIFF
--- a/infrastructure-as-code/k8s-cluster-gke/variables.tf
+++ b/infrastructure-as-code/k8s-cluster-gke/variables.tf
@@ -39,7 +39,7 @@ variable "node_disk_size" {
 
 variable "environment" {
   description = "value passed to Environment tag and used in name of Vault auth backend later"
-  default = "dev"
+  default = "gke-dev"
 }
 
 variable "vault_user" {

--- a/infrastructure-as-code/k8s-vault-config/main.tf
+++ b/infrastructure-as-code/k8s-vault-config/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 resource "vault_auth_backend" "k8s" {
   type = "kubernetes"
-  path = "${data.terraform_remote_state.k8s_cluster.vault_user}-gke-${data.terraform_remote_state.k8s_cluster.environment}"
+  path = "${data.terraform_remote_state.k8s_cluster.vault_user}-${data.terraform_remote_state.k8s_cluster.environment}"
   description = "Vault Auth backend for Kubernetes"
 }
 


### PR DESCRIPTION
minor fix to naming of Vault k8s auth method.  It is now set to <user>-<environment> in which latter defaults to "gke-dev" for GKE and "aks-dev" for AKS.