### PR TITLE
added env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This directory contains sample Terraform configurations to enable self-service i
 This directory contains some sample Sentinel policies for several clouds which ensure that all infrastructure provisioned with Terraform Enterprise complies with an organization's provisioning rules.
 
 ## operations
-This directory provides artifacts that can be used by operations teams using Terraform Enterprise. In particular, it includes a script that shows how the Terraform Enterprise REST API can be used to automate interactions with Terraform Enterprise.
+This directory provides artifacts that can be used by operations teams using Terraform Enterprise. In particular, it includes scripts that show how the Terraform Enterprise REST API can be used to automate interactions with Terraform Enterprise, set and delete variables in workspaces, and export, import, and delete Sentinel policies.
 
 ## cloud-management-platform
 This directory provides samples of how Terraform can be used to support cloud management platforms.

--- a/operations/variable-scripts/set-variables.sh
+++ b/operations/variable-scripts/set-variables.sh
@@ -4,15 +4,49 @@
 # The variables must be set in <workspace>.csv, variables.csv or in a similar
 # delimited file named in the second, optional argument passed to the script.
 
-# Make sure the TFE_TOKEN environment variable is set
+# Exit if any errors encountered
+set -e
+
+# Make sure the $TFE_TOKEN environment variable is set
 # to a user or team token that has the write or admin permission
 # for the workspace.
+if [ ! -z "$TFE_TOKEN" ]; then
+  token=$TFE_TOKEN
+  echo "TFE_TOKEN environment variable was found."
+else
+  echo "TFE_TOKEN environment variable was not set."
+  echo "You must export/set the TFE_TOKEN environment variable."
+  echo "It should be a user or team token that has write or admin"
+  echo "permission on the workspace."
+  echo "Exiting."
+  exit
+fi
 
-# Set address if using a private Terraform Enterprise server.
-# Set the organization to use.
+# Evaluate $TFE_ORG environment variable
+# If not set, give error and exit
+if [ ! -z "$TFE_ORG" ]; then
+  organization=$TFE_ORG
+  echo "TFE_ORG environment variable was set to ${TFE_ORG}."
+  echo "Using organization, ${organization}."
+else
+  echo "You must export/set the TFE_ORG environment variable."
+  echo "Exiting."
+  exit
+fi
+
+# Evaluate $TFE_ADDR environment variable if it exists
+# Otherwise, use "app.terraform.io"
 # You should edit these before running the script.
-address="app.terraform.io"
-organization="<your_organization>"
+if [ ! -z "$TFE_ADDR" ]; then
+  address=$TFE_ADDR
+  echo "TFE_ADDR environment variable was set to ${TFE_ADDR}."
+  echo "Using address, ${address}"
+else
+  address="app.terraform.io"
+  echo "TFE_ADDR environment variable was not set."
+  echo "Using Terraform Cloud (TFE SaaS) address, app.terraform.io."
+  echo "If you want to use a private TFE server, export/set TFE_ADDR."
+fi
 
 # Set delete_first to "true" if you want this script to always
 # call the delete-variables.sh script first to delete all
@@ -95,26 +129,34 @@ EOF
 
 # Check to see if the workspace already exists and get workspace ID
 echo "Checking to see if workspace exists and getting workspace ID"
-check_workspace_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/workspaces/${workspace}")
+check_workspace_result=$(curl -s --header "Authorization: Bearer $token" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/workspaces/${workspace}")
 
 # Parse workspace_id from check_workspace_result
 workspace_id=$(echo $check_workspace_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['id'])")
 echo "Workspace ID: " $workspace_id
+echo ""
 
 # Delete all variables in the workspace if $delete_first is true
 if [ "$delete_first" == "true" ]; then
-  ./delete-variables.sh $workspace
+  ./delete-variables.sh $workspace true
 fi
 
 # Set variables in workspace
 while IFS=${delimiter} read -r key value category hcl sensitive
 do
+  # Create variable.json from variable.template.json
   sed -e "s/my-workspace/${workspace_id}/" -e "s/my-key/$key/" -e "s/my-value/$value/" -e "s/my-category/$category/" -e "s/my-hcl/$hcl/" -e "s/my-sensitive/$sensitive/" < variable.template.json  > variable.json
+
+  # Make the API call to set the variable
   echo "Setting $category variable $key with value $value, hcl: $hcl, sensitive: $sensitive"
-  upload_variable_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @variable.json "https://${address}/api/v2/vars?filter%5Borganization%5D%5Bname%5D=${organization}&filter%5Bworkspace%5D%5Bname%5D=${workspace}")
-  echo ""
-  echo ""
-  echo $upload_variable_result
+  upload_variable_result=$(curl -s --header "Authorization: Bearer $token" --header "Content-Type: application/vnd.api+json" --data @variable.json "https://${address}/api/v2/vars?filter%5Borganization%5D%5Bname%5D=${organization}&filter%5Bworkspace%5D%5Bname%5D=${workspace}")
+
+  # Show JSON returned from the TFE API call
+  # You can uncomment this for debugging
+  # It will show errors caused by setting variables that already exist
+  #echo $upload_variable_result
+  #echo ""
+
 done < ${variables_file}
 
 echo "Set all variables."


### PR DESCRIPTION
I modified variable scripts to require TFE_TOKEN and TFE_ORG environment variables be set. An optional TFE_ADDR variable can also be set, but it not the scripts will use app.terraform.io.

I also added second argument, run_from_set_variables, to delete-variables.sh which is only used (and set to "true") when it is called from set-variables.sh.  The purpose of this is to avoid redundant outputs related to the environment orgs when set-variables.sh does call delete-variables.sh.

Currently, the only editing of the script that would be needed before using would be to change `delete_first="false"` to `delete_first="true"` so that set-variables.sh will always call delete-variables.sh.  I did not set this to true in the script because I don't want anyone to accidentally delete variables when running set-variables.sh.  Forcing people to change this line ensures that they will understand that calling set-variables.sh will in fact delete all variables first.

At some point, a good enhancement to the set-variables.sh script would be to make it check for the existence of each variable first and then do an update instead of a create if it does exist.  But doing this is somewhat of a nuisance because there is no API to update variables by name.  So, the script would first have to retrieve all variables  and then pair up the variable names and IDs so it could know which ID to use when updating with this API: https://www.terraform.io/docs/enterprise/api/variables.html#update-variables

Since the delete-variables.sh script already does retrieve the list of all variables and does pair up the names and IDs, actually adding code to check if a variable exists and then calling the create if it does not and the update if it does will not be too hard.

