### PR TITLE
make find_resources_from_state handle no modules

### DIFF
--- a/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
+++ b/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
@@ -15,7 +15,7 @@ find_resources_from_state = func(type) {
   resources = {}
 
   # Iterate over all modules in the tfstate import
-  for tfstate.module_paths as path {
+  for tfstate.module_paths else [] as path {
     # Iterate over the named resources of desired type in the module
     for tfstate.module(path).resources[type] else {} as name, instances {
       # Iterate over resource instances

--- a/governance/second-generation/common-functions/state/find_resources_from_state.sentinel
+++ b/governance/second-generation/common-functions/state/find_resources_from_state.sentinel
@@ -4,7 +4,7 @@ find_resources_from_state = func(type) {
   resources = {}
 
   # Iterate over all modules in the tfstate import
-  for tfstate.module_paths as path {
+  for tfstate.module_paths else [] as path {
     # Iterate over the named resources of desired type in the module
     for tfstate.module(path).resources[type] else {} as name, instances {
       # Iterate over resource instances


### PR DESCRIPTION
I realized today that state for an existing workspace could have no modules.  In particular, this is true after running a `terraform destroy` against the workspace.  This caused the find_resources_from_state() function to give a hard error since tfstate.module_paths was undefined.  I have fixed that in both the function itself and in the copy of it used in the restrict-publishers-of-current-vms.sentinel by adding `else []` so that the code now reads:
```
for tfstate.module_paths else [] as path {
```