### PR TITLE
fixed GKE and c-&-d

### DIFF
--- a/infrastructure-as-code/k8s-cluster-gke/main.tf
+++ b/infrastructure-as-code/k8s-cluster-gke/main.tf
@@ -27,6 +27,10 @@ resource "google_container_cluster" "k8sexample" {
   master_auth {
     username = "${var.master_username}"
     password = "${var.master_password}"
+
+    client_certificate_config {
+      issue_client_certificate = true
+    }
   }
 
   node_config {

--- a/self-serve-infrastructure/cats-and-dogs/backend/vote-db/start_redis.sh
+++ b/self-serve-infrastructure/cats-and-dogs/backend/vote-db/start_redis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Authenticate against Vault
-login_result=$(curl --request POST --data '{"role": "demo", "jwt": "'"${K8S_TOKEN}"'"}' ${VAULT_ADDR}/v1/auth/${VAULT_K8S_BACKEND}login)
+login_result=$(curl --request POST --data '{"role": "demo", "jwt": "'"${K8S_TOKEN}"'"}' ${VAULT_ADDR}/v1/auth/${VAULT_K8S_BACKEND}/login)
 
 # Read cats-and-dogs secret from Vault
 vault_token=$(echo $login_result | python3 -c "import sys, json; print(json.load(sys.stdin)['auth']['client_token'])")

--- a/self-serve-infrastructure/cats-and-dogs/frontend/azure-vote/main.py
+++ b/self-serve-infrastructure/cats-and-dogs/frontend/azure-vote/main.py
@@ -19,7 +19,7 @@ title =         app.config['TITLE']
 try:
     client = hvac.Client(url=os.environ['VAULT_ADDR'])
     params = {'role':'demo', 'jwt':os.environ['K8S_TOKEN']}
-    result = client.auth('/v1/auth/' + os.environ['VAULT_K8S_BACKEND'] + 'login', json=params)
+    result = client.auth('/v1/auth/' + os.environ['VAULT_K8S_BACKEND'] + '/login', json=params)
     print(result)
 
     # Redis configurations


### PR DESCRIPTION
Fixes GKE cluster to ensure that cert and key are generated.
Fixes cats-and-dogs application to add "/" in Vault path to adjust for change in output from Vault provider for auth backends that no longer includes the "/"