### PR TITLE
added cost estimate policies

### DIFF
--- a/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
@@ -1,0 +1,37 @@
+# This policy uses the Sentinel tfrun import to restrict the
+# proposed monthly cost that would be incurred if the current
+# plan were applied
+
+##### Imports #####
+
+import "tfrun"
+import "decimal"
+
+##### Functions #####
+
+# Validate that the proposed monthly cost is less than the limit
+limit_proposed_monthly_cost = func(limit) {
+
+  # Determine proposed monthly cost
+  proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+
+  # Compare proposed monthly cost to the limit
+  if proposed_cost.lte(limit) {
+    print("Proposed monthly cost", proposed_cost.string,
+          "is under the limit:", limit.string)
+    return true
+  } else {
+    print("Proposed monthly cost", proposed_cost.string,
+          "is over the limit:", limit.string)
+    return false
+  }
+}
+
+##### Monthly Limit #####
+limit = decimal.new(1000)
+
+##### Rules #####
+cost_validated = limit_proposed_monthly_cost(limit)
+main = rule {
+  cost_validated
+}

--- a/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
+++ b/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
@@ -1,0 +1,60 @@
+# This policy uses the Sentinel tfrun import to restrict the
+# both the total monthly cost and the percentage increase in
+# the monthly cost that would be incurred if the current plan
+# were applied
+
+##### Imports #####
+
+import "tfrun"
+import "decimal"
+
+##### Functions #####
+
+# Validate that the proposed cost is less than the given limit and
+# that the percentage increase in the monthly cost
+# is less than a given percentage
+restrict_cost_and_percentage_increase = func(limit, max_percent) {
+
+  validated = true
+
+  # Determine cost data
+  prior_cost = decimal.new(tfrun.cost_estimate.prior_monthly_cost)
+  proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+  increase_in_cost = decimal.new(tfrun.cost_estimate.delta_monthly_cost)
+
+  # Compare proposed monthly cost to the limit
+  if proposed_cost.gt(limit) {
+    print("Proposed monthly cost", proposed_cost.string,
+          "is over the limit:", limit.string)
+    validated = false
+  }
+
+  # If prior_cost is not 0.0, compare percentage increase in monthly cost
+  # to max_percent
+  if prior_cost.is_not(0.0) {
+    #print("We had a prior cost.")
+    percentage_change = increase_in_cost.divide(prior_cost).multiply(100)
+    #print("Percentage Change:", percentage_change.float)
+    if decimal.new(percentage_change).gt(max_percent) {
+      print("Proposed percentage increase", percentage_change.float,
+            "is over the max percentage change:", max_percent.float)
+      validated = false
+    } else {
+      print("Proposed percentage increase", percentage_change.float,
+            "is under the max percentage change:", max_percent.float)
+    }
+  }
+
+  return validated
+
+}
+
+##### Parameters #####
+limit = decimal.new(1000)
+max_percent = decimal.new(10.0)
+
+##### Rules #####
+cost_validated = restrict_cost_and_percentage_increase(limit, max_percent)
+main = rule {
+  cost_validated
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/fail-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/fail-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-fail-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "1211.10435",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "1211.10435",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-pass-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "341.19982",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "341.19982",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/pass-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/pass-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/fail-limit-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/fail-limit-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-limit-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/fail-percent-increase-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/fail-percent-increase-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-percent-increase-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-fail-limit-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-fail-limit-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "1211.10435",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "1211.10435",
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-fail-percent-increase-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-fail-percent-increase-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "43.05439",
+	"prior_monthly_cost":    "320.14543",
+	"proposed_monthly_cost": "363.19982",
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-pass-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "21.05439",
+	"prior_monthly_cost":    "320.14543",
+	"proposed_monthly_cost": "341.19982",
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/pass-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/pass-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}


### PR DESCRIPTION
I added two policies that restrict provisioning based on the new cost estimates made available by the tfrun import. 

The limit-proposed-monthly-cost policy requires the run's `tfrun.cost_estimate.proposed_monthly_cost` to be less than the provided `limit` parameter.

The restrict-cost-and-percentage-increase policy imposes the same limit on `proposed_monthly_cost` as the other policy, but also requires the percentage increase in the proposed cost to be less than a `max_percent` parameter, but only if the run includes a non-zero value for `tfrun.cost_estimate.prior_monthly_cost` is not 0.  This is because a percentage increase cannot be computed against an initial cost of 0.

These policies also show the use of the new decimal import which was added for the purpose of doing accurate numeric computations with cost estimates.