### PR TITLE
add r.requires_new

### DIFF
--- a/governance/second-generation/README.md
+++ b/governance/second-generation/README.md
@@ -5,7 +5,7 @@ This directory and its sub-directories contain second-generation Sentinel polici
 These policies are intended for use with Terraform 0.11.x and 0.12.x.
 
 ## Note about Using These Policies with Terraform Enterprise
-These policies test whether resources are being destroyed using the [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) value that was added to Terraform Cloud (https://app.terraform.io) on 8/15/2019 and to Terraform Enterprise (formerly known as PTFE) in the v201909-1 release on 9/13/2019. Please upgrade to that release or higher before using these policies on your Terraform Enterprise server. (If you are not currently able to upgrade your TFE server, see an older version of this document for a workaround that allows you to use these policies on older versions of TFE.)
+These policies test whether resources are being destroyed using the [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) and [requires_new](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-requires_new) values that were added to Terraform Cloud (https://app.terraform.io) on 8/15/2019 and to Terraform Enterprise (formerly known as PTFE) in the v201909-1 release on 9/13/2019. Please upgrade to that release or higher before using these policies on your Terraform Enterprise server. (If you are not currently able to upgrade your TFE server, see an older version of this document for a workaround that allows you to use these policies on older versions of TFE.)
 
 ## Improvements
 These new second-generation policies have several improvements over the older first-generation policies:
@@ -13,7 +13,7 @@ These new second-generation policies have several improvements over the older fi
 1. They have been written in a way that causes all violations or all rules to be reported. Older policies typically only reported the first violation of the first rule that had one. This is accomplished by offloading all of the processing from rules to functions.
 1. They print out the full address of each resource instance that does violate a rule in the same format that is used in plan and apply logs, namely `module.<A>.module.<B>.<type>.<name>[<index>]`.
 1. They are designed to make Sentinel's default output less verbose. Users looking at Sentinel policy violations that occur during their runs will get all the information they need from the messages explicitly printed from the policies using Sentinel's `print` function.
-1. They skip resources that are being destroyed since policy violations for them are not usually of interest.
+1. They skip resources that are being destroyed but not re-created since policy violations for them are not usually of interest. It is important to check the condition `r.destroy and not r.requires_new` rather than `r.destroy` by itself to avoid skipping resources that are being temporarily destroyed and then re-created. Terraform does this when changing certain attributes cannot be done for an existing resource. 
 1. They test whether resource attributes are computed to avoid errors. Note that the validation functions can be modified to consider computed values of specific attributes to be violations.
 
 ## Common Functions

--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -57,7 +57,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -59,7 +59,7 @@ validate_private_acl_and_kms_encryption = func() {
     # Skip resources that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-availability-zones.sentinel
+++ b/governance/second-generation/aws/restrict-availability-zones.sentinel
@@ -55,7 +55,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-db-instance-engines.sentinel
+++ b/governance/second-generation/aws/restrict-db-instance-engines.sentinel
@@ -54,7 +54,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
@@ -54,7 +54,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -55,7 +55,7 @@ validate_sgr_cidr_blocks = func() {
     # Skip resources that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
@@ -61,7 +61,7 @@ validate_instance_types = func(allowed_types) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/azure/enforce-mandatory-tags.sentinel
@@ -58,7 +58,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/restrict-app-service-to-https.sentinel
+++ b/governance/second-generation/azure/restrict-app-service-to-https.sentinel
@@ -55,7 +55,7 @@ validate_attribute_has_value = func(type, attribute, value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/azure/restrict-vm-size.sentinel
+++ b/governance/second-generation/azure/restrict-vm-size.sentinel
@@ -54,7 +54,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
@@ -12,7 +12,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
@@ -13,7 +13,7 @@ validate_attribute_greater_than_value = func(type, attribute, min_value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_has_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_has_value.sentinel
@@ -13,7 +13,7 @@ validate_attribute_has_value = func(type, attribute, value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_in_list.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_in_list.sentinel
@@ -13,7 +13,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
@@ -13,7 +13,7 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/common-functions/plan/validate_attribute_matches_expression.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_matches_expression.sentinel
@@ -13,7 +13,7 @@ validate_attribute_matches_expression = func(type, attribute, expression) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -58,7 +58,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
@@ -54,7 +54,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy {
+    if r.destroy and not r.requires_new {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -54,24 +54,9 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
     # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    #if r.destroy {
-    #  print("Skipping resource", address, "that is being destroyed.")
-    #  continue
-    #}
-
-    # Skip resource instances that are being destroyed
-    # to avoid unnecessary policy violations.
-    # We are using the following until r.destroy is added to PTFE
-    if tfplan.terraform_version matches "^0\\.11\\.\\d+$" {
-      if length(r.diff) == 0 {
-      	print("Skipping resource", address, "that is being destroyed.")
-      	continue
-    	}
-    } else if tfplan.terraform_version matches "^0\\.12\\.\\d+$" {
-      if length(r.diff.memory.new) == 0 {
-      	print("Skipping resource", address, "that is being destroyed.")
-      	continue
-    	}
+    if r.destroy and not r.requires_new {
+      print("Skipping resource", address, "that is being destroyed.")
+      continue
     }
 
     # Determine if the attribute is computed

--- a/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
@@ -50,27 +50,12 @@ validate_disk_size = func(disk_limit) {
   # Loop through the resource instances
   for resource_instances as address, r {
 
-    # Skip resources that are being destroyed
+    # Skip resource instances that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    #if r.destroy {
-    #  print("Skipping resource", address, "that is being destroyed.")
-    #  continue
-    #}
-
-    # Skip resources that are being destroyed
-    # to avoid unnecessary policy violations.
-    # We are using the following until r.destroy is added to PTFE
-    if tfplan.terraform_version matches "^0\\.11\\.\\d+$" {
-      if length(r.diff) == 0 {
-      	print("Skipping resource", address, "that is being destroyed.")
-      	continue
-    	}
-    } else if tfplan.terraform_version matches "^0\\.12\\.\\d+$" {
-      if r.diff["disk.#"].new == "" {
-      	print("Skipping resource", address, "that is being destroyed.")
-      	continue
-    	}
+    if r.destroy and not r.requires_new {
+      print("Skipping resource", address, "that is being destroyed.")
+      continue
     }
 
     # Initialize disk_count


### PR DESCRIPTION
I had to change the condition that tests whether resources are being destroyed from `r.destroy` to `r.destroy and not r.requires_new` since `r.destroy` will be true when a resource is being temporarily destroyed and then re-created.  This happens when Terraform (actually the technology behind the provider) cannot modify certain attributes of an existing resource.  We don't want to skip these resources. We only want to skip the ones that are really being destroyed.

I updated all policies and functions that had the test that checked for resource destruction.

I also updated the second-generation README.md to explicitly refer to the improved condition.