### PR TITLE
better tests for null

### DIFF
--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -74,7 +74,7 @@ validate_sgr_cidr_blocks = func() {
       # We check that it is present and really a list
       # before checking whether it contains "0.0.0.0/0"
       if r.applied.type is "ingress" and
-         length(r.applied.cidr_blocks) else 0 > 0 and
+         r.applied.cidr_blocks else null is not null and
          types.type_of(r.applied.cidr_blocks) is "list" and
          r.applied.cidr_blocks contains "0.0.0.0/0" {
         print("Security group rule", address, "of type ingress",

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-kms-no-ssec-0.12.json
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-kms-no-ssec-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-fail-kms-no-ssec-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-kms-no-ssec-0.12.sentinel
+++ b/governance/second-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-fail-kms-no-ssec-0.12.sentinel
@@ -1,0 +1,203 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_s3_bucket": {
+				"bucket": {
+					0: {
+						"applied": {
+							"acl":                                  "private",
+							"bucket":                               "roger-012-test",
+							"bucket_prefix":                        null,
+							"cors_rule":                            [],
+							"force_destroy":                        false,
+							"lifecycle_rule":                       [],
+							"logging":                              [],
+							"object_lock_configuration":            [],
+							"policy":                               null,
+							"replication_configuration":            [],
+							"server_side_encryption_configuration": [],
+							"tags": {
+								"Owner": "roger@hashicorp.com",
+								"name":  "Roger Test Bucket",
+							},
+							"website": [],
+						},
+						"destroy": false,
+						"diff": {
+							"acceleration_status": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"acl": {
+								"computed": false,
+								"new":      "private",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"bucket": {
+								"computed": false,
+								"new":      "roger-012-test",
+								"old":      "",
+							},
+							"bucket_domain_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"bucket_prefix": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"bucket_regional_domain_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cors_rule.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"force_destroy": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"hosted_zone_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"lifecycle_rule.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"logging.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"object_lock_configuration.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"policy": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"region": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"replication_configuration.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"request_payer": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"server_side_encryption_configuration.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Owner": {
+								"computed": false,
+								"new":      "roger@hashicorp.com",
+								"old":      "",
+							},
+							"tags.name": {
+								"computed": false,
+								"new":      "Roger Test Bucket",
+								"old":      "",
+							},
+							"versioning.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"website.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"website_domain": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"website_endpoint": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.7"
+
+variables = {
+	"aws_region":  "us-east-1",
+	"bucket_acl":  "private",
+	"bucket_name": "roger-012-test",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-no-cidr-blocks-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-no-cidr-blocks-0.12.sentinel
@@ -1,0 +1,123 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_security_group_rule": {
+				"allow_all": {
+					0: {
+						"applied": {
+							"cidr_blocks":       null,
+							"description":       null,
+							"from_port":         0,
+							"ipv6_cidr_blocks":  null,
+							"prefix_list_ids":   null,
+							"protocol":          "tcp",
+							"security_group_id": "sg-008b502d0a24d0136",
+							"self":              true,
+							"to_port":           65535,
+							"type":              "ingress",
+						},
+						"destroy": false,
+						"diff": {
+							"cidr_blocks": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"from_port": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_blocks": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"prefix_list_ids": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"security_group_id": {
+								"computed": false,
+								"new":      "sg-008b502d0a24d0136",
+								"old":      "",
+							},
+							"self": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"source_security_group_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"to_port": {
+								"computed": false,
+								"new":      "65535",
+								"old":      "",
+							},
+							"type": {
+								"computed": false,
+								"new":      "ingress",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.9"
+
+variables = {}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/pass-no-cidr-blocks-0.12.json
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/pass-no-cidr-blocks-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-pass-no-cidr-blocks-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_contains_list.sentinel
@@ -29,7 +29,7 @@ validate_attribute_contains_list = func(type, attribute, required_values) {
       # validated = false
     } else {
       # Validate that the attribute is a list or a map
-      if length(r.applied[attribute]) else 0 > 0 and
+      if r.applied[attribute] else null is not null and
          (types.type_of(r.applied[attribute]) is "list" or
           types.type_of(r.applied[attribute]) is "map") {
 

--- a/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_greater_than_value.sentinel
@@ -27,7 +27,7 @@ validate_attribute_greater_than_value = func(type, attribute, min_value) {
       # validated = false
     } else {
       # Validate that the attribute exists
-      if length(r.applied[attribute]) else 0 > 0 {
+      if r.applied[attribute] else null is not null {
         # Validate that each instance has desired value
         if float(r.applied[attribute]) > min_value {
           print("Resource", address, "has attribute", attribute, "with value",

--- a/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
+++ b/governance/second-generation/common-functions/plan/validate_attribute_less_than_value.sentinel
@@ -27,7 +27,7 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
       # validated = false
     } else {
       # Validate that the attribute exists
-      if length(r.applied[attribute]) else 0 > 0 {
+      if r.applied[attribute] else null is not null {
         # Validate that each instance has desired value
         if float(r.applied[attribute]) > max_value {
           print("Resource", address, "has attribute", attribute, "with value",

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -68,7 +68,7 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
       # validated = false
     } else {
       # Validate that the attribute exists
-      if length(string(r.applied[attribute])) else 0 > 0 {
+      if r.applied[attribute] else null is not null {
         # Validate that each instance has desired value
         if float(r.applied[attribute]) > max_value {
           print("Resource", address, "has attribute", attribute, "with value",


### PR DESCRIPTION
After having improved tests for null in policies that test for tags/labels on VMs, I realized that I had neglected to do the same in three of the common functions.  So, I updated them to use the new test `r.applied[attribute] else null is not null`.  I also updated the restrict-vm-cpu-and-memory policy which uses the validate_attribute_less_than_value() function. Handling null cidr_blocks in aws_security_group_rules required a similar modification in the restrict-ingress-sg-rule-cidr-blocks policy.

Additionally, I added some additional test cases to check for the absence of server_side_encryption_configuration in aws_s3_buckets and for null cidr_blocks in aws_security_group_rules.  The first involved a new fail test case while the second involved a new pass test case.

