### PR TITLE
new for_each for resources example

### DIFF
--- a/infrastructure-as-code/terraform-0.12-examples/README.md
+++ b/infrastructure-as-code/terraform-0.12-examples/README.md
@@ -6,6 +6,7 @@ These examples have been tested with terraform 0.12.3.
 The examples are:
 1. [First Class Expressions](./first-class-expressions)
 1. [For Expressions](./for-expressions)
+1. [For_each for Resources](./for-each-for-resources)
 1. [Dynamic Blocks and Splat Expresions](./dynamic-blocks-and-splat-expressions)
 1. [Advanced Dynamic Blocks](./advanced-dynamic-blocks)
 1. [Rich Value Types](./rich-value-types)
@@ -44,6 +45,9 @@ See the example's [README.md](./first-class-expressions/README.md).
 
 ## For Expressions Example
 See the example's [README.md](./for-expressions/README.md).
+
+## For_each for Resources Example
+See the example's [README.md](./for-each-for-resources/README.md).
 
 ## Dynamic Blocks and Splat Expressions Example
 See the example's [README.md](./dynamic-blocks-and-splat-expressions/README.md).

--- a/infrastructure-as-code/terraform-0.12-examples/for-each-for-resources/README.md
+++ b/infrastructure-as-code/terraform-0.12-examples/for-each-for-resources/README.md
@@ -1,0 +1,48 @@
+# Resources that Use for_each Example
+The [For_each for Resources](./for-each-for-resources) example illustrates how the [for_each meta-argument](https://www.terraform.io/docs/configuration/resources.html#for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings) can be used instead of the `count` meta-argument to create multiple instances of a resource with different properties based on the contents of a map or set of strings.
+
+Note that the `for_each` meta-argument for resources was added in Terraform 0.12.6.
+
+The example illustrates `for_each` by creating an EC2 instance in all six availability zones of the AWS region us-east-1.
+
+We first define a variable of type map listing all six zones:
+```
+variable "zones" {
+  description = "AWS availability zones"
+  type = map
+  default = {
+    a = "us-east-1a"
+    b = "us-east-1b"
+    c = "us-east-1c"
+    d = "us-east-1d"
+    e = "us-east-1e"
+    f = "us-east-1f"
+  }
+}
+```
+
+We then use an aws_ami data source to find the most recent Ubuntu 16.04 AMI issued by Canonical in the us-east-1 region.
+
+The use of the `for_each` meta-argument actually occurs in the definition of the example's aws_instance resource:
+```
+resource "aws_instance" "ubuntu" {
+  for_each = var.zones
+  ami = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+  associate_public_ip_address = true
+  availability_zone = each.value
+
+  tags = {
+    Name = format("for-each-demo-zone-%s", each.key)
+  }
+
+}
+```
+Note that `for_each` in this case refers to the `zones` variable which defines the map of availability zones. We are then able to reference the keys and values of that map with `each.key` and `each.value` respectively. In particular, note the use of the values in `availability_zone = each.value` and the use of the keys in the `tags` map.
+
+Finally, we also use the [for](https://www.terraform.io/docs/configuration/expressions.html#for-expressions) expression in the `public_ips` output that gives the public IPs of all six EC2 instances in a list:
+```
+output "public_ips" {
+  value = [for r in aws_instance.ubuntu: r.public_ip]
+}
+```

--- a/infrastructure-as-code/terraform-0.12-examples/for-each-for-resources/main.tf
+++ b/infrastructure-as-code/terraform-0.12-examples/for-each-for-resources/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_version = ">= 0.12.6"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "zones" {
+  description = "AWS availability zones"
+  type = map
+  default = {
+    a = "us-east-1a"
+    b = "us-east-1b"
+    c = "us-east-1c"
+    d = "us-east-1d"
+    e = "us-east-1e"
+    f = "us-east-1f"
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent      = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "ubuntu" {
+  for_each = var.zones
+  ami = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+  associate_public_ip_address = true
+  availability_zone = each.value
+
+  tags = {
+    Name = format("for-each-demo-zone-%s", each.key)
+  }
+
+}
+
+output "public_ips" {
+  value = [for r in aws_instance.ubuntu: r.public_ip]
+}


### PR DESCRIPTION
This addes new example under the infrastructure-as-code/terraform-0.12-examples directory that shows how to use the new `for_each` meta-argument that was added to resources in 0.12.6. It allows multiple instances of a single resource to be created based off data in a map or set in a different way than the `count` meta-argument supports.