### PR TITLE
add limit-cost-by-workspace-type

### DIFF
--- a/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
@@ -1,0 +1,59 @@
+# This policy uses the Sentinel tfrun import to restrict the
+# proposed monthly cost that would be incurred if the current
+# plan were applied, using different limits for different
+# workspaces based on their names.
+
+##### Imports #####
+
+import "tfrun"
+import "decimal"
+
+##### Functions #####
+
+# Validate that the proposed monthly cost is less than the limit
+limit_cost_by_workspace_type = func(limits) {
+
+  # Get workspace name
+  workspace_name = tfrun.workspace.name
+
+  # Determine limit for current workspace
+  if workspace_name matches "(.*)-dev$" {
+    limit = limits["dev"]
+  } else if workspace_name matches "(.*)-qa$" {
+    limit = limits["qa"]
+  } else if workspace_name matches "(.*)-prod$" {
+    limit = limits["prod"]
+  } else {
+    limit = limits["other"]
+  }
+
+  # Determine proposed monthly cost
+  proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+
+  # Compare proposed monthly cost to the limit
+  if proposed_cost.lte(limit) {
+    print("Proposed monthly cost", proposed_cost.string,
+          "of workspace", workspace_name,
+          "is under the limit:", limit.string)
+    return true
+  } else {
+    print("Proposed monthly cost", proposed_cost.string,
+          "of workspace", workspace_name,
+          "is over the limit:", limit.string)
+    return false
+  }
+}
+
+##### Monthly Limits #####
+limits = {
+  "dev": decimal.new(200),
+  "qa": decimal.new(500),
+  "prod": decimal.new(1000),
+  "other": decimal.new(50),
+}
+
+##### Rules #####
+cost_validated = limit_cost_by_workspace_type(limits)
+main = rule {
+  cost_validated
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-dev-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-dev-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-dev-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-other-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-other-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-other-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-prod-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-prod-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-prod-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-qa-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/fail-qa-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-qa-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-dev-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-dev-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-dev",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "300.0000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "300.0000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-other-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-other-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "55.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "55.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-prod-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-prod-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-prod",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "1200.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "1200.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-qa-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-fail-qa-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-qa",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "524.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "524.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-dev-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-dev-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-dev",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "172.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "172.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-other-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-other-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "36.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "36.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-prod-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-prod-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-prod",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "950.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "950.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-qa-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-qa-0.12.sentinel
@@ -1,0 +1,21 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance-qa",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}
+
+cost_estimate = {
+	"delta_monthly_cost":    "480.00000",
+	"prior_monthly_cost":    "0.0",
+	"proposed_monthly_cost": "480.00000",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-dev-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-dev-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-dev-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-other-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-other-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-other-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-prod-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-prod-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-prod-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-qa-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-qa-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-qa-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}


### PR DESCRIPTION
Add new cost estimate policy that sets different limits for different workspaces based on the workspace names, doing regex matching for names ending in "-dev", "-qa", and "-prod".  If a workspace name does not match one of those, it gets a lower limit.