### PR TITLE
Fix sentinel resource destruction checks

### DIFF
--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -55,8 +55,9 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/mocks/ec2-instance-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/ec2-instance-mock-tfplan.sentinel
@@ -55,6 +55,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -318,6 +319,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -582,6 +584,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/mocks/launch-configuration-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/launch-configuration-mock-tfplan.sentinel
@@ -20,6 +20,7 @@ _modules = {
 							"name":                        "web_config",
 							"root_block_device":           "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"associate_public_ip_address": {
 								"computed": false,

--- a/governance/second-generation/aws/mocks/rds-db-instance-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/rds-db-instance-mock-tfplan.sentinel
@@ -50,6 +50,7 @@ _modules = {
 							"username":                   "foo",
 							"vpc_security_group_ids":     "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"address": {
 								"computed": true,

--- a/governance/second-generation/aws/mocks/s3-bucket-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/s3-bucket-mock-tfplan.sentinel
@@ -61,6 +61,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/mocks/sgr-mock-tfplan.sentinel
+++ b/governance/second-generation/aws/mocks/sgr-mock-tfplan.sentinel
@@ -21,6 +21,7 @@ _modules = {
 							"to_port":                  "65535",
 							"type":                     "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,

--- a/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -57,8 +57,9 @@ validate_private_acl_and_kms_encryption = func() {
   for resource_instances as address, r {
 
     # Skip resources that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-availability-zones.sentinel
+++ b/governance/second-generation/aws/restrict-availability-zones.sentinel
@@ -53,8 +53,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-db-instance-engines.sentinel
+++ b/governance/second-generation/aws/restrict-db-instance-engines.sentinel
@@ -52,8 +52,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
@@ -52,8 +52,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -53,8 +53,9 @@ validate_sgr_cidr_blocks = func() {
   for resource_instances as address, r {
 
     # Skip resources that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
@@ -59,8 +59,9 @@ validate_instance_types = func(allowed_types) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail-0.11.sentinel
@@ -53,6 +53,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -297,6 +298,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -544,6 +546,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -794,6 +797,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail-0.12.sentinel
@@ -31,6 +31,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass-0.11.sentinel
@@ -54,6 +54,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -304,6 +305,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -556,6 +558,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -806,6 +809,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass-0.12.sentinel
@@ -32,6 +32,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-0.11.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-0.11.sentinel
@@ -61,6 +61,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-and-kms-0.11.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-and-kms-0.11.sentinel
@@ -60,6 +60,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-and-kms-0.12.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-acl-and-kms-0.12.sentinel
@@ -62,6 +62,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-kms-0.11.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-kms-0.11.sentinel
@@ -47,6 +47,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-0.11.sentinel
@@ -61,6 +61,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-0.12.sentinel
@@ -62,6 +62,7 @@ _modules = {
 							"website_domain":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"website_endpoint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"acceleration_status": {
 								"computed": true,

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail-0.11.sentinel
@@ -53,6 +53,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -297,6 +298,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -543,6 +545,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -787,6 +790,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-fail-0.12.sentinel
@@ -32,6 +32,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass-0.11.sentinel
@@ -53,6 +53,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -297,6 +298,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -543,6 +545,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -787,6 +790,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-availability-zones/mock-tfplan-pass-0.12.sentinel
@@ -32,6 +32,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-fail-0.11.sentinel
@@ -50,6 +50,7 @@ _modules = {
 							"username":                   "foo",
 							"vpc_security_group_ids":     "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"address": {
 								"computed": true,

--- a/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-fail-0.12.sentinel
@@ -42,6 +42,7 @@ _modules = {
 							"timeouts":                            null,
 							"username":                            "foo",
 						},
+						"destroy": false,
 						"diff": {
 							"address": {
 								"computed": true,

--- a/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-pass-0.11.sentinel
@@ -50,6 +50,7 @@ _modules = {
 							"username":                   "foo",
 							"vpc_security_group_ids":     "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"address": {
 								"computed": true,

--- a/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-db-instance-engines/mock-tfplan-pass-0.12.sentinel
@@ -42,6 +42,7 @@ _modules = {
 							"timeouts":                            null,
 							"username":                            "foo",
 						},
+						"destroy": false,
 						"diff": {
 							"address": {
 								"computed": true,

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail-0.11.sentinel
@@ -55,6 +55,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -318,6 +319,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -582,6 +584,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-fail-0.12.sentinel
@@ -32,6 +32,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass-0.11.sentinel
@@ -55,6 +55,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -318,6 +319,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,
@@ -582,6 +584,7 @@ _modules = {
 							"volume_tags":            {},
 							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ec2-instance-type/mock-tfplan-pass-0.12.sentinel
@@ -32,6 +32,7 @@ _modules = {
 							"user_data":        null,
 							"user_data_base64": null,
 						},
+						"destroy": false,
 						"diff": {
 							"ami": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.11.sentinel
@@ -21,6 +21,7 @@ _modules = {
 							"to_port":                  "65535",
 							"type":                     "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.12.sentinel
@@ -23,6 +23,7 @@ _modules = {
 							"to_port":           65535,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -106,6 +107,7 @@ _modules = {
 							"to_port":           65535,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -191,6 +193,7 @@ _modules = {
 							"to_port":           22,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -287,6 +290,7 @@ _modules = {
 							"to_port":           443,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -384,6 +388,7 @@ _modules = {
 							"to_port":           80,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.11.sentinel
@@ -21,6 +21,7 @@ _modules = {
 							"to_port":                  "65535",
 							"type":                     "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.12.sentinel
@@ -23,6 +23,7 @@ _modules = {
 							"to_port":           65535,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -106,6 +107,7 @@ _modules = {
 							"to_port":           65535,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -191,6 +193,7 @@ _modules = {
 							"to_port":           22,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -287,6 +290,7 @@ _modules = {
 							"to_port":           443,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,
@@ -384,6 +388,7 @@ _modules = {
 							"to_port":           80,
 							"type":              "ingress",
 						},
+						"destroy": false,
 						"diff": {
 							"cidr_blocks.#": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-fail-0.11.sentinel
@@ -20,6 +20,7 @@ _modules = {
 							"name":                        "web_config",
 							"root_block_device":           "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"associate_public_ip_address": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-fail-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"vpc_classic_link_id":              null,
 							"vpc_classic_link_security_groups": null,
 						},
+						"destroy": false,
 						"diff": {
 							"associate_public_ip_address": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-pass-0.11.sentinel
@@ -20,6 +20,7 @@ _modules = {
 							"name":                        "web_config",
 							"root_block_device":           "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"associate_public_ip_address": {
 								"computed": false,

--- a/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-launch-configuration-instance-type/mock-tfplan-pass-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"vpc_classic_link_id":              null,
 							"vpc_classic_link_security_groups": null,
 						},
+						"destroy": false,
 						"diff": {
 							"associate_public_ip_address": {
 								"computed": false,

--- a/governance/second-generation/azure/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/azure/enforce-mandatory-tags.sentinel
@@ -56,8 +56,9 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/mocks/app-service-mock-tfplan.sentinel
+++ b/governance/second-generation/azure/mocks/app-service-mock-tfplan.sentinel
@@ -14,6 +14,7 @@ _modules = {
 							"name":     "palace-arcade-containerapp-demo",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": false,
@@ -144,6 +145,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_plan_id": {
 								"computed": false,
@@ -568,6 +570,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_environment_id": {
 								"computed": false,

--- a/governance/second-generation/azure/mocks/network-and-vms-mock-tfplan.sentinel
+++ b/governance/second-generation/azure/mocks/network-and-vms-mock-tfplan.sentinel
@@ -38,6 +38,7 @@ _modules = {
 							"tags":                 {},
 							"virtual_machine_id":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -177,6 +178,7 @@ _modules = {
 							"name":     "azurevmdemo-resources",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -213,6 +215,7 @@ _modules = {
 							"resource_group_name":  "azurevmdemo-resources",
 							"virtual_network_name": "azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -301,6 +304,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -532,6 +536,7 @@ _modules = {
 							},
 							"vm_size": "Standard_DS1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -726,6 +731,7 @@ _modules = {
 							"subnet":              "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags":                {},
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/restrict-app-service-to-https.sentinel
+++ b/governance/second-generation/azure/restrict-app-service-to-https.sentinel
@@ -53,8 +53,9 @@ validate_attribute_has_value = func(type, attribute, value) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/restrict-vm-size.sentinel
+++ b/governance/second-generation/azure/restrict-vm-size.sentinel
@@ -52,8 +52,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-fail-0.11.sentinel
@@ -38,6 +38,7 @@ _modules = {
 							"tags":                 {},
 							"virtual_machine_id":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -177,6 +178,7 @@ _modules = {
 							"name":     "azurevmdemo-resources",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -213,6 +215,7 @@ _modules = {
 							"resource_group_name":  "azurevmdemo-resources",
 							"virtual_network_name": "azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -301,6 +304,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -532,6 +536,7 @@ _modules = {
 							},
 							"vm_size": "Standard_DS1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -726,6 +731,7 @@ _modules = {
 							"subnet":              "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags":                {},
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-fail-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"network_security_group_id": null,
 							"resource_group_name":       "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -128,6 +129,7 @@ _modules = {
 							"location": "eastus",
 							"name":     "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -166,6 +168,7 @@ _modules = {
 							"service_endpoints":         null,
 							"virtual_network_name":      "roger-azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -274,6 +277,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -505,6 +509,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -698,6 +703,7 @@ _modules = {
 							"name":                 "roger-azurevmdemo-network",
 							"resource_group_name":  "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-pass-0.11.sentinel
@@ -38,6 +38,7 @@ _modules = {
 							"tags":                 {},
 							"virtual_machine_id":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -177,6 +178,7 @@ _modules = {
 							"name":     "azurevmdemo-resources",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -213,6 +215,7 @@ _modules = {
 							"resource_group_name":  "azurevmdemo-resources",
 							"virtual_network_name": "azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -301,6 +304,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -532,6 +536,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -726,6 +731,7 @@ _modules = {
 							"subnet":              "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags":                {},
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/azure/test/enforce-mandatory-tags/mock-tfplan-pass-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"network_security_group_id": null,
 							"resource_group_name":       "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -128,6 +129,7 @@ _modules = {
 							"location": "eastus",
 							"name":     "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -166,6 +168,7 @@ _modules = {
 							"service_endpoints":         null,
 							"virtual_network_name":      "roger-azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -274,6 +277,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -505,6 +509,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -698,6 +703,7 @@ _modules = {
 							"name":                 "roger-azurevmdemo-network",
 							"resource_group_name":  "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-app-service-to-https/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/azure/test/restrict-app-service-to-https/mock-tfplan-fail-0.12.sentinel
@@ -14,6 +14,7 @@ _modules = {
 							"name":     "palace-arcade-containerapp-demo",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": false,
@@ -144,6 +145,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_plan_id": {
 								"computed": false,
@@ -568,6 +570,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_environment_id": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-app-service-to-https/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/azure/test/restrict-app-service-to-https/mock-tfplan-pass-0.12.sentinel
@@ -14,6 +14,7 @@ _modules = {
 							"name":     "palace-arcade-containerapp-demo",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": false,
@@ -144,6 +145,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_plan_id": {
 								"computed": false,
@@ -568,6 +570,7 @@ _modules = {
 							],
 							"tags": {},
 						},
+						"destroy": false,
 						"diff": {
 							"app_service_environment_id": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-fail-0.11.sentinel
@@ -38,6 +38,7 @@ _modules = {
 							"tags":                 {},
 							"virtual_machine_id":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -177,6 +178,7 @@ _modules = {
 							"name":     "azurevmdemo-resources",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -213,6 +215,7 @@ _modules = {
 							"resource_group_name":  "azurevmdemo-resources",
 							"virtual_network_name": "azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -301,6 +304,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -532,6 +536,7 @@ _modules = {
 							},
 							"vm_size": "Standard_DS1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -726,6 +731,7 @@ _modules = {
 							"subnet":              "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags":                {},
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-fail-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"network_security_group_id": null,
 							"resource_group_name":       "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -128,6 +129,7 @@ _modules = {
 							"location": "eastus",
 							"name":     "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -166,6 +168,7 @@ _modules = {
 							"service_endpoints":         null,
 							"virtual_network_name":      "roger-azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -274,6 +277,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -505,6 +509,7 @@ _modules = {
 							"vm_size": "Basic_A0",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -698,6 +703,7 @@ _modules = {
 							"name":                 "roger-azurevmdemo-network",
 							"resource_group_name":  "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-pass-0.11.sentinel
@@ -38,6 +38,7 @@ _modules = {
 							"tags":                 {},
 							"virtual_machine_id":   "74D93920-ED26-11E3-AC10-0800200C9A66",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -177,6 +178,7 @@ _modules = {
 							"name":     "azurevmdemo-resources",
 							"tags":     {},
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -213,6 +215,7 @@ _modules = {
 							"resource_group_name":  "azurevmdemo-resources",
 							"virtual_network_name": "azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -301,6 +304,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -532,6 +536,7 @@ _modules = {
 							},
 							"vm_size": "Standard_D1_v2",
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -726,6 +731,7 @@ _modules = {
 							"subnet":              "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"tags":                {},
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/azure/test/restrict-vm-size/mock-tfplan-pass-0.12.sentinel
@@ -26,6 +26,7 @@ _modules = {
 							"network_security_group_id": null,
 							"resource_group_name":       "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"applied_dns_servers.#": {
 								"computed": true,
@@ -128,6 +129,7 @@ _modules = {
 							"location": "eastus",
 							"name":     "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"id": {
 								"computed": true,
@@ -166,6 +168,7 @@ _modules = {
 							"service_endpoints":         null,
 							"virtual_network_name":      "roger-azurevmdemo-network",
 						},
+						"destroy": false,
 						"diff": {
 							"address_prefix": {
 								"computed": false,
@@ -274,6 +277,7 @@ _modules = {
 							"vm_size": "Standard_A1",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -505,6 +509,7 @@ _modules = {
 							"vm_size": "Standard_A1",
 							"zones":   null,
 						},
+						"destroy": false,
 						"diff": {
 							"availability_set_id": {
 								"computed": true,
@@ -698,6 +703,7 @@ _modules = {
 							"name":                 "roger-azurevmdemo-network",
 							"resource_group_name":  "roger-azurevmdemo-resources",
 						},
+						"destroy": false,
 						"diff": {
 							"address_space.#": {
 								"computed": false,

--- a/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
@@ -10,8 +10,9 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
@@ -11,8 +11,9 @@ validate_attribute_greater_than_value = func(type, attribute, min_value) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_has_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_has_value.sentinel
@@ -11,8 +11,9 @@ validate_attribute_has_value = func(type, attribute, value) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_in_list.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_in_list.sentinel
@@ -11,8 +11,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
@@ -11,8 +11,9 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_matches_expression.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_matches_expression.sentinel
@@ -11,8 +11,9 @@ validate_attribute_matches_expression = func(type, attribute, expression) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -56,8 +56,9 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/gcp/mocks/gce-instance-mock-tfplan.sentinel
+++ b/governance/second-generation/gcp/mocks/gce-instance-mock-tfplan.sentinel
@@ -72,6 +72,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -361,6 +362,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
@@ -52,8 +52,9 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-fail-0.11.sentinel
@@ -71,6 +71,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -354,6 +355,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-fail-0.12.sentinel
@@ -66,6 +66,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -312,6 +313,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-pass-0.11.sentinel
@@ -72,6 +72,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -361,6 +362,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/gcp/test/enforce-mandatory-labels/mock-tfplan-pass-0.12.sentinel
@@ -67,6 +67,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -319,6 +320,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-fail-0.11.sentinel
@@ -66,6 +66,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -330,6 +331,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-fail-0.12.sentinel
@@ -66,6 +66,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -312,6 +313,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-pass-0.11.sentinel
@@ -66,6 +66,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -330,6 +331,7 @@ _modules = {
 							"tags_fingerprint": "74D93920-ED26-11E3-AC10-0800200C9A66",
 							"zone":             "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/gcp/test/restrict-gce-machine-type/mock-tfplan-pass-0.12.sentinel
@@ -67,6 +67,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,
@@ -319,6 +320,7 @@ _modules = {
 							"timeouts": null,
 							"zone":     "us-east1-b",
 						},
+						"destroy": false,
 						"diff": {
 							"allow_stopping_for_update": {
 								"computed": false,

--- a/governance/second-generation/vmware/mocks/vsphere-test-mock-tfplan.sentinel
+++ b/governance/second-generation/vmware/mocks/vsphere-test-mock-tfplan.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -52,8 +52,9 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
   for resource_instances as address, r {
 
     # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
@@ -51,8 +51,9 @@ validate_disk_size = func(disk_limit) {
   for resource_instances as address, r {
 
     # Skip resources that are being destroyed
-    # to avoid unnecessary policy violations
-    if length(r.diff) == 0 {
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-0.11.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-and-memory-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-and-memory-0.11.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-and-memory-0.12.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-cpu-and-memory-0.12.sentinel
@@ -91,6 +91,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-memory-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-fail-memory-0.11.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-pass-0.11.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-cpu-and-memory/mock-tfplan-pass-0.12.sentinel
@@ -91,6 +91,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-fail-0.11.sentinel
@@ -111,6 +111,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-fail-0.12.sentinel
@@ -91,6 +91,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-pass-0.11.sentinel
@@ -90,6 +90,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,

--- a/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/vmware/test/restrict-vm-disk-size/mock-tfplan-pass-0.12.sentinel
@@ -91,6 +91,7 @@ _modules = {
 							"wait_for_guest_net_routable":             false,
 							"wait_for_guest_net_timeout":              "0",
 						},
+						"destroy": false,
 						"diff": {
 							"boot_retry_delay": {
 								"computed": false,


### PR DESCRIPTION
Learned that previously used check `if length(r.diff) == 0` did not work for Terraform 0.12.
Sentinel team added new destroy value on resources in Sentinel.
Now using that value with `if r.destroy` in policies.

New logic works in both Terraform 0.11 and 0.12.

Also added `"destroy": false,` to all mocks and test cases so that simulator will still work.