### PR TITLE
updated for terraform 0.12

### DIFF
--- a/infrastructure-as-code/aws-ec2-instance/main.tf
+++ b/infrastructure-as-code/aws-ec2-instance/main.tf
@@ -1,17 +1,33 @@
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12"
 }
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-disco-19.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
 }
 
 resource "aws_instance" "ubuntu" {
-  ami           = "${var.ami_id}"
-  instance_type = "${var.instance_type}"
+  ami               = "${data.aws_ami.ubuntu.id}"
+  instance_type     = var.instance_type
   availability_zone = "${var.aws_region}a"
 
-  tags {
-    Name = "${var.name}"
+  tags = {
+    Name = var.name
   }
 }

--- a/infrastructure-as-code/aws-ec2-instance/outputs.tf
+++ b/infrastructure-as-code/aws-ec2-instance/outputs.tf
@@ -1,3 +1,4 @@
 output "public_dns" {
-  value = "${aws_instance.ubuntu.public_dns}"
+  value = aws_instance.ubuntu.public_dns
 }
+

--- a/infrastructure-as-code/aws-ec2-instance/variables.tf
+++ b/infrastructure-as-code/aws-ec2-instance/variables.tf
@@ -1,19 +1,15 @@
 variable "aws_region" {
   description = "AWS region"
-  default = "us-west-1"
-}
-
-variable "ami_id" {
-  description = "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image"
-  default = "ami-2e1ef954"
+  default     = "us-west-1"
 }
 
 variable "instance_type" {
   description = "type of EC2 instance to provision."
-  default = "t2.micro"
+  default     = "t2.micro"
 }
 
 variable "name" {
   description = "name to pass to Name tag"
-  default = "Provisioned by Terraform"
+  default     = "Provisioned by Terraform"
 }
+


### PR DESCRIPTION
aws-ec2-instance updated for terraform 0.12
ami id gathered from data source instead of being hard coded.