### PR TITLE
add advanced-dynamic-block TF 0.12 example

### DIFF
--- a/infrastructure-as-code/terraform-0.12-examples/README.md
+++ b/infrastructure-as-code/terraform-0.12-examples/README.md
@@ -1,29 +1,23 @@
 # Terraform 0.12 Examples
 This repository contains some Terraform 0.12 examples that demonstrate new HCL features and other Terraform enhancements that are being added to Terraform 0.12. Each sub-directory contains a separate example that can be run separately from the others by running `terraform init` followed by `terraform apply`.
 
-These examples have been tested with terraform 0.12 beta1.
+These examples have been tested with terraform 0.12.3.
 
 The examples are:
 1. [First Class Expressions](./first-class-expressions)
 1. [For Expressions](./for-expressions)
 1. [Dynamic Blocks and Splat Expresions](./dynamic-blocks-and-splat-expressions)
+1. [Advanced Dynamic Blocks](./advanced-dynamic-blocks)
 1. [Rich Value Types](./rich-value-types)
 1. [New Template Syntax](./new-template-syntax)
 1. [Reliable JSON Syntax](./reliable-json-syntax)
 
-## Installing Terraform 0.12 Beta1
+## Installing Terraform 0.12
 1. Determine the location of the Terraform binary in your path. On a Mac of Linux machine, run `which terraform`. On a Windows machine, run `where terraform`.
-1. Move your current copy of the Terraform binary to a different location outside your path and remember where so you can restore it after using the Terraform 0.12 beta. Also note the old location.
+1. Move your current copy of the Terraform binary to a different location outside your path and remember where so you can restore it after using the Terraform 0.12 binary if you want to revert back to an earlier version. Also note the old location.
 1. On a Mac or Linux machine, rename the `~/.terraform.d` directory to something like `.terraformd`; on a Windows machine, rename `%USERPROFILE%\terraform.d` to `%USERPROFILE%\terraformd`. This way, you can restore the directory (if anything was in it) after the class.
-1. Download the Terraform 0.12 beta1 zip file for your OS from https://releases.hashicorp.com/terraform/0.12.0-beta1.
+1. Download the current Terraform 0.12.x zip file for your OS from https://www.terraform.io/downloads.html.
 1. Unzip the file and copy the terraform or terraform.exe binary to the location where your original terraform binary was. If you did not previously have the terraform binary deployed, copy it to a location within your path or edit your PATH environment variable to include the directory you put it in.
-1. Download the AWS and template providers for your OS from the [AWS provider](http://terraform-0.12.0-dev-snapshots.s3-website-us-west-2.amazonaws.com/terraform-provider-aws/1.60.0-dev20190216H00-dev/) and the [Template provider](http://terraform-0.12.0-dev-snapshots.s3-website-us-west-2.amazonaws.com/terraform-provider-template/2.1.0-dev20190216H00-dev/) directories.
-1. Unzip the provider binaries from the zip files.
-1. Create a directory to contain the providers:
-  1. On a Mac, run `mkdir -p ~/.terraform.d/plugins/darwin_amd64`.
-  1. On a Linux machine, run `mkdir -p ~/.terraform.d/plugins/linux_amd64`.
-  1. On a Windows laptop, run `mkdir %USERPROFILE%\terraform.d\plugins\windows_amd64`.
-1. Copy the AWS and template provider binaries to the directory you created.
 1. Clone this repository to your laptop with the command `git clone https://github.com/hashicorp/terraform-guides.git`.
 1. Use `cd terraform-guides/infrastructure-as-code/terraform-0.12-examples` to change into the directory containing the Terraform 0.12 examples.
 
@@ -54,6 +48,9 @@ See the example's [README.md](./for-expressions/README.md).
 ## Dynamic Blocks and Splat Expressions Example
 See the example's [README.md](./dynamic-blocks-and-splat-expressions/README.md).
 
+## Advanced Dynamic Blocks Example
+See the example's [README.md](./advanced-dynamic-blocks/README.md).
+
 ## Rich Value Types
 See the example's [README.md](./rich-value-types/README.md).
 
@@ -62,6 +59,3 @@ See the example's [README.md](./new-template-syntax/README.md).
 
 ## Reliable JSON Syntax
 See the example's [README.md](./reliable-json-syntax/README.md).
-
-## Cleanup
-When done with the Terraform 0.12 beta, delete the terraform.d or .terraform.d directory under your home directory and rename the original version of the directory to what it was before. Replace the Terraform 0.12 binary with the Terraform binary you were previously using in your path.

--- a/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/README.md
+++ b/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/README.md
@@ -1,0 +1,91 @@
+# Advanced Dynamic Blocks
+The Advanced Dynamic Blocks example shows how [dynamic blocks](https://www.terraform.io/docs/configuration/expressions.html#dynamic-blocks) can be used to dynamically create multiple instances of a block within a resource from a complex value such as a list of maps.
+
+In this example, we create an [Elastic Beanstalk Environment](https://www.terraform.io/docs/providers/aws/r/elastic_beanstalk_environment.html) resource with two option settings dynamically generated from a variable `settings` defined as a list of maps, each of which has three entries: `namespace`, `name`, and `value`.  
+
+We define the `settings` variable in main.tf like this:
+
+```
+variable "settings" {
+  type = list(map(string))
+}
+```
+Note that we specify the type of the variable as `list(map(string))` which indicates that it is a list of maps whose values are strings.
+
+We provide the value for the `settings` variable in a terraform.tfvars file:
+
+```
+settings = [
+ {
+   namespace = "aws:ec2:vpc"
+   name = "VPCId"
+   value = "vpc-xxxxxxxxxxxxxxxxx"
+ },
+ {
+   namespace = "aws:ec2:vpc"
+   name = "Subnets"
+   value = "subnet-xxxxxxxxxxxxxxxxx"
+ },
+]
+```
+
+Finally, we dynamically create the setting blocks within the aws_elastic_beanstalk_environment resource like this:
+
+```
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name                = "tf-test-name"
+  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  solution_stack_name = "64bit Amazon Linux 2018.03 v2.11.4 running Go 1.12.6"
+
+  dynamic "setting" {
+    for_each = var.settings
+    content {
+      namespace = setting.value["namespace"]
+      name = setting.value["name"]
+      value = setting.value["value"]
+    }
+  }
+}
+```
+
+Note that we specify the `settings` variable in the `for_each` argument and then reference the three items of each map within the `settings` variable using the names of the map's keys.
+
+To actually run this, please specify valid VPC and subnet IDs in your copy of terraform.tfvars.
+
+You should see output from running `terraform apply` that looks like this:
+
+```
+  # aws_elastic_beanstalk_environment.tfenvtest will be created
+  + resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+      + all_settings           = (known after apply)
+      + application            = "tf-test-name"
+      + arn                    = (known after apply)
+      + autoscaling_groups     = (known after apply)
+      + cname                  = (known after apply)
+      + cname_prefix           = (known after apply)
+      + id                     = (known after apply)
+      + instances              = (known after apply)
+      + launch_configurations  = (known after apply)
+      + load_balancers         = (known after apply)
+      + name                   = "tf-test-name"
+      + platform_arn           = (known after apply)
+      + queues                 = (known after apply)
+      + solution_stack_name    = "64bit Amazon Linux 2018.03 v2.11.4 running Go 1.12.6"
+      + tier                   = "WebServer"
+      + triggers               = (known after apply)
+      + version_label          = (known after apply)
+      + wait_for_ready_timeout = "20m"
+
+      + setting {
+          + name      = "Subnets"
+          + namespace = "aws:ec2:vpc"
+          + value     = "subnet-06dcc5d225b48b816"
+        }
+      + setting {
+          + name      = "VPCId"
+          + namespace = "aws:ec2:vpc"
+          + value     = "vpc-00e555dc5f3a3cbc2"
+        }
+    }
+```
+

--- a/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/main.tf
+++ b/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/main.tf
@@ -1,0 +1,23 @@
+variable "settings" {
+  type = list(map(string))
+}
+
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name        = "tf-test-name"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name                = "tf-test-name"
+  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  solution_stack_name = "64bit Amazon Linux 2018.03 v2.11.4 running Go 1.12.6"
+
+  dynamic "setting" {
+    for_each = var.settings
+    content {
+      namespace = setting.value["namespace"]
+      name = setting.value["name"]
+      value = setting.value["value"]
+    }
+  }
+}

--- a/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/terraform.tfvars
+++ b/infrastructure-as-code/terraform-0.12-examples/advanced-dynamic-blocks/terraform.tfvars
@@ -1,0 +1,13 @@
+settings = [
+ {
+   namespace = "aws:ec2:vpc"
+   name = "VPCId"
+   value = "vpc-xxxxxxxxxxxxxxxxx"
+ },
+ {
+   namespace = "aws:ec2:vpc"
+   name = "Subnets"
+   value = "subnet-xxxxxxxxxxxxxxxxx"
+ },
+]
+ 


### PR DESCRIPTION
This adds an advanced dynamic block example for Terraform 0.12 which uses a variable that is a list of maps for determining the content of the dynamically generated blocks.  The specific example using the aws_elastic_beanstalk_environment resource had been asked about by a customer.