### PR TITLE
Added some common Sentinel functions

### DIFF
--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -1,5 +1,9 @@
-# This policy uses the Sentinel tfplan import to require that
-# all EC2 instances have specified tags
+# This policy uses the Sentinel tfplan import to require that all EC2 instances
+# have specified tags.
+
+# Note that the comparison is case-sensitive since AWS tags are case-sensitive.
+# If you want to ignore case, make all items in the mandatory_tags list lower
+# case and then modify line 90 as indicated in the comment above it.
 
 ##### Imports #####
 
@@ -79,6 +83,9 @@ validate_tags = func(required_tags) {
          } else {
            # Validate that each instance has required tags
            for required_tags as tag {
+             # To make the comparison ignore case, change the next line to:
+             # if r.applied.tags not contains strings.to_lower(tag) {
+             # and make sure that all tags in mandatory_tags are lower case.
              if r.applied.tags not contains tag {
                print("EC2 instance", address,
                  "is missing required tag", tag)

--- a/governance/second-generation/aws/mocks/ec2-instance-mock-tfconfig.sentinel
+++ b/governance/second-generation/aws/mocks/ec2-instance-mock-tfconfig.sentinel
@@ -1,23 +1,35 @@
 import "strings"
+import "types"
 
 _modules = {
 	"root": {
-		"data":    {},
-		"modules": {},
+		"data": {},
+		"modules": {
+			"nested": {
+				"config": {
+					"ami_id":        "${var.ami_id}",
+					"aws_region":    "${var.aws_region}",
+					"instance_type": "${var.instance_type}",
+					"key_name":      "${var.key_name}",
+					"name":          "${var.name}",
+					"volume_size":   "${var.volume_size}",
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
 		"outputs": {
 			"public_dns": {
 				"depends_on":  [],
 				"description": "",
 				"sensitive":   false,
-				"value":       "${aws_instance.ubuntu.public_dns}",
+				"value":       "${aws_instance.ubuntu.*.public_dns}",
 			},
 		},
 		"providers": {
 			"aws": {
-				"alias": {},
-				"config": {
-					"region": "${var.aws_region}",
-				},
+				"alias":   {},
+				"config":  {},
 				"version": "",
 			},
 		},
@@ -27,12 +39,18 @@ _modules = {
 					"config": {
 						"ami": "${var.ami_id}",
 						"associate_public_ip_address": "true",
-						"availability_zone":           "${var.aws_region}b",
+						"availability_zone":           "${var.aws_region}a",
 						"instance_type":               "${var.instance_type}",
+						"key_name":                    "${var.key_name}",
+						"root_block_device": [
+							{
+								"volume_size": "${var.volume_size}",
+							},
+						],
 						"tags": [
 							{
 								"Name":  "${var.name}",
-								"owner": "roger@hashicorp.com",
+								"owner": "Roger",
 								"ttl":   "24",
 							},
 						],
@@ -54,9 +72,152 @@ _modules = {
 				"default":     "t2.micro",
 				"description": "type of EC2 instance to provision.",
 			},
+			"key_name": {
+				"default":     null,
+				"description": "name of the SSH key for accessing the instance",
+			},
 			"name": {
-				"default":     "Provisioned by Terraform",
+				"default":     "Provisioned very quickly by Terraform",
 				"description": "name to pass to Name tag",
+			},
+			"vault_addr": {
+				"default":     "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+				"description": "address of the Vault server",
+			},
+			"volume_size": {
+				"default":     "10",
+				"description": "the size of root device",
+			},
+		},
+	},
+
+	"module.nested": {
+		"data": {},
+		"modules": {
+			"nested-again": {
+				"config": {
+					"ami_id":        "${var.ami_id}",
+					"aws_region":    "${var.aws_region}",
+					"instance_type": "${var.instance_type}",
+					"key_name":      "${var.key_name}",
+					"name":          "${var.name}",
+					"volume_size":   "${var.volume_size}",
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"ubuntu-too": {
+					"config": {
+						"ami": "${var.ami_id}",
+						"associate_public_ip_address": "true",
+						"availability_zone":           "${var.aws_region}a",
+						"instance_type":               "${var.instance_type}",
+						"key_name":                    "${var.key_name}",
+						"root_block_device": [
+							{
+								"volume_size": "${var.volume_size}",
+							},
+						],
+						"tags": [
+							{
+								"Name":  "${var.name}",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     null,
+				"description": "",
+			},
+			"aws_region": {
+				"default":     null,
+				"description": "",
+			},
+			"instance_type": {
+				"default":     null,
+				"description": "",
+			},
+			"key_name": {
+				"default":     null,
+				"description": "",
+			},
+			"name": {
+				"default":     null,
+				"description": "",
+			},
+			"volume_size": {
+				"default":     null,
+				"description": "",
+			},
+		},
+	},
+
+	"module.nested.module.nested-again": {
+		"data":      {},
+		"modules":   {},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"ubuntu-three": {
+					"config": {
+						"ami": "${var.ami_id}",
+						"associate_public_ip_address": "true",
+						"availability_zone":           "${var.aws_region}a",
+						"instance_type":               "${var.instance_type}",
+						"key_name":                    "${var.key_name}",
+						"root_block_device": [
+							{
+								"volume_size": "${var.volume_size}",
+							},
+						],
+						"tags": [
+							{
+								"Name":  "${var.name}",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     null,
+				"description": "",
+			},
+			"aws_region": {
+				"default":     null,
+				"description": "",
+			},
+			"instance_type": {
+				"default":     null,
+				"description": "",
+			},
+			"key_name": {
+				"default":     null,
+				"description": "",
+			},
+			"name": {
+				"default":     null,
+				"description": "",
+			},
+			"volume_size": {
+				"default":     null,
+				"description": "",
 			},
 		},
 	},
@@ -64,14 +225,31 @@ _modules = {
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
+	[
+		"nested",
+		"nested-again",
+	],
 ]
 
 module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
 	if length(path) < 1 {
 		return _modules.root
 	}
 
-	return _modules[strings.join(["module", path], ".")]
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
 }
 
 data = _modules.root.data

--- a/governance/second-generation/aws/mocks/ec2-instance-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/ec2-instance-mock-tfplan.sentinel
@@ -1,4 +1,5 @@
 import "strings"
+import "types"
 
 _modules = {
 	"root": {
@@ -12,7 +13,7 @@ _modules = {
 							"ami": "ami-2e1ef954",
 							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"associate_public_ip_address":  true,
-							"availability_zone":            "us-east-1b",
+							"availability_zone":            "us-east-1a",
 							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
@@ -21,10 +22,10 @@ _modules = {
 							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_type":                "m5.large",
+							"instance_type":                "t2.micro",
 							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
 							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
@@ -34,13 +35,20 @@ _modules = {
 							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"source_dest_check":            true,
-							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name":  "roger-demo-dev",
-								"owner": "roger@hashicorp.com",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
 								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
@@ -65,7 +73,7 @@ _modules = {
 							},
 							"availability_zone": {
 								"computed": false,
-								"new":      "us-east-1b",
+								"new":      "us-east-1a",
 								"old":      "",
 							},
 							"cpu_core_count": {
@@ -110,7 +118,7 @@ _modules = {
 							},
 							"instance_type": {
 								"computed": false,
-								"new":      "m5.large",
+								"new":      "t2.micro",
 								"old":      "",
 							},
 							"ipv6_address_count": {
@@ -124,8 +132,8 @@ _modules = {
 								"old":      "",
 							},
 							"key_name": {
-								"computed": true,
-								"new":      "",
+								"computed": false,
+								"new":      "roger-vault",
 								"old":      "",
 							},
 							"network_interface.#": {
@@ -174,6 +182,26 @@ _modules = {
 								"old":      "",
 							},
 							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
 								"computed": true,
 								"new":      "",
 								"old":      "",
@@ -200,12 +228,539 @@ _modules = {
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
 								"old":      "",
 							},
 							"tags.owner": {
 								"computed": false,
-								"new":      "roger@hashicorp.com",
+								"new":      "Roger",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	"module.nested": {
+		"data": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-too": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
+								"old":      "",
+							},
+							"tags.ttl": {
+								"computed": false,
+								"new":      "24",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	"module.nested.module.nested-again": {
+		"data": {},
+		"path": [
+			"nested",
+			"nested-again",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-three": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1a",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "roger-vault",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+									"volume_size":           "10",
+									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+								},
+							],
+							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check": true,
+							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1a",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": false,
+								"new":      "roger-vault",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"root_block_device.0.delete_on_termination": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"root_block_device.0.volume_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.0.volume_size": {
+								"computed": false,
+								"new":      "10",
+								"old":      "",
+							},
+							"root_block_device.0.volume_type": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "3",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -238,23 +793,43 @@ _modules = {
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
+	[
+		"nested",
+		"nested-again",
+	],
 ]
 
-terraform_version = "0.11.13"
+terraform_version = "0.11.14"
 
 variables = {
 	"ami_id":        "ami-2e1ef954",
 	"aws_region":    "us-east-1",
-	"instance_type": "m5.large",
-	"name":          "roger-demo-dev",
+	"instance_type": "t2.micro",
+	"key_name":      "roger-vault",
+	"name":          "roger-ec2-demo",
+	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
+	"volume_size":   "10",
 }
 
 module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
 	if length(path) < 1 {
 		return _modules.root
 	}
 
-	return _modules[strings.join(["module", path], ".")]
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
 }
 
 data = _modules.root.data

--- a/governance/second-generation/aws/mocks/ec2-instance-mock-tfstate.sentinel
+++ b/governance/second-generation/aws/mocks/ec2-instance-mock-tfstate.sentinel
@@ -1,26 +1,275 @@
 import "strings"
+import "types"
 
 _modules = {
 	"root": {
-		"data":      {},
-		"outputs":   {},
-		"path":      [],
-		"resources": {},
+		"data": {},
+		"outputs": {
+			"public_dns": {
+				"sensitive": false,
+				"type":      "list",
+				"value": [
+					"ec2-3-88-146-182.compute-1.amazonaws.com",
+				],
+			},
+		},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"ami": "ami-2e1ef954",
+							"arn": "arn:aws:ec2:us-east-1:753646501470:instance/i-08b3b7c09915673c5",
+							"associate_public_ip_address": true,
+							"availability_zone":           "us-east-1a",
+							"cpu_core_count":              "1",
+							"cpu_threads_per_core":        "1",
+							"credit_specification": [
+								{
+									"cpu_credits": "standard",
+								},
+							],
+							"disable_api_termination": false,
+							"ebs_block_device":        [],
+							"ebs_optimized":           false,
+							"ephemeral_block_device":  [],
+							"get_password_data":       false,
+							"iam_instance_profile":    "",
+							"id":                           "i-08b3b7c09915673c5",
+							"instance_state":               "running",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "0",
+							"ipv6_addresses":               [],
+							"key_name":                     "roger-vault",
+							"monitoring":                   false,
+							"network_interface":            [],
+							"password_data":                "",
+							"placement_group":              "",
+							"primary_network_interface_id": "eni-0789906d93500d666",
+							"private_dns":                  "ip-172-31-46-68.ec2.internal",
+							"private_ip":                   "172.31.46.68",
+							"public_dns":                   "ec2-3-88-146-182.compute-1.amazonaws.com",
+							"public_ip":                    "3.88.146.182",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"iops":                  "0",
+									"volume_id":             "vol-08536670e90b58e93",
+									"volume_size":           "10",
+									"volume_type":           "standard",
+								},
+							],
+							"security_groups": [
+								"default",
+							],
+							"source_dest_check": true,
+							"subnet_id":         "subnet-0be41057",
+							"tags": {
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+							"tenancy":     "default",
+							"volume_tags": {},
+							"vpc_security_group_ids": [
+								"sg-5eb84716",
+							],
+						},
+						"depends_on": [],
+						"id":         "i-08b3b7c09915673c5",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.nested": {
+		"data":    {},
+		"outputs": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-too": {
+					0: {
+						"attr": {
+							"ami": "ami-2e1ef954",
+							"arn": "arn:aws:ec2:us-east-1:753646501470:instance/i-07da785c6ea519a46",
+							"associate_public_ip_address": true,
+							"availability_zone":           "us-east-1a",
+							"cpu_core_count":              "1",
+							"cpu_threads_per_core":        "1",
+							"credit_specification": [
+								{
+									"cpu_credits": "standard",
+								},
+							],
+							"disable_api_termination": false,
+							"ebs_block_device":        [],
+							"ebs_optimized":           false,
+							"ephemeral_block_device":  [],
+							"get_password_data":       false,
+							"iam_instance_profile":    "",
+							"id":                           "i-07da785c6ea519a46",
+							"instance_state":               "running",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "0",
+							"ipv6_addresses":               [],
+							"key_name":                     "roger-vault",
+							"monitoring":                   false,
+							"network_interface":            [],
+							"password_data":                "",
+							"placement_group":              "",
+							"primary_network_interface_id": "eni-0aa74d78903aeca18",
+							"private_dns":                  "ip-172-31-46-160.ec2.internal",
+							"private_ip":                   "172.31.46.160",
+							"public_dns":                   "ec2-54-225-3-16.compute-1.amazonaws.com",
+							"public_ip":                    "54.225.3.16",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"iops":                  "0",
+									"volume_id":             "vol-077df187108f7174c",
+									"volume_size":           "10",
+									"volume_type":           "standard",
+								},
+							],
+							"security_groups": [
+								"default",
+							],
+							"source_dest_check": true,
+							"subnet_id":         "subnet-0be41057",
+							"tags": {
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+							"tenancy":     "default",
+							"volume_tags": {},
+							"vpc_security_group_ids": [
+								"sg-5eb84716",
+							],
+						},
+						"depends_on": [],
+						"id":         "i-07da785c6ea519a46",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.nested.module.nested-again": {
+		"data":    {},
+		"outputs": {},
+		"path": [
+			"nested",
+			"nested-again",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-three": {
+					0: {
+						"attr": {
+							"ami": "ami-2e1ef954",
+							"arn": "arn:aws:ec2:us-east-1:753646501470:instance/i-02e5304c92bf69c4f",
+							"associate_public_ip_address": true,
+							"availability_zone":           "us-east-1a",
+							"cpu_core_count":              "1",
+							"cpu_threads_per_core":        "1",
+							"credit_specification": [
+								{
+									"cpu_credits": "standard",
+								},
+							],
+							"disable_api_termination": false,
+							"ebs_block_device":        [],
+							"ebs_optimized":           false,
+							"ephemeral_block_device":  [],
+							"get_password_data":       false,
+							"iam_instance_profile":    "",
+							"id":                           "i-02e5304c92bf69c4f",
+							"instance_state":               "running",
+							"instance_type":                "t2.small",
+							"ipv6_address_count":           "0",
+							"ipv6_addresses":               [],
+							"key_name":                     "roger-vault",
+							"monitoring":                   false,
+							"network_interface":            [],
+							"password_data":                "",
+							"placement_group":              "",
+							"primary_network_interface_id": "eni-09bb723fc156918f3",
+							"private_dns":                  "ip-172-31-40-196.ec2.internal",
+							"private_ip":                   "172.31.40.196",
+							"public_dns":                   "ec2-54-90-190-245.compute-1.amazonaws.com",
+							"public_ip":                    "54.90.190.245",
+							"root_block_device": [
+								{
+									"delete_on_termination": true,
+									"iops":                  "0",
+									"volume_id":             "vol-04ad345e1f254d0c4",
+									"volume_size":           "10",
+									"volume_type":           "standard",
+								},
+							],
+							"security_groups": [
+								"default",
+							],
+							"source_dest_check": true,
+							"subnet_id":         "subnet-0be41057",
+							"tags": {
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
+							},
+							"tenancy":     "default",
+							"volume_tags": {},
+							"vpc_security_group_ids": [
+								"sg-5eb84716",
+							],
+						},
+						"depends_on": [],
+						"id":         "i-02e5304c92bf69c4f",
+						"tainted":    false,
+					},
+				},
+			},
+		},
 	},
 }
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
+	[
+		"nested",
+		"nested-again",
+	],
 ]
 
-terraform_version = "0.11.13"
+terraform_version = "0.11.14"
 
 module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
 	if length(path) < 1 {
 		return _modules.root
 	}
 
-	return _modules[strings.join(["module", path], ".")]
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
 }
 
 data = _modules.root.data

--- a/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
@@ -41,20 +41,15 @@ get_instance_address = func(joined_path, type, name, index) {
   return address
 }
 
-# Validate that all EC2 instances have instance_type
-# in allowed_types list
+# Validate that all EC2 instances have instance_type in allowed_types list
 validate_instance_types = func(allowed_types) {
 
   # Initialize validated to true
-  # This will be set to false if any instances violate rule
+  # This will be set to false if any instances violate any conditions
   validated = true
 
-  # Set resource_type
-  resource_type = "aws_instance"
-
   # Get all resources of specified type
-  resource_maps = find_resources_from_plan(resource_type)
-
+  resource_maps = find_resources_from_plan("aws_instance")
 
   # Loop through the module-level resource maps
   for resource_maps as module_path, resource_map {
@@ -78,12 +73,13 @@ validate_instance_types = func(allowed_types) {
         if r.diff["instance_type"].computed else false is true {
           print("EC2 instance", address,
             "has attribute, instance_type, that is computed.")
-          # If you want computed values to cause the policy to fail, uncomment the next line.
-          #validated = false
+          # If you want computed values to cause the policy to fail,
+          # uncomment the next line.
+          # validated = false
         } else {
           # Validate that each instance has allowed value
           if r.applied.instance_type not in allowed_types {
-            print("EC2 instance", address, "has attribute",
+            print("EC2 instance", address, "has instance_type",
               r.applied.instance_type, "that is not in the allowed list:", allowed_types)
             validated = false
           }

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail.sentinel
@@ -1,4 +1,5 @@
 import "strings"
+import "types"
 
 _modules = {
 	"root": {
@@ -21,7 +22,7 @@ _modules = {
 							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_type":                "t2.small",
+							"instance_type":                "t2.micro",
 							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"key_name":                     "roger-vault",
@@ -46,8 +47,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -116,7 +118,7 @@ _modules = {
 							},
 							"instance_type": {
 								"computed": false,
-								"new":      "t2.small",
+								"new":      "t2.micro",
 								"old":      "",
 							},
 							"ipv6_address_count": {
@@ -221,256 +223,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
 								"old":      "",
 							},
-							"tags.ttl": {
+							"tags.owner": {
 								"computed": false,
-								"new":      "24",
-								"old":      "",
-							},
-							"tenancy": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"volume_tags.%": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"vpc_security_group_ids.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-						},
-					},
-					1: {
-						"applied": {
-							"ami": "ami-2e1ef954",
-							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"associate_public_ip_address":  true,
-							"availability_zone":            "us-east-1a",
-							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"get_password_data":            false,
-							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_type":                "t2.small",
-							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"key_name":                     "roger-vault",
-							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"root_block_device": [
-								{
-									"delete_on_termination": true,
-									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
-									"volume_size":           "10",
-									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
-								},
-							],
-							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"source_dest_check": true,
-							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
-							},
-							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"volume_tags":            {},
-							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
-						},
-						"diff": {
-							"ami": {
-								"computed": false,
-								"new":      "ami-2e1ef954",
-								"old":      "",
-							},
-							"arn": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"associate_public_ip_address": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"availability_zone": {
-								"computed": false,
-								"new":      "us-east-1a",
-								"old":      "",
-							},
-							"cpu_core_count": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"cpu_threads_per_core": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ebs_block_device.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ephemeral_block_device.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"get_password_data": {
-								"computed": false,
-								"new":      "false",
-								"old":      "",
-							},
-							"host_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"instance_state": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"instance_type": {
-								"computed": false,
-								"new":      "t2.small",
-								"old":      "",
-							},
-							"ipv6_address_count": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ipv6_addresses.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"key_name": {
-								"computed": false,
-								"new":      "roger-vault",
-								"old":      "",
-							},
-							"network_interface.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"network_interface_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"password_data": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"placement_group": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"primary_network_interface_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"private_dns": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"private_ip": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"public_dns": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"public_ip": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"root_block_device.#": {
-								"computed": false,
-								"new":      "1",
-								"old":      "",
-							},
-							"root_block_device.0.delete_on_termination": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"root_block_device.0.volume_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"root_block_device.0.volume_size": {
-								"computed": false,
-								"new":      "10",
-								"old":      "",
-							},
-							"root_block_device.0.volume_type": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"security_groups.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"source_dest_check": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"subnet_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"tags.%": {
-								"computed": false,
-								"new":      "2",
-								"old":      "",
-							},
-							"tags.Name": {
-								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -496,6 +259,17 @@ _modules = {
 						},
 					},
 				},
+			},
+		},
+	},
+
+	"module.nested": {
+		"data": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
 				"ubuntu-too": {
 					0: {
 						"applied": {
@@ -536,8 +310,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -711,12 +486,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -741,7 +521,21 @@ _modules = {
 							},
 						},
 					},
-					1: {
+				},
+			},
+		},
+	},
+
+	"module.nested.module.nested-again": {
+		"data": {},
+		"path": [
+			"nested",
+			"nested-again",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-three": {
+					0: {
 						"applied": {
 							"ami": "ami-2e1ef954",
 							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
@@ -780,8 +574,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -955,12 +750,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -993,26 +793,43 @@ _modules = {
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
+	[
+		"nested",
+		"nested-again",
+	],
 ]
 
-terraform_version = "0.11.13"
+terraform_version = "0.11.14"
 
 variables = {
 	"ami_id":        "ami-2e1ef954",
 	"aws_region":    "us-east-1",
-	"instance_type": "t2.small",
+	"instance_type": "t2.micro",
 	"key_name":      "roger-vault",
-	"name":          "roger-demo-dev",
+	"name":          "roger-ec2-demo",
 	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
 	"volume_size":   "10",
 }
 
 module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
 	if length(path) < 1 {
 		return _modules.root
 	}
 
-	return _modules[strings.join(["module", path], ".")]
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
 }
 
 data = _modules.root.data

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass.sentinel
@@ -1,4 +1,5 @@
 import "strings"
+import "types"
 
 _modules = {
 	"root": {
@@ -46,8 +47,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -221,256 +223,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
 								"old":      "",
 							},
-							"tags.ttl": {
+							"tags.owner": {
 								"computed": false,
-								"new":      "24",
-								"old":      "",
-							},
-							"tenancy": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"volume_tags.%": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"vpc_security_group_ids.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-						},
-					},
-					1: {
-						"applied": {
-							"ami": "ami-2e1ef954",
-							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"associate_public_ip_address":  true,
-							"availability_zone":            "us-east-1a",
-							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"get_password_data":            false,
-							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"instance_type":                "t2.small",
-							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"key_name":                     "roger-vault",
-							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"root_block_device": [
-								{
-									"delete_on_termination": true,
-									"volume_id":             "74D93920-ED26-11E3-AC10-0800200C9A66",
-									"volume_size":           "10",
-									"volume_type":           "74D93920-ED26-11E3-AC10-0800200C9A66",
-								},
-							],
-							"security_groups":   "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"source_dest_check": true,
-							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
-							},
-							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
-							"volume_tags":            {},
-							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
-						},
-						"diff": {
-							"ami": {
-								"computed": false,
-								"new":      "ami-2e1ef954",
-								"old":      "",
-							},
-							"arn": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"associate_public_ip_address": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"availability_zone": {
-								"computed": false,
-								"new":      "us-east-1a",
-								"old":      "",
-							},
-							"cpu_core_count": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"cpu_threads_per_core": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ebs_block_device.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ephemeral_block_device.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"get_password_data": {
-								"computed": false,
-								"new":      "false",
-								"old":      "",
-							},
-							"host_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"instance_state": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"instance_type": {
-								"computed": false,
-								"new":      "t2.small",
-								"old":      "",
-							},
-							"ipv6_address_count": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"ipv6_addresses.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"key_name": {
-								"computed": false,
-								"new":      "roger-vault",
-								"old":      "",
-							},
-							"network_interface.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"network_interface_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"password_data": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"placement_group": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"primary_network_interface_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"private_dns": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"private_ip": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"public_dns": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"public_ip": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"root_block_device.#": {
-								"computed": false,
-								"new":      "1",
-								"old":      "",
-							},
-							"root_block_device.0.delete_on_termination": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"root_block_device.0.volume_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"root_block_device.0.volume_size": {
-								"computed": false,
-								"new":      "10",
-								"old":      "",
-							},
-							"root_block_device.0.volume_type": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"security_groups.#": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"source_dest_check": {
-								"computed": false,
-								"new":      "true",
-								"old":      "",
-							},
-							"subnet_id": {
-								"computed": true,
-								"new":      "",
-								"old":      "",
-							},
-							"tags.%": {
-								"computed": false,
-								"new":      "2",
-								"old":      "",
-							},
-							"tags.Name": {
-								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -496,6 +259,17 @@ _modules = {
 						},
 					},
 				},
+			},
+		},
+	},
+
+	"module.nested": {
+		"data": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
 				"ubuntu-too": {
 					0: {
 						"applied": {
@@ -536,8 +310,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -711,12 +486,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -741,7 +521,21 @@ _modules = {
 							},
 						},
 					},
-					1: {
+				},
+			},
+		},
+	},
+
+	"module.nested.module.nested-again": {
+		"data": {},
+		"path": [
+			"nested",
+			"nested-again",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-three": {
+					0: {
 						"applied": {
 							"ami": "ami-2e1ef954",
 							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
@@ -780,8 +574,9 @@ _modules = {
 							"source_dest_check": true,
 							"subnet_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags": {
-								"Name": "roger-demo-dev",
-								"ttl":  "24",
+								"Name":  "roger-ec2-demo",
+								"owner": "Roger",
+								"ttl":   "24",
 							},
 							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"volume_tags":            {},
@@ -955,12 +750,17 @@ _modules = {
 							},
 							"tags.%": {
 								"computed": false,
-								"new":      "2",
+								"new":      "3",
 								"old":      "",
 							},
 							"tags.Name": {
 								"computed": false,
-								"new":      "roger-demo-dev",
+								"new":      "roger-ec2-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Roger",
 								"old":      "",
 							},
 							"tags.ttl": {
@@ -993,26 +793,43 @@ _modules = {
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
+	[
+		"nested",
+		"nested-again",
+	],
 ]
 
-terraform_version = "0.11.13"
+terraform_version = "0.11.14"
 
 variables = {
 	"ami_id":        "ami-2e1ef954",
 	"aws_region":    "us-east-1",
 	"instance_type": "t2.small",
 	"key_name":      "roger-vault",
-	"name":          "roger-demo-dev",
+	"name":          "roger-ec2-demo",
 	"vault_addr":    "http://kubernetes-vault-elb-1163802512.us-east-1.elb.amazonaws.com:8200",
 	"volume_size":   "10",
 }
 
 module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
 	if length(path) < 1 {
 		return _modules.root
 	}
 
-	return _modules[strings.join(["module", path], ".")]
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
 }
 
 data = _modules.root.data

--- a/governance/second-generation/common-functions/find_resources_from_config.sentinel
+++ b/governance/second-generation/common-functions/find_resources_from_config.sentinel
@@ -1,0 +1,30 @@
+import "tfconfig"
+import "strings"
+
+# Find all resources of specific type from all modules using the tfconfig import
+find_resources_from_config = func(type) {
+
+  resources = {}
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Iterate over the named resources of desired type in the module
+    for tfconfig.module(path).resources[type] else {} as name, r {
+
+      # Get the address of the instance
+      if length(path) == 0 {
+        # root module
+        address = type + "." + name
+      } else {
+        # non-root module
+        address = "module." + strings.join(path, ".module.") + "." +
+                  type + "." + name
+      }
+
+      # Add the resource to resources map, setting the key to the address
+      resources[address] = r
+    }
+  }
+
+  return resources
+}

--- a/governance/second-generation/common-functions/find_resources_from_plan.sentinel
+++ b/governance/second-generation/common-functions/find_resources_from_plan.sentinel
@@ -1,0 +1,33 @@
+import "tfplan"
+import "strings"
+
+# Find all resources of specific type from all modules using the tfplan import
+find_resources_from_plan = func(type) {
+
+  resources = {}
+
+  # Iterate over all modules in the tfplan import
+  for tfplan.module_paths as path {
+    # Iterate over the named resources of desired type in the module
+    for tfplan.module(path).resources[type] else {} as name, instances {
+      # Iterate over resource instances
+      for instances as index, r {
+
+        # Get the address of the instance
+        if length(path) == 0 {
+          # root module
+          address = type + "." + name + "[" + string(index) + "]"
+        } else {
+          # non-root module
+          address = "module." + strings.join(path, ".module.") + "." +
+                    type + "." + name + "[" + string(index) + "]"
+        }
+
+        # Add the instance to resources map, setting the key to the address
+        resources[address] = r
+      }
+    }
+  }
+
+  return resources
+}

--- a/governance/second-generation/common-functions/find_resources_from_state.sentinel
+++ b/governance/second-generation/common-functions/find_resources_from_state.sentinel
@@ -1,0 +1,33 @@
+import "tfstate"
+import "strings"
+
+# Find all resources of specific type from all modules using the tfstate import
+find_resources_from_state = func(type) {
+
+  resources = {}
+
+  # Iterate over all modules in the tfstate import
+  for tfstate.module_paths as path {
+    # Iterate over the named resources of desired type in the module
+    for tfstate.module(path).resources[type] else {} as name, instances {
+      # Iterate over resource instances
+      for instances as index, r {
+
+        # Get the address of the instance
+        if length(path) == 0 {
+          # root module
+          address = type + "." + name + "[" + string(index) + "]"
+        } else {
+          # non-root module
+          address = "module." + strings.join(path, ".module.") + "." +
+                    type + "." + name + "[" + string(index) + "]"
+        }
+
+        # Add the instance to resources map, setting the key to the address
+        resources[address] = r
+      }
+    }
+  }
+
+  return resources
+}

--- a/governance/second-generation/common-functions/validate_resource_attribute_in_list.sentinel
+++ b/governance/second-generation/common-functions/validate_resource_attribute_in_list.sentinel
@@ -1,0 +1,24 @@
+import "tfplan"
+
+# Validate that all instances of specific type have
+# a specific top-level attribute in a given list
+validate_resource_attribute_in_list = func(type, attribute, allowed_values) {
+    validated = true
+    resource_instances = find_resources_from_plan(type)
+    for resource_instances as address, r {
+        # Determine if the attribute is computed
+        if r.diff[attribute].computed else false is true {
+            print("Resource", address, "has attribute", attribute,
+                  "that is computed.")
+        } else {
+            # Validate that each instance has allowed value
+            if (r.applied[attribute] else "") not in allowed_values {
+                print("Resource", address, "has attribute", attribute,
+                      "with value", r.applied[attribute] else "",
+                      "that is not in the allowed list:", allowed_values)
+                validated = false
+            }
+        }
+    }
+    return validated
+}


### PR DESCRIPTION
I've added some common Sentinel functions in a new governance/second-generation/common-functions directory:
* find_resources_from_plan() finds all resources of a specific type from all modules using the tfplan import. It is used in most of the second-generation policies in this repository.
* find_resources_from_config finds all resources of a specific type from all modules using the tfconfig import.
* find_resources_from_state finds all resources of a specific type from all modules using the tfstate import.
* validate_resource_attribute_in_list() validates that a specified top-level attribute in all resources of a specific type are in a specified list using the tfplan import. It uses the find_resources_from_plan() function. I will use this in at least one second-generation policy to illustrate its use.

The updated page https://www.terraform.io/docs/enterprise/sentinel/import/index.html will soon refer to this directory after a PR is merged, so I would like this approved quickly to avoid a broken link on the Terraform website.