### PR TITLE
note on PTFE v201909-1 and destroy

### DIFF
--- a/governance/second-generation/README.md
+++ b/governance/second-generation/README.md
@@ -4,21 +4,8 @@ This directory and its sub-directories contain second-generation Sentinel polici
 
 These policies are intended for use with Terraform 0.11.x and 0.12.x.
 
-## Note about Using with Private Terraform Enterprise (PTFE)
-The portion of these policies that test whether resources are being destroyed use a new [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) value that is present in Terraform Cloud (https://app.terraform.io) since 8/15/2019 but is not yet available in Private Terraform Enterprise (PTFE).
-
-If you use these policies with PTFE and are using Terraform 0.11.x in your workspaces, please simply comment out portions of the policies that look like this:
-```
-if r.destroy {
-  print("Skipping resource", address, "that is being destroyed.")
-  continue
-}
-```
-
-However, if you are using Terraform 0.12.x in your PTFE workspaces, you actually do need to check whether each resource is being destroyed since the `applied` value will be missing for those.  Until the destroy value is added to PTFE (currently expected in October, 2019), what you can do is test something like `length(r.diff.<attribute>.new) == 0` where `<attribute>` would be a specific top-level attribute of the resource that would generally have some value unless the resource is being destroyed.
-
-You could also use the latter approach with Terraform 0.11 if you do want to prevent Sentinel policies from being applied to destroyed resources on your PTFE servers.
-
+## Note about Using These Policies with Terraform Enterprise
+These policies test whether resources are being destroyed using the [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) value that was added to Terraform Cloud (https://app.terraform.io) on 8/15/2019 and to Terraform Enterprise (formerly known as PTFE) in the v201909-1 release on 9/13/2019. Please upgrade to that release or higher before using these policies on your Terraform Enterprise server. (If you are not currently able to upgrade your TFE server, see an older version of this document for a workaround that allows you to use these policies on older versions of TFE.)
 
 ## Improvements
 These new second-generation policies have several improvements over the older first-generation policies:


### PR DESCRIPTION
I updated the README.md under governance/second-generation to revise note about using the policies with TFE (PTFE) since the new v201909-1 PTFE release which has added the tfstate resouce.destroy value that can test if a resource is being destroyed.  Previously, I had a note that warned that code like r.destroy could not be used in PTFE and suggested a workaround.  However, now I advise customers upgrade to the PTFE v201909-1 release so that they can use the current second-generation policies in this repository.