### PR TITLE
added int type for cpu and memory comparison

### DIFF
--- a/governance/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -14,7 +14,7 @@ vms = get_vms()
 cpus_limit = rule {
   all vms as _, instances {
     all instances as index, r {
-  	  r.applied.num_cpus <= 4
+  	  int(r.applied.num_cpus) <= 4
     }
   }
 }
@@ -23,7 +23,7 @@ cpus_limit = rule {
 memory_limit = rule {
   all vms as _, instances {
     all instances as index, r {
-  	  r.applied.memory <= 8192
+  	  int(r.applied.memory) <= 8192
     }
   }
 }


### PR DESCRIPTION
Without explicitly specifying `int()` the following error occurs: `An error occurred: restrict-vm-cpu-and-memory.sentinel.sentinel:17:6: comparison requires both operands to be the same type, got string and int`  This PR fixes the issue. Tested in run-id: `run-BhfypMx1GjU11yBr`