### PR TITLE
make scripts run from same directory

### DIFF
--- a/operations/variable-scripts/README.md
+++ b/operations/variable-scripts/README.md
@@ -6,7 +6,9 @@ The scripts in this directory let you set values of new variables in and delete 
 
 In addition to bash, these scripts require python. On Linux and Mac, make sure that python is installed. If you want to run the scripts on Windows, install Git, which includes Git Bash, and python if you don't already have them. Then run the scripts and your terraform commands inside a Git Bash shell.
 
-The set-variables.sh has a `delete_first` variable, which will call the delete-variables.sh script first if set to `"true"`. Most users will want to set this to `"true"`, but the default, hard-coded value is `"false"` since we do not want anyone to accidentally delete variables.
+The set-variables.sh has a `delete_first` variable, which will call the delete-variables.sh script first if set to `"true"`. Most users will want to set this to `"true"`, but the default, hard-coded value is `"false"` since we do not want anyone to accidentally delete variables. The set-variables.sh script will call the delete-variables.sh script from the same directory even if that directory is not your current working directory.
+
+We recommend copying both scripts to a directory such as /usr/local/bin that is in your PATH so that you can execute them from any directory containing a Terraform configuration. You will then only have to create a variables CSV file for that configuration in the configuration's directory.
 
 The set-variables.sh script cannot currently update the values of existing variables. So, you should either set the `delete_first` variable to `"true"` or make sure the delimited file you use does not contain any variables that already exist in the workspace.
 

--- a/operations/variable-scripts/delete-variables.sh
+++ b/operations/variable-scripts/delete-variables.sh
@@ -8,7 +8,8 @@ set -e
 # So that we can suppress repeated outputs
 if [ ! -z "$2" ]; then
   run_from_set_variables=$2
-  echo "Running delete-variables.sh"
+  script_location=$(dirname $0)
+  echo "Running ${script_location}/delete-variables.sh"
   echo ""
 fi
 

--- a/operations/variable-scripts/set-variables.sh
+++ b/operations/variable-scripts/set-variables.sh
@@ -138,7 +138,8 @@ echo ""
 
 # Delete all variables in the workspace if $delete_first is true
 if [ "$delete_first" == "true" ]; then
-  ./delete-variables.sh $workspace true
+  script_location=$(dirname $0)
+  ${script_location}/delete-variables.sh $workspace true
 fi
 
 # Set variables in workspace


### PR DESCRIPTION
I added some logic so that the set-variables.sh script will call delete-variables.sh from the same directory that set-variables.sh lives in when the $delete_first variable  is set to "true".  This allows users to copy both scripts into a directory such as /usr/local/bin in their $PATH so that they can then run the scripts from that directory no matter what their current working directory is and make sure that set-variables.sh can find delete-variables.sh in the one added to the $PATH.  Previously, set-variables.sh would look for delete-variables.sh in the current working diretory.

If you simply clone the repository and run the scripts from operations/variable-scripts, the set-variables.sh script will find delete-variables.sh in that directory.  The same is true if you copy both scripts into a directory containing a Terraform configuration and then run `./set-variables.sh <workspace>`.  So, you do not have to copy the scripts into your $PATH.