### PR TITLE
compare null to null

### DIFF
--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -75,7 +75,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     } else {
       # Validate that the attribute is a list or a map
       # but first check if r.applied[attribute] exists
-      if r.applied[attribute] else "" is not "" and
+      if r.applied[attribute] else null is not null and
          (types.type_of(r.applied[attribute]) is "list" or
           types.type_of(r.applied[attribute]) is "map") {
 

--- a/governance/second-generation/azure/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/azure/enforce-mandatory-tags.sentinel
@@ -80,10 +80,10 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     # Sentinel will show tags = {} for Terraform 0.11 but
     # It will not have tags at all for Terraform 0.12
     # So, we do the following check even when tags.% is computed
-    
+
     # Validate that the attribute is a list or a map
     # but first check if r.applied[attribute] exists
-    if r.applied[attribute] else "" is not "" and
+    if r.applied[attribute] else null is not null and
        (types.type_of(r.applied[attribute]) is "list" or
         types.type_of(r.applied[attribute]) is "map") {
 

--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -76,7 +76,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
     } else {
       # Validate that the attribute is a list or a map
       # but first check if r.applied[attribute] exists
-      if r.applied[attribute] else "" is not "" and
+      if r.applied[attribute] else null is not null and
          (types.type_of(r.applied[attribute]) is "list" or
           types.type_of(r.applied[attribute]) is "map") {
 


### PR DESCRIPTION
So, while my revised tags/labels policies for AWS, Azure, and GCP all work and pass all their test cases, while helping another SE with a much simpler policy, I determined that the attempt to convert `null` to `""` with the `else` operator was not working.  This was done in the test `r.applied[attribute] else "" is not ""`.  While the `else` operator converts `undefined` to the thing on its right, it does not convert `null`.

In my case, since I also had the condition `(types.type_of(r.applied[attribute]) is "list" or types.type_of(r.applied[attribute]) is "map")`, it did not matter that `null` was not converted to `""` since this additional test failed since `null` is neither a map nor a list.

But I don't want people to look at the code and think that they can convert `null` to something else with the `else` operator.

So, a better test to use is `r.applied[attribute] else null is not null`.  In this case if `r.applied[attribute]` is `undefined` as will be the case for Terraform 0.11 when the attribute (e.g., tags) is missing, it will be converted to `null` and the test will become `null is not null` which is `false` as desired.  On the other hand, for Terraform 0.12, when the attribute is missing, `r.applied[attribute]` will be `null`, and `r.applied[attribute] else null` will also be `null` so that the total expression again becomes `null is not null` which is again `false`.