### PR TITLE
two new AWS policies

### DIFF
--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -1,0 +1,114 @@
+# This policy uses the Sentinel tfplan import to require that
+# all EC2 instances have specified tags
+
+##### Imports #####
+
+import "tfplan"
+import "strings"
+
+##### Functions #####
+
+# Find all resources of a specific type
+# from all modules using the tfplan import
+find_resources_from_plan = func(type) {
+
+  resource_maps = {}
+
+  # Iterate over all modules in the tfplan import
+  for tfplan.module_paths as path {
+
+    # Compute joined_path from the module path
+    if length(path) == 0 {
+      joined_path = ""
+    } else {
+      joined_path = "module." + strings.join(path, ".module.") + "."
+    }
+
+    # Append all resources of the specified type to resource_maps
+    # setting the key to joined_path. Append the empty map, {}, if the
+    # module does not have any resources of the specified type.
+    resource_maps[joined_path] = tfplan.module(path).resources[type] else {}
+  }
+
+  return resource_maps
+}
+
+# Get the full address of a resource instance including modules, type,
+# name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
+# joined_path is is returned in keys by find_resources_from_plan
+get_instance_address = func(module_path, type, name, index) {
+  address = module_path + type + "." + name + "[" + string(index) + "]"
+  return address
+}
+
+validate_tags = func(required_tags) {
+
+   # Initialize validated to true
+   # This will be set to false if there are violations
+   validated = true
+
+   # Set the resource_type
+   resource_type = "aws_instance"
+
+   # Get all resources of the specified type
+   resource_maps = find_resources_from_plan(resource_type)
+
+   # Loop through the module-level resource maps
+   for resource_maps as module_path, resource_map {
+     # Loop through the named resources
+     for resource_map as name, instances {
+       # Loop through resource instances
+       for instances as index, r {
+
+         # Get address of the instance
+         address = get_instance_address(module_path, resource_type, name, index)
+
+         # Skip resources that are being destroyed
+         # to avoid unnecessary policy violations
+         if length(r.diff) == 0 {
+           print("Skipping resource", address,
+             "that is being destroyed.")
+           continue
+         }
+
+         if r.diff["tags.%"].computed else false is true {
+           print("EC2 instance", address,
+             "has attribute, tags, that is computed.")
+           # If you want computed values to cause the policy to fail, uncomment the next line.
+           #validated = false
+         } else {
+           # Validate that each instance has required tags
+           for required_tags as tag {
+             if r.applied.tags not contains tag {
+               print("EC2 instance", address,
+                 "is missing required tag", tag)
+               print("Required tags are:", required_tags)
+               validated = false
+             } // end tag check
+           } // end tag loop
+        } // end computed check
+
+      } // end resource instances
+    } // end named resources
+  } // end resorce maps
+
+  # Return validated
+  return validated
+
+}
+
+### List of mandatory tags ###
+mandatory_tags = [
+  "Name",
+  "ttl",
+  "owner",
+]
+
+### Rules ###
+
+# Call the validation function and assign results
+tags_validated = validate_tags(mandatory_tags)
+
+main = rule {
+  tags_validated is true
+}

--- a/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -1,4 +1,3 @@
-##### restrict-private-acl-and-kms-for-s3-buckets.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all S3 buckets have ACL "private" and be encrypted by a KMS key
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -94,8 +93,7 @@ validate_private_acl_and_kms_encryption = func() {
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #encrypted_by_kms = false
         } else {
-          # Check whether server-side encryption enabled
-          # by default with KMS encryption
+          # Check whether server-side encryption enabled by default with KMS encryption
           if length(r.applied.server_side_encryption_configuration) else 0 == 0 or r.applied.server_side_encryption_configuration[0].rule[0].apply_server_side_encryption_by_default[0].sse_algorithm is not "aws:kms" {
             print("S3 bucket", address,
             "is not encrypted by default with a KMS key.")

--- a/governance/second-generation/aws/restrict-availability-zones.sentinel
+++ b/governance/second-generation/aws/restrict-availability-zones.sentinel
@@ -1,5 +1,6 @@
-# This policy uses the Sentinel tfplan import to require that
-# all RDS database instances have engines from an allowed list
+# This policy uses the Sentinel tfplan import to restrict
+# the availability zones used by EC2 instances. This can
+# be used to restrict the region by only listing zones in one.
 
 ##### Imports #####
 
@@ -41,19 +42,20 @@ get_instance_address = func(joined_path, type, name, index) {
   return address
 }
 
-# Validate that all RDS DB instances have engine
-# in allowed_engines list
-validate_engines = func(allowed_engines) {
+# Validate that all EC2 instances have availability_zone
+# in allowed_zones list
+restrict_azs = func(allowed_zones) {
 
   # Initialize validated to true
-  # This will be set to false if any DB instances violate rule
+  # This will be set to false if any instances violate rule
   validated = true
 
   # Set resource_type
-  resource_type = "aws_db_instance"
+  resource_type = "aws_instance"
 
   # Get all resources of specified type
   resource_maps = find_resources_from_plan(resource_type)
+
 
   # Loop through the module-level resource maps
   for resource_maps as module_path, resource_map {
@@ -62,7 +64,7 @@ validate_engines = func(allowed_engines) {
       # Loop through resource instances
       for instances as index, r {
 
-        # Get addresses of the resource and the instance
+        # Get address of the resource instance
         address = get_instance_address(module_path, resource_type, name, index)
 
         # Skip resources that are being destroyed
@@ -74,17 +76,16 @@ validate_engines = func(allowed_engines) {
         }
 
         # Determine if the attribute is computed
-        if r.diff["engine"].computed else false is true {
-          print("resource", address,
-            "has attribute, engine, that is computed.")
+        if r.diff["availability_zone"].computed else false is true {
+          print("EC2 instance", address,
+            "has attribute, availability_zone, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each instance has allowed value
-          if r.applied.engine not in allowed_engines {
-            print("RDS DB instance", address,
-              "has engine", r.applied.engine,
-              "that is not in the allowed list:", allowed_engines)
+          if r.applied.availability_zone not in allowed_zones {
+            print("EC2 instance", address, "has attribute",
+              r.applied.availability_zone, "that is not in the allowed list:", allowed_zones)
             validated = false
           }
         } // end computed check
@@ -98,20 +99,24 @@ validate_engines = func(allowed_engines) {
 }
 
 ##### Lists #####
-# Allowed RDS DB Engines
-allowed_engines = [
-  "mysql",
-  "oracle-se1",
-  "oracle-se2",
-  "postgres",
+
+# Allowed EC2 Instance Types
+# We don't include t2.micro to illustrate overriding failed policy
+allowed_zones = [
+  "us-east-1a",
+  "us-east-1b",
+  "us-east-1c",
+  "us-east-1d",
+  "us-east-1e",
+  "us-east-1f",
 ]
 
 ##### Rules #####
 
 # Call the validation function and assign results
-engine_allowed = validate_engines(allowed_engines)
+availability_zone_allowed = restrict_azs(allowed_zones)
 
-# Main rule
+# Main rule that requires other rules to be true
 main = rule {
-  engine_allowed is true
+  availability_zone_allowed is true
 }

--- a/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
@@ -1,4 +1,3 @@
-##### restrict-ec2-instance-type.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all EC2 instances have instance types from an allowed list
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -77,14 +76,12 @@ validate_instance_types = func(allowed_types) {
 
         # Determine if the attribute is computed
         if r.diff["instance_type"].computed else false is true {
-          # Print message indicating a computed value was found
           print("EC2 instance", address,
             "has attribute, instance_type, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each instance has allowed value
-          # If not, print violation message
           if r.applied.instance_type not in allowed_types {
             print("EC2 instance", address, "has attribute",
               r.applied.instance_type, "that is not in the allowed list:", allowed_types)

--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -1,4 +1,3 @@
-##### restrict-ingress-sg-rule-cidr-blocks.sentinel #####
 # This policy uses the Sentinel tfplan import to validate that
 # no security group rules have the CIDR "0.0.0.0/0"
 
@@ -37,7 +36,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -78,14 +77,12 @@ validate_sgr_cidr_blocks = func() {
         # Determine if the attribute is computed
         if r.diff["type"].computed else false or
           r.diff["cidr_blocks.#"].computed else false is true {
-          # Print message indicating a computed value was found
           print("Security group rule", address,
             "has attributes, type and/or cidr_blocks that are computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each SG rule does not have disallowed value
-          # If it does, print violation message
           # Since cidr_blocks is optional and could be computed,
           # We check that it is present and really a list
           # before checking whether it contains "0.0.0.0/0"

--- a/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
@@ -1,4 +1,3 @@
-##### restrict-ec2-instance-type.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all EC2 instances have instance types from an allowed list
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -76,15 +75,12 @@ validate_instance_types = func(allowed_types) {
 
         # Determine if the attribute is computed
         if r.diff["instance_type"].computed else false is true {
-          # Print message indicating a computed value was found
           print("Launch configuration", address,
             "has attribute, instance_type, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
-          # Validate that each launch configuration
-          # has allowed instance type
-          # If not, print violation message
+          # Validate that each launch configuration has allowed instance type
           if r.applied.instance_type not in allowed_types {
             print("Launch configuration", address,
               "has instance type", r.applied.instance_type,

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/fail.json
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/fail.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail.sentinel
@@ -1,0 +1,1032 @@
+import "strings"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+				"ubuntu-too": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.13"
+
+variables = {
+	"ami_id":        "ami-2e1ef954",
+	"aws_region":    "us-east-1",
+	"instance_type": "t2.small",
+	"key_name":      "roger-vault",
+	"name":          "roger-demo-dev",
+	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+	"volume_size":   "10",
+}
+
+module = func(path) {
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	return _modules[strings.join(["module", path], ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass.sentinel
@@ -1,0 +1,1044 @@
+import "strings"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+				"ubuntu-too": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+								"owner": "roger@hashicorp.com",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.13"
+
+variables = {
+	"ami_id":        "ami-2e1ef954",
+	"aws_region":    "us-east-1",
+	"instance_type": "t2.small",
+	"key_name":      "roger-vault",
+	"name":          "roger-demo-dev",
+	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+	"volume_size":   "10",
+}
+
+module = func(path) {
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	return _modules[strings.join(["module", path], ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/pass.json
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/pass.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/aws/test/restrict-availability-zones/fail.json
+++ b/governance/second-generation/aws/test/restrict-availability-zones/fail.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail.sentinel
@@ -1,0 +1,1020 @@
+import "strings"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-west-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-west-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-west-2b",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-west-2b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+				"ubuntu-too": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.13"
+
+variables = {
+	"ami_id":        "ami-2e1ef954",
+	"aws_region":    "us-east-1",
+	"instance_type": "t2.small",
+	"key_name":      "roger-vault",
+	"name":          "roger-demo-dev",
+	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+	"volume_size":   "10",
+}
+
+module = func(path) {
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	return _modules[strings.join(["module", path], ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass.sentinel
@@ -1,0 +1,1020 @@
+import "strings"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+				"ubuntu-too": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+					1: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "roger-demo-dev",
+								"ttl":  "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.small",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-demo-dev",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.13"
+
+variables = {
+	"ami_id":        "ami-2e1ef954",
+	"aws_region":    "us-east-1",
+	"instance_type": "t2.small",
+	"key_name":      "roger-vault",
+	"name":          "roger-demo-dev",
+	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+	"volume_size":   "10",
+}
+
+module = func(path) {
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	return _modules[strings.join(["module", path], ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-availability-zones/pass.json
+++ b/governance/second-generation/aws/test/restrict-availability-zones/pass.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/azure/restrict-app-service-to-https.sentinel
+++ b/governance/second-generation/azure/restrict-app-service-to-https.sentinel
@@ -1,4 +1,3 @@
-##### restrict-app-service-to-https.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all Azure app services have https_only set to true so that
 # they can only be accessed via HTTPS
@@ -37,7 +36,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -76,14 +75,12 @@ validate_app_services = func() {
 
         # Determine if the attribute is computed
         if r.diff["https_only"].computed else false is true {
-          # Print message indicating a computed value was found
           print("Azure app service", address,
             "has attribute, https_only, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each app service has https_only set to true
-          # If not, print violation message
           if r.applied.https_only is not true {
             print("Azure app service", address,
               "has attribute https_only that is not set to true.")

--- a/governance/second-generation/azure/restrict-vm-size.sentinel
+++ b/governance/second-generation/azure/restrict-vm-size.sentinel
@@ -1,4 +1,3 @@
-##### restrict-vm-size.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all Azure VMs have vm size from an allowed list
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -76,14 +75,12 @@ validate_vm_sizes = func(allowed_sizes) {
 
         # Determine if the attribute is computed
         if r.diff["vm_size"].computed else false is true {
-          # Print message indicating a computed value was found
           print("Azure VM", address,
             "has attribute, vm_size, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each VM has allowed size
-          # If not, print violation message
           if r.applied.vm_size not in allowed_sizes {
             print("Azure VM", address, "has attribute", r.applied.vm_size,
               "that is not in the allowed list:", allowed_sizes)

--- a/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
@@ -1,4 +1,3 @@
-##### restrict-gce-machine-type.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all Google compute instances have machine types from an allowed list
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -76,14 +75,12 @@ validate_machine_types = func(allowed_types) {
 
         # Determine if the attribute is computed
         if r.diff["machine_type"].computed else false is true {
-          # Print message indicating a computed value was found
           print("GCP compute instance", address,
             "has attribute, machine_type, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #validated = false
         } else {
           # Validate that each instance has allowed value
-          # If not, print violation message
           if r.applied.machine_type not in allowed_types {
             print("GCP compute instance", address,
               "has attribute", r.applied.machine_type,

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -1,4 +1,3 @@
-##### restrict-vm-cpu-and-memory.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all VMware VMs obey CPU and memory limits
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -76,14 +75,12 @@ validate_cpu_and_memory_limits = func(cpu_limit, memory_limit) {
 
         # Determine if the attribute is computed
         if r.diff["num_cpus"].computed else false is true {
-          # Print message indicating a computed value was found
           print("resource", address,
             "has attribute, num_cpus, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #valid_cpu = false
         } else {
           # Validate that each instance has valid number of CPUs
-          # If not, print violation message
           if int(r.applied.num_cpus) > cpu_limit {
             print("Virtual machine", address,
               "has", r.applied.num_cpus, "CPUs,",
@@ -94,14 +91,12 @@ validate_cpu_and_memory_limits = func(cpu_limit, memory_limit) {
 
         # Determine if the attribute is computed
         if r.diff["memory"].computed else false is true {
-          # Print message indicating a computed value was found
           print("resource", address,
             "has attribute, memory, that is computed.")
           # If you want computed values to cause the policy to fail, uncomment the next line.
           #valid_memory = false
         } else {
           # Validate that each instance has valid amount of memory
-          # If not, print violation message
           if int(r.applied.memory) > memory_limit {
             print("Virtual machine", address,
               "has", r.applied.memory,

--- a/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
@@ -1,4 +1,3 @@
-##### restrict-vm-disk-size.sentinel #####
 # This policy uses the Sentinel tfplan import to require that
 # all VMware VMs obey a disk limit
 
@@ -36,7 +35,7 @@ find_resources_from_plan = func(type) {
 
 # Get the full address of a resource instance including modules, type,
 # name, and index in form module.<A>.module.<B>.<type>.<name>[<index>]
-# module_path is like module paths returned by tfplan.module_paths
+# joined_path is is returned in keys by find_resources_from_plan
 get_instance_address = func(joined_path, type, name, index) {
   address = joined_path + type + "." + name + "[" + string(index) + "]"
   return address
@@ -84,14 +83,12 @@ validate_disk_size = func(disk_limit) {
 
           # Determine if the attribute is computed
           if r.diff["disk." + string(disk_count) + ".size"].computed else false is true {
-            # Print message indicating a computed value was found
             print("Virtual machine", address, "has disk", disk.label,
               "with attribute, disk.size, that is computed.")
             # If you want computed values to cause the policy to fail, uncomment the next line.
             #validated = false
           } else {
             # Validate that each disk has valid disk size
-            # If not, print violation message
             if int(disk.size) > disk_limit {
               print("Virtual machine", address,
               "has disk", disk.label, "with size",


### PR DESCRIPTION
I added new new AWS policies in the new second generation style, enforce-mandatory-tags.sentinel and restrict-availability-zones.sentinel along with test cases for use with the Sentinel Simulator

Additionally, I revised all the second generation Sentinel policies that I had previously added as follows:
1. I removed names of policies from first line. It turns out that comments at the beginning of a Sentinel policy are shown in Sentinel output as the policy's description (ignoring the description added to the TF UI or by the TFE API or TFE provider).  Since the Sentinel output already gives the name of the policies, having them output again in the descriptions is redundant.
2. I removed some extraneous comments including some about things being printed since the Sentinel code made it clear what was being done.
3. I replaced an old description of the module_path argument on all occurences of the get_instance_address function with a description of the joined_path argument.