### PR TITLE
fix VMware policies for Terraform 0.12 and PTFE

### DIFF
--- a/governance/second-generation/README.md
+++ b/governance/second-generation/README.md
@@ -2,6 +2,24 @@
 
 This directory and its sub-directories contain second-generation Sentinel policies which were created in 2019 for several clouds including AWS, Microsoft Azure, Google Cloud Platform (GCP), and VMware. It also contains some common, re-usable functions and mocks that can be used to test the new policies with the [Sentinel Simulator](https://docs.hashicorp.com/sentinel/commands).
 
+These policies are intended for use with Terraform 0.11.x and 0.12.x.
+
+## Note about Using with Private Terraform Enterprise (PTFE)
+The portion of these policies that test whether resources are being destroyed use a new [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) value that is present in Terraform Cloud (https://app.terraform.io) since 8/15/2019 but is not yet available in Private Terraform Enterprise (PTFE).
+
+If you use these policies with PTFE and are using Terraform 0.11.x in your workspaces, please simply comment out portions of the policies that look like this:
+```
+if r.destroy {
+  print("Skipping resource", address, "that is being destroyed.")
+  continue
+}
+```
+
+However, if you are using Terraform 0.12.x in your PTFE workspaces, you actually do need to check whether each resource is being destroyed since the `applied` value will be missing for those.  Until the destroy value is added to PTFE (currently expected in October, 2019), what you can do is test something like `length(r.diff.<attribute>.new) == 0` where `<attribute>` would be a specific top-level attribute of the resource that would generally have some value unless the resource is being destroyed.
+
+You could also use the latter approach with Terraform 0.11 if you do want to prevent Sentinel policies from being applied to destroyed resources on your PTFE servers.
+
+
 ## Improvements
 These new second-generation policies have several improvements over the older first-generation policies:
 1. They use some common parameterized functions including [find_resources_from_plan(type)](./common-functions/plan/find_resources_from_plan.md) and [validate_attribute_in_list(type, attribute, allowed_values)](./common-functions/plan/validate_attribute_in_list.md), which can be used unchanged in all policies that use the associated import. Using these reduces the amount of changes needed when writing new policies.

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -54,9 +54,24 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
-      print("Skipping resource", address, "that is being destroyed.")
-      continue
+    #if r.destroy {
+    #  print("Skipping resource", address, "that is being destroyed.")
+    #  continue
+    #}
+
+    # Skip resource instances that are being destroyed
+    # to avoid unnecessary policy violations.
+    # We are using the following until r.destroy is added to PTFE
+    if tfplan.terraform_version matches "^0\\.11\\.\\d+$" {
+      if length(r.diff) == 0 {
+      	print("Skipping resource", address, "that is being destroyed.")
+      	continue
+    	}
+    } else if tfplan.terraform_version matches "^0\\.12\\.\\d+$" {
+      if length(r.diff.memory.new) == 0 {
+      	print("Skipping resource", address, "that is being destroyed.")
+      	continue
+    	}
     }
 
     # Determine if the attribute is computed
@@ -68,7 +83,7 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
       # validated = false
     } else {
       # Validate that the attribute exists
-      if length(r.applied[attribute]) else 0 > 0 {
+      if length(string(r.applied[attribute])) else 0 > 0 {
         # Validate that each instance has desired value
         if float(r.applied[attribute]) > max_value {
           print("Resource", address, "has attribute", attribute, "with value",

--- a/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
@@ -53,9 +53,24 @@ validate_disk_size = func(disk_limit) {
     # Skip resources that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
-      print("Skipping resource", address, "that is being destroyed.")
-      continue
+    #if r.destroy {
+    #  print("Skipping resource", address, "that is being destroyed.")
+    #  continue
+    #}
+
+    # Skip resources that are being destroyed
+    # to avoid unnecessary policy violations.
+    # We are using the following until r.destroy is added to PTFE
+    if tfplan.terraform_version matches "^0\\.11\\.\\d+$" {
+      if length(r.diff) == 0 {
+      	print("Skipping resource", address, "that is being destroyed.")
+      	continue
+    	}
+    } else if tfplan.terraform_version matches "^0\\.12\\.\\d+$" {
+      if r.diff["disk.#"].new == "" {
+      	print("Skipping resource", address, "that is being destroyed.")
+      	continue
+    	}
     }
 
     # Initialize disk_count


### PR DESCRIPTION
Fixed VMware policies to better handle Terraform 0.12 and nuances between Terraform 0.11 and 0.12.
Also added note to second-generation README.md warning that r.destroy is not yet available for PTFE and suggesting workarounds.