### PR TITLE
Add restrict assumed role policy

### DIFF
--- a/governance/second-generation/aws/restrict-assumed-role.sentinel
+++ b/governance/second-generation/aws/restrict-assumed-role.sentinel
@@ -1,0 +1,161 @@
+# This policy restricts accounts that can be assumed by the AWS provider
+# It assumes that the role_arn is either a hard-coded value or a reference
+# to a Terraform variable
+
+#### Imports #####
+import "tfconfig"
+import "tfplan"
+import "strings"
+
+##### Functions #####
+
+# Find all providers aliases of given type using the tfconfig import
+find_provider_aliases = func(type) {
+
+  # We will find all provider aliases og given type from tfconfig,
+  # meaning providers.TYPE.alias.ALIAS
+  providers = {}
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Iterate over providers of given type in module
+    aliases = tfconfig.module(path).providers[type]["alias"] else {}
+    for aliases as alias, data {
+        #print("alias:", alias)
+        # Change default alias ("") to "default"
+        if alias is "" {
+          #print("found default alias")
+          alias = "default"
+        }
+
+        # Get the address of the provider alias
+        if length(path) == 0 {
+          # root module
+          address =  type + "." + alias
+        } else {
+          # non-root module
+          address = "module." + strings.join(path, ".module.") + "." +
+                    type + "." + alias
+        }
+        #print("address:", address)
+
+        providers[address] = data
+
+    } // end aliases loop
+  } // end module_paths loop
+
+  return providers
+}
+
+
+# Determine role_arn of a provider from its data
+determine_role_arn = func(data) {
+
+  role_arn_value = ""
+
+  # Check for role_arn in config
+  if (length(data["config"]) else 0) > 0 and
+     (length(data["config"]["assume_role"]) else 0) > 0 {
+    config_assume_role = data["config"]["assume_role"]
+    #print ( "config_assume_role is: ", config_assume_role )
+    if config_assume_role[0]["role_arn"] else null is not null {
+      role_arn = config_assume_role[0]["role_arn"]
+      # This would only happen for Terraform 0.11 since a reference
+      # to a variable in Terraform 0.12 would end up in
+      # the references value
+      #print("role_arn in config:", role_arn)
+      if role_arn matches "\\$\\{var\\.(.*)\\}" {
+        # role_arn of AWS provider was a Terraform 0.11 style variable
+        #print ( "role_arn is a Terraform 0.11 style variable" )
+        role_arn_variable = strings.trim_suffix(strings.trim_prefix(role_arn, "${var."), "}")
+        #print ( "role_arn variable is: ", role_arn_variable )
+        #print ( "Value of role_arn is: ", tfplan.variables[role_arn_variable] )
+        role_arn_value = tfplan.variables[role_arn_variable]
+      } else {
+        # role_arn of AWS provider was hard-coded role_arn
+        #print ( "role_arn is a hard-coded value" )
+        #print ( "Value of role_arn is: ", role_arn )
+        role_arn_value = role_arn
+      } // end determination of role_arn type
+    } // end role_arn in config test
+  } // end config test
+
+  # Check for role_arn in references
+  if (length(data["references"]) else 0) > 0 and
+     (length(data["references"]["assume_role"]) else 0) > 0 {
+    references_assume_role = data["references"]["assume_role"]
+    #print ( "references_assume_role is: ", references_assume_role )
+    if references_assume_role[0]["role_arn"] else null is not null and
+       length(references_assume_role[0]["role_arn"]) > 0 {
+      role_arn = references_assume_role[0]["role_arn"][0]
+      #print("role_arn in references:", role_arn)
+      if role_arn matches "\\$\\{var\\.(.*)\\}" {
+        # role_arn of AWS provider was a Terraform 0.11 style variable
+        #print ( "role_arn is a Terraform 0.11 style variable" )
+        role_arn_variable = strings.trim_suffix(strings.trim_prefix(role_arn, "${var."), "}")
+        #print ( "role_arn variable is: ", role_arn_variable )
+        #print ( "Value of role_arn is: ", tfplan.variables[role_arn_variable] )
+        role_arn_value = tfplan.variables[role_arn_variable]
+      } else if role_arn matches "var\\.(.*)" {
+        # role_arn of AWS provider was a Terraform 0.12 style variable
+        #print ( "role_arn is a Terraform 0.12 style variable" )
+        role_arn_variable = strings.trim_prefix(role_arn, "var.")
+        #print ( "role_arn variable is: ", role_arn_variable )
+        #print ( "Value of role_arn is: ", tfplan.variables[role_arn_variable] )
+        role_arn_value = tfplan.variables[role_arn_variable]
+      } // end determination of role_arn type
+    } // end role_arn in references test
+  } // end references test
+
+  return role_arn_value
+}
+
+# Get assumed roles from all AWS providers
+get_assumed_roles = func() {
+
+  # Initialize empty map of roles indexed by aliases
+  assumed_roles = {}
+
+  # Get all AWS provider aliases
+  aws_providers = find_provider_aliases("aws")
+  #print("aws providers:", aws_providers)
+
+  # Iterate through all AWS provider aliases
+  for aws_providers as alias, data {
+        #print("alias:", alias)
+        assumed_roles[alias] = determine_role_arn(data)
+  } // end aws_providers
+
+  return assumed_roles
+
+}
+
+# Validate that all assumed roles are allowed
+validate_assumed_roles = func(allowed_roles) {
+
+  validated = true
+
+  assumed_roles = get_assumed_roles()
+  #print("assumed roles:", assumed_roles)
+
+  for assumed_roles as alias, role {
+    if role is not "" and role not in allowed_roles {
+      print("AWS provider with alias", alias, "has assumed role",
+            role, "that is not allowed.")
+      validated = false
+    }
+  }
+
+  return validated
+}
+
+###### Allowed Roles #####
+allowed_roles = [
+  "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+]
+
+##### Rules #####
+roles_validated = validate_assumed_roles(allowed_roles)
+main = rule {
+  roles_validated
+}

--- a/governance/second-generation/aws/test/restrict-assumed-role/fail-0.11.json
+++ b/governance/second-generation/aws/test/restrict-assumed-role/fail-0.11.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.11.sentinel",
+    "tfplan": "mock-tfplan-fail-0.11.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/restrict-assumed-role/fail-0.12.json
+++ b/governance/second-generation/aws/test/restrict-assumed-role/fail-0.12.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.12.sentinel",
+    "tfplan": "mock-tfplan-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-fail-0.11.sentinel
@@ -1,0 +1,232 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config": {
+					"role": "${var.role}",
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-ptfe-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id":  "EXTERNAL_ID",
+							"role_arn":     "${var.role}",
+							"session_name": "${var.session}",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "assumed_role_instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+
+	"module.first": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-ptfe-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id":  "EXTERNAL_ID",
+							"role_arn":     "${var.role}",
+							"session_name": "${var.session}",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "assumed_role_instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-fail-0.12.sentinel
@@ -1,0 +1,383 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config": {},
+				"references": {
+					"role": [
+						"var.role",
+					],
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-ptfe-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id":  [],
+									"role_arn":     [],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-12-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id": "EXTERNAL_ID",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"references": {
+					"assume_role": [
+						{
+							"external_id": [],
+							"role_arn": [
+								"var.role",
+							],
+							"session_name": [
+								"var.session",
+							],
+						},
+					],
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "assumed_role_instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+
+	"module.first": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-ptfe-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id":  [],
+									"role_arn":     [],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-12-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id": "EXTERNAL_ID",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"references": {
+					"assume_role": [
+						{
+							"external_id": [],
+							"role_arn": [
+								"var.role",
+							],
+							"session_name": [
+								"var.session",
+							],
+						},
+					],
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "assumed_role_instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-pass-0.11.sentinel
@@ -1,0 +1,232 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config": {
+					"role": "${var.role}",
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id":  "EXTERNAL_ID",
+							"role_arn":     "${var.role}",
+							"session_name": "${var.session}",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "assumed_role_instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+
+	"module.first": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "${var.role}",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id":  "EXTERNAL_ID",
+							"role_arn":     "${var.role}",
+							"session_name": "${var.session}",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "assumed_role_instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfconfig-pass-0.12.sentinel
@@ -1,0 +1,383 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config": {},
+				"references": {
+					"role": [
+						"var.role",
+					],
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id":  [],
+									"role_arn":     [],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-12-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id": "EXTERNAL_ID",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"references": {
+					"assume_role": [
+						{
+							"external_id": [],
+							"role_arn": [
+								"var.role",
+							],
+							"session_name": [
+								"var.session",
+							],
+						},
+					],
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "assumed_role_instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+
+	"module.first": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-2",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"hard-coded-role": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"role_arn":     "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id":  [],
+									"role_arn":     [],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-11-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"tf-12-var": {
+						"config": {
+							"assume_role": [
+								{
+									"external_id":  "EXTERNAL_ID",
+									"session_name": "SESSION_NAME",
+								},
+							],
+							"region": "us-east-1",
+						},
+						"references": {
+							"assume_role": [
+								{
+									"external_id": [],
+									"role_arn": [
+										"var.role",
+									],
+									"session_name": [],
+								},
+							],
+							"region": [],
+						},
+						"version": "",
+					},
+					"west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"assume_role": [
+						{
+							"external_id": "EXTERNAL_ID",
+						},
+					],
+					"region": "us-east-2",
+				},
+				"references": {
+					"assume_role": [
+						{
+							"external_id": [],
+							"role_arn": [
+								"var.role",
+							],
+							"session_name": [
+								"var.session",
+							],
+						},
+					],
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "assumed_role_instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {
+			"role": {
+				"default":     null,
+				"description": "IAM Role to assume",
+			},
+			"session": {
+				"default":     "SESSION_NAME",
+				"description": "",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-fail-0.11.sentinel
@@ -1,0 +1,490 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"availability_zone":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.first": {
+		"data": {},
+		"path": [
+			"first",
+		],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"availability_zone":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+terraform_version = "0.11.14"
+
+variables = {
+	"role":    "arn:aws:iam::753646501470:role/roger-ptfe-role",
+	"session": "SESSION_NAME",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-fail-0.12.sentinel
@@ -1,0 +1,542 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.first": {
+		"data": {},
+		"path": [
+			"first",
+		],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+terraform_version = "0.12.9"
+
+variables = {
+	"role":    "arn:aws:iam::753646501470:role/roger-ptfe-role",
+	"session": "SESSION_NAME",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-pass-0.11.sentinel
@@ -1,0 +1,490 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"availability_zone":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.first": {
+		"data": {},
+		"path": [
+			"first",
+		],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"availability_zone":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+terraform_version = "0.11.14"
+
+variables = {
+	"role":    "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+	"session": "SESSION_NAME",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-assumed-role/mock-tfplan-pass-0.12.sentinel
@@ -1,0 +1,542 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+
+	"module.first": {
+		"data": {},
+		"path": [
+			"first",
+		],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "assumed_role_instance",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "assumed_role_instance",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+]
+
+terraform_version = "0.12.9"
+
+variables = {
+	"role":    "arn:aws:iam::753646501470:role/roger-terraform-assumed-role",
+	"session": "SESSION_NAME",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-assumed-role/pass-0.11.json
+++ b/governance/second-generation/aws/test/restrict-assumed-role/pass-0.11.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.11.sentinel",
+    "tfplan": "mock-tfplan-pass-0.11.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/aws/test/restrict-assumed-role/pass-0.12.json
+++ b/governance/second-generation/aws/test/restrict-assumed-role/pass-0.12.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.12.sentinel",
+    "tfplan": "mock-tfplan-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/fail-0.11.json
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/fail-0.11.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.11.sentinel",
+    "tfplan": "mock-tfplan-fail-0.11.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/fail-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/fail-0.12.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.12.sentinel",
+    "tfplan": "mock-tfplan-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.11.sentinel
@@ -1,0 +1,93 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"sensitive":   false,
+				"value":       "${aws_instance.ubuntu.public_dns}",
+			},
+		},
+		"providers": {
+			"aws": {
+				"alias": {},
+				"config": {
+					"region": "${var.aws_region}",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					"config": {
+						"ami": "${var.ami_id}",
+						"associate_public_ip_address": "${var.associate_public_ip_address}",
+						"availability_zone":           "${var.aws_region}b",
+						"instance_type":               "${var.instance_type}",
+						"tags": [
+							{
+								"Name": "${var.name}",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     "1",
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.12.sentinel
@@ -3,8 +3,31 @@ import "types"
 
 _modules = {
 	"root": {
-		"data":    {},
-		"modules": {},
+		"data": {},
+		"modules": {
+			"nested": {
+				"config": {},
+				"references": {
+					"ami_id": [
+						"var.ami_id",
+					],
+					"associate_public_ip_address": [
+						"var.associate_public_ip_address",
+					],
+					"aws_region": [
+						"var.aws_region",
+					],
+					"instance_type": [
+						"var.instance_type",
+					],
+					"name": [
+						"var.name",
+					],
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
 		"outputs": {
 			"public_dns": {
 				"depends_on":  [],
@@ -71,6 +94,70 @@ _modules = {
 			},
 			"name": {
 				"default":     "Provisioned by Terraform",
+				"description": "name to pass to Name tag",
+			},
+		},
+	},
+
+	"module.nested": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"references": [
+					"aws_instance.ubuntu-nested",
+				],
+				"sensitive": false,
+				"value":     undefined,
+			},
+		},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"ubuntu-nested": {
+					"config":       {},
+					"provisioners": null,
+					"references": {
+						"ami": [
+							"var.ami_id",
+						],
+						"associate_public_ip_address": [
+							"var.associate_public_ip_address",
+						],
+						"availability_zone": [
+							"var.aws_region",
+						],
+						"instance_type": [
+							"var.instance_type",
+						],
+						"tags": [
+							"var.name",
+						],
+					},
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     true,
+				"description": "associate a public IP",
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
 			},
 		},
 	},
@@ -78,6 +165,9 @@ _modules = {
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
 ]
 
 module = func(path) {

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-fail-0.12.sentinel
@@ -1,0 +1,106 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"references": [
+					"aws_instance.ubuntu",
+				],
+				"sensitive": false,
+				"value":     undefined,
+			},
+		},
+		"providers": {
+			"aws": {
+				"alias":  {},
+				"config": {},
+				"references": {
+					"region": [
+						"var.aws_region",
+					],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					"config":       {},
+					"provisioners": null,
+					"references": {
+						"ami": [
+							"var.ami_id",
+						],
+						"associate_public_ip_address": [
+							"var.associate_public_ip_address",
+						],
+						"availability_zone": [
+							"var.aws_region",
+						],
+						"instance_type": [
+							"var.instance_type",
+						],
+						"tags": [
+							"var.name",
+						],
+					},
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     true,
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.11.sentinel
@@ -1,0 +1,95 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"sensitive":   false,
+				"value":       "${aws_instance.ubuntu.public_dns}",
+			},
+		},
+		"providers": {
+			"aws": {
+				"alias": {},
+				"config": {
+					"region": "${var.aws_region}",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					"config": {
+						"ami": "${var.ami_id}",
+						"associate_public_ip_address": "${var.associate_public_ip_address}",
+						"availability_zone":           "${var.aws_region}b",
+						"instance_type":               "${var.instance_type}",
+						"tags": [
+							{
+								"Name": "${var.name}",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     "1",
+				"description": "associate a public IP",
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
+				"description": "name to pass to Name tag",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.12.sentinel
@@ -3,8 +3,31 @@ import "types"
 
 _modules = {
 	"root": {
-		"data":    {},
-		"modules": {},
+		"data": {},
+		"modules": {
+			"nested": {
+				"config": {},
+				"references": {
+					"ami_id": [
+						"var.ami_id",
+					],
+					"associate_public_ip_address": [
+						"var.associate_public_ip_address",
+					],
+					"aws_region": [
+						"var.aws_region",
+					],
+					"instance_type": [
+						"var.instance_type",
+					],
+					"name": [
+						"var.name",
+					],
+				},
+				"source":  "./module",
+				"version": "",
+			},
+		},
 		"outputs": {
 			"public_dns": {
 				"depends_on":  [],
@@ -76,10 +99,77 @@ _modules = {
 			},
 		},
 	},
+
+	"module.nested": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"references": [
+					"aws_instance.ubuntu-nested",
+				],
+				"sensitive": false,
+				"value":     undefined,
+			},
+		},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"ubuntu-nested": {
+					"config":       {},
+					"provisioners": null,
+					"references": {
+						"ami": [
+							"var.ami_id",
+						],
+						"associate_public_ip_address": [
+							"var.associate_public_ip_address",
+						],
+						"availability_zone": [
+							"var.aws_region",
+						],
+						"instance_type": [
+							"var.instance_type",
+						],
+						"tags": [
+							"var.name",
+						],
+					},
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     true,
+				"description": "associate a public IP",
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
+				"description": "name to pass to Name tag",
+			},
+		},
+	},
 }
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
 ]
 
 module = func(path) {

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfconfig-pass-0.12.sentinel
@@ -1,0 +1,108 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data":    {},
+		"modules": {},
+		"outputs": {
+			"public_dns": {
+				"depends_on":  [],
+				"description": "",
+				"references": [
+					"aws_instance.ubuntu",
+				],
+				"sensitive": false,
+				"value":     undefined,
+			},
+		},
+		"providers": {
+			"aws": {
+				"alias":  {},
+				"config": {},
+				"references": {
+					"region": [
+						"var.aws_region",
+					],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					"config":       {},
+					"provisioners": null,
+					"references": {
+						"ami": [
+							"var.ami_id",
+						],
+						"associate_public_ip_address": [
+							"var.associate_public_ip_address",
+						],
+						"availability_zone": [
+							"var.aws_region",
+						],
+						"instance_type": [
+							"var.instance_type",
+						],
+						"tags": [
+							"var.name",
+						],
+					},
+				},
+			},
+		},
+		"variables": {
+			"ami_id": {
+				"default":     "ami-2e1ef954",
+				"description": "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+			},
+			"associate_public_ip_address": {
+				"default":     true,
+				"description": "associate a public IP",
+			},
+			"aws_region": {
+				"default":     "us-east-1",
+				"description": "AWS region",
+			},
+			"instance_type": {
+				"default":     "t2.micro",
+				"description": "type of EC2 instance to provision.",
+			},
+			"name": {
+				"default":     "Provisioned by Terraform",
+				"description": "name to pass to Name tag",
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.11.sentinel
@@ -1,0 +1,264 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1b",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "Provisioned by Terraform",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.14"
+
+variables = {
+	"ami_id":                      "ami-2e1ef954",
+	"associate_public_ip_address": "1",
+	"aws_region":                  "us-east-1",
+	"instance_type":               "t2.micro",
+	"name":                        "Provisioned by Terraform",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.12.sentinel
@@ -1,0 +1,292 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"associate_public_ip_address":          true,
+							"availability_zone":                    "us-east-1b",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "Provisioned by Terraform",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.9"
+
+variables = {
+	"ami_id":                      "ami-2e1ef954",
+	"associate_public_ip_address": true,
+	"aws_region":                  "us-east-1",
+	"instance_type":               "t2.micro",
+	"name":                        "Provisioned by Terraform",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-fail-0.12.sentinel
@@ -253,10 +253,267 @@ _modules = {
 			},
 		},
 	},
+
+	"module.nested": {
+		"data": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-nested": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"associate_public_ip_address":          true,
+							"availability_zone":                    "us-east-1b",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "Provisioned by Terraform-nested",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform-nested",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
 }
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
 ]
 
 terraform_version = "0.12.9"

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.11.sentinel
@@ -1,0 +1,264 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"arn": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"associate_public_ip_address":  true,
+							"availability_zone":            "us-east-1b",
+							"cpu_core_count":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"cpu_threads_per_core":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ebs_block_device":             "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ephemeral_block_device":       "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"get_password_data":            false,
+							"host_id":                      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":                           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_state":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"instance_type":                "t2.micro",
+							"ipv6_address_count":           "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ipv6_addresses":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"key_name":                     "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"network_interface_id":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"password_data":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"placement_group":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"primary_network_interface_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_dns":                  "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"private_ip":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_dns":                   "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"public_ip":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"root_block_device":            "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"security_groups":              "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"source_dest_check":            true,
+							"subnet_id":                    "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"tags": {
+								"Name": "Provisioned by Terraform",
+							},
+							"tenancy":                "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"volume_tags":            {},
+							"vpc_security_group_ids": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.11.14"
+
+variables = {
+	"ami_id":                      "ami-2e1ef954",
+	"associate_public_ip_address": "1",
+	"aws_region":                  "us-east-1",
+	"instance_type":               "t2.micro",
+	"name":                        "Provisioned by Terraform",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.12.sentinel
@@ -1,0 +1,292 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"ubuntu": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"associate_public_ip_address":          true,
+							"availability_zone":                    "us-east-1b",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "Provisioned by Terraform",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.9"
+
+variables = {
+	"ami_id":                      "ami-2e1ef954",
+	"associate_public_ip_address": true,
+	"aws_region":                  "us-east-1",
+	"instance_type":               "t2.micro",
+	"name":                        "Provisioned by Terraform",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/mock-tfplan-pass-0.12.sentinel
@@ -253,10 +253,267 @@ _modules = {
 			},
 		},
 	},
+
+	"module.nested": {
+		"data": {},
+		"path": [
+			"nested",
+		],
+		"resources": {
+			"aws_instance": {
+				"ubuntu-nested": {
+					0: {
+						"applied": {
+							"ami": "ami-2e1ef954",
+							"associate_public_ip_address":          true,
+							"availability_zone":                    "us-east-1b",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"tags": {
+								"Name": "Provisioned by Terraform-nested",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-2e1ef954",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "us-east-1b",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "Provisioned by Terraform-nested",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
 }
 
 module_paths = [
 	[],
+	[
+		"nested",
+	],
 ]
 
 terraform_version = "0.12.9"

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/pass-0.11.json
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/pass-0.11.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.11.sentinel",
+    "tfplan": "mock-tfplan-pass-0.11.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/pass-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/validate-all-variables-have-descriptions/pass-0.12.json
@@ -1,0 +1,9 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.12.sentinel",
+    "tfplan": "mock-tfplan-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/validate-all-variables-have-descriptions.sentinel
+++ b/governance/second-generation/cloud-agnostic/validate-all-variables-have-descriptions.sentinel
@@ -1,0 +1,61 @@
+# This policy validates that all variables in all modules have descriptions
+
+##### Imports #####
+import "tfconfig"
+import "strings"
+
+##### Functions #####
+
+# Find all variables using the tfconfig import
+# This returns a flat map of variables across all modules
+find_variables_in_config = func() {
+  variables = {}
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Iterate over the variables in the module
+    for tfconfig.module(path).variables else {} as name, v {
+
+      # Get the address of the variable
+      if length(path) == 0 {
+        # root module
+        address = name
+      } else {
+        # non-root module
+        address = "module." + strings.join(path, ".module.") + "." + name
+      }
+
+      # Add the variable to the variables map, setting the key to the address
+      variables[address] = v
+    }
+  }
+
+  return variables
+
+}
+
+# Validate that all variables have descriptions
+validate_variables_have_descriptions = func() {
+
+  validated = true
+
+  # Get all variables
+  variables = find_variables_in_config()
+  #print("variables:", variables)
+
+  # Iterate over all variables
+  for variables as address, v {
+    if v.description else "" is "" {
+      print("variable", address, "does not have a description.")
+      validated = false
+    }
+  }
+
+  return validated
+}
+
+###### Rules ######
+variables_validated = validate_variables_have_descriptions()
+main = rule {
+  variables_validated
+}

--- a/governance/second-generation/common-functions/config/find_provider_aliases.md
+++ b/governance/second-generation/common-functions/config/find_provider_aliases.md
@@ -1,0 +1,39 @@
+# find_provider_aliases
+This function finds all providers of a specified type from all modules in the Terraform configuration using the [tfconfig](https://www.terraform.io/docs/enterprise/sentinel/import/tfconfig.html) import.
+
+## Scope
+Terraform configurations
+
+## Declaration
+`find_provider_aliases = func(type)`
+
+## Arguments
+* **type**: the type of provider to find
+
+## Required Imports
+This function requires the following imports:
+```
+import "tfconfig"
+import "strings"
+```
+Be sure to include them in any policy that uses this function.
+
+## Custom Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all providers of the specified type indexed by concatentation of the module path and the provider alias. However, the default alias in any module is converted from "" to "default".
+
+## What It Prints
+This function does not print anything. Users calling it in a policy might want to print out the map that it returns.
+
+## Code
+The Sentinel code for this function is in [find_provider_aliases](./find_provider_aliases.sentinel)
+
+## Examples
+Here is an example of using this function:
+```
+aws_providers = find_provider_aliases("aws")
+```
+
+You can see this function being used in context in the AWS policy [restrict-assumed-role](../../aws/restrict-assumed-role.sentinel) which restricts which roles AWS providers can assume.

--- a/governance/second-generation/common-functions/config/find_provider_aliases.sentinel
+++ b/governance/second-generation/common-functions/config/find_provider_aliases.sentinel
@@ -1,0 +1,34 @@
+# Find all providers aliases of given type using the tfconfig import
+find_provider_aliases = func(type) {
+
+  # We will find all provider aliases og given type from tfconfig,
+  # meaning providers.TYPE.alias.ALIAS
+  providers = {}
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Iterate over providers of given type in module
+    aliases = tfconfig.module(path).providers[type]["alias"] else {}
+    for aliases as alias, data {
+        # Change default alias ("") to "default"
+        if alias is "" {
+          alias = "default"
+        }
+
+        # Get the address of the provider alias
+        if length(path) == 0 {
+          # root module
+          address =  type + "." + alias
+        } else {
+          # non-root module
+          address = "module." + strings.join(path, ".module.") + "." +
+                    type + "." + alias
+        }
+
+        providers[address] = data
+
+    } // end aliases loop
+  } // end module_paths loop
+
+  return providers
+}

--- a/governance/second-generation/common-functions/config/find_variables_in_config.md
+++ b/governance/second-generation/common-functions/config/find_variables_in_config.md
@@ -1,0 +1,39 @@
+# find_variables_in_config
+This function finds all variables from all modules in the Terraform configuration using the [tfconfig](https://www.terraform.io/docs/enterprise/sentinel/import/tfconfig.html) import. This can let you determine whether variables have default values and descriptions.
+
+## Scope
+Terraform configurations
+
+## Declaration
+`find_variables_in_config = func`
+
+## Arguments
+None
+
+## Required Imports
+This function requires the following imports:
+```
+import "tfconfig"
+import "strings"
+```
+Be sure to include them in any policy that uses this function.
+
+## Custom Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all variables indexed by concatentation of the module path and the names of the variables.
+
+## What It Prints
+This function does not print anything. Users calling it in a policy might want to print out the map that it returns.
+
+## Code
+The Sentinel code for this function is in [find_variables_in_config.sentinel](./find_variables_in_config.sentinel)
+
+## Examples
+Here is an example of using this function:
+```
+find_variables_in_config()
+
+```
+You can see this function being used in context in the policy [validate-all-variables-have-descriptions](../../cloud-agnostic/validate-all-variables-have-descriptions.sentinel).

--- a/governance/second-generation/common-functions/config/find_variables_in_config.sentinel
+++ b/governance/second-generation/common-functions/config/find_variables_in_config.sentinel
@@ -1,0 +1,27 @@
+# Find all variables using the tfconfig import
+# This returns a flat map of variables across all modules
+find_variables_in_config = func() {
+  variables = {}
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Iterate over the variables in the module
+    for tfconfig.module(path).variables else {} as name, v {
+
+      # Get the address of the variable
+      if length(path) == 0 {
+        # root module
+        address = name
+      } else {
+        # non-root module
+        address = "module." + strings.join(path, ".module.") + "." + name
+      }
+
+      # Add the variable to the variables map, setting the key to the address
+      variables[address] = v
+    }
+  }
+
+  return variables
+
+}


### PR DESCRIPTION
I actually added two new policies and two functions as well as test cases that go with the policies.

The new policies are:
aws/restrict-assumed-role.sentinel
cloud-agnostic/validate-all-variables-have-descriptions.sentinel

The new functions are:
common-functions/config/find_provisioner_aliases.sentinel
common-functions/config/find_variables_in_config.sentinel

The functions have corresponding `*.md` files that describe them.
