### PR TITLE
Restrict aws sgs

### DIFF
--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -1,5 +1,6 @@
-# This policy uses the Sentinel tfplan import to validate that
-# no security group rules have the CIDR "0.0.0.0/0"
+# This policy uses the Sentinel tfplan import to validate that no security group
+# rules have the CIDR "0.0.0.0/0".  It covers both the aws_security_group and
+# the aws_security_group_rule resources.
 
 ##### Imports #####
 
@@ -42,21 +43,21 @@ find_resources_from_plan = func(type) {
 
 # Validate that all AWS ingress security group rules
 # do not have cidr_block 0.0.0.0/0
-validate_sgr_cidr_blocks = func() {
+validate_cidr_blocks = func() {
 
   validated = true
 
-  # Get all resources of specified type
-  resource_instances = find_resources_from_plan("aws_security_group_rule")
+  # Get all AWS security group rules
+  sgr_instances = find_resources_from_plan("aws_security_group_rule")
 
   # Loop through the resource instances
-  for resource_instances as address, r {
+  for sgr_instances as address, r {
 
     # Skip resources that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
     if r.destroy and not r.requires_new {
-      print("Skipping resource", address, "that is being destroyed.")
+      print("Skipping security group rule", address, "that is being destroyed.")
       continue
     }
 
@@ -83,7 +84,68 @@ validate_sgr_cidr_blocks = func() {
       }
     } // end computed check
 
-  } // end resource instances
+  } // end security group rule instances
+
+  # Get all AWS security groups
+  sg_instances = find_resources_from_plan("aws_security_group")
+
+  # Loop through the resource instances
+  for sg_instances as address, r {
+
+    # Skip resources that are being destroyed
+    # to avoid unnecessary policy violations.
+    # Used to be: if length(r.diff) == 0
+    if r.destroy and not r.requires_new {
+      print("Skipping security group", address, "that is being destroyed.")
+      continue
+    }
+
+    # Check if there are ingress blocks that are not computed
+    if (r.diff["ingress.#"].computed else false) is true {
+      print("Security group", address, "does not have any ingress blocks",
+            "or, they are computed.")
+      # If you want computed values to cause the policy to fail,
+      # uncomment the next line.
+      # validated = false
+    } else {
+      # Check if r.applied.ingress is a list (to be safe)
+      if types.type_of(r.applied.ingress) is "list" {
+
+        ingress_count = 0
+
+        for r.applied.ingress as i {
+
+          # Determine if ingress.<n>.cidr_blocks.# attribute is computed
+          ingress_cidr_blocks = "ingress." + string(ingress_count) + ".cidr_blocks.#"
+          if (r.diff[ingress_cidr_blocks].computed else false) is true {
+            print("Ingress block #", ingress_count, "of security group",
+                  address, "has cidr_blocks that is computed.")
+            # If you want computed values to cause the policy to fail,
+            # uncomment the next line.
+            # validated = false
+          } else {
+            # Validate that the ingress rule does not have disallowed value
+            # Since cidr_blocks is optional and could be computed,
+            # We check that it is present and really a list
+            # before checking whether it contains "0.0.0.0/0"
+            if i.cidr_blocks else null is not null and
+               types.type_of(i.cidr_blocks) is "list" and
+               i.cidr_blocks contains "0.0.0.0/0" {
+              print("Ingress block #", ingress_count, "of security group",
+                    address, "contains disallowed cidr_block 0.0.0.0/0" )
+              validated = false
+            }
+          } // end cidr_blocks.# computed check
+
+          # increment ingress_count
+          ingress_count += 1
+
+        } // end ingress loop
+
+      } // end if r.applied.ingress a list
+    } // end if diff[ingress.#] computed
+
+  } // end security group instances
 
   return validated
 }
@@ -91,7 +153,7 @@ validate_sgr_cidr_blocks = func() {
 ##### Rules #####
 
 # Call the validation function and assign results
-sgrs_validated = validate_sgr_cidr_blocks()
+sgrs_validated = validate_cidr_blocks()
 
 # Main rule
 main = rule {

--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -116,6 +116,10 @@ validate_cidr_blocks = func() {
         for r.applied.ingress as i {
 
           # Determine if ingress.<n>.cidr_blocks.# attribute is computed
+          # Note that this approach works for Terraform 0.12, but not
+          # for Terraform 0.11 which has diff expressions like
+          # "ingress.3167104115.cidr_blocks.#" rather than using 0, 1, 2
+          # after "ingress".
           ingress_cidr_blocks = "ingress." + string(ingress_count) + ".cidr_blocks.#"
           if (r.diff[ingress_cidr_blocks].computed else false) is true {
             print("Ingress block #", ingress_count, "of security group",

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.11.sentinel
@@ -5,6 +5,205 @@ _modules = {
 		"data": {},
 		"path": [],
 		"resources": {
+			"aws_security_group": {
+				"allow_tls": {
+					0: {
+						"applied": {
+							"arn":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"description": "Allow TLS inbound traffic",
+							"egress":      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":          "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ingress": [
+								{
+									"cidr_blocks":      [],
+									"description":      "",
+									"from_port":        "443",
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             true,
+									"to_port":          "443",
+								},
+								{
+									"cidr_blocks": [
+										"0.0.0.0/0",
+									],
+									"description":      "",
+									"from_port":        "444",
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             false,
+									"to_port":          "444",
+								},
+							],
+							"name":                   "allow_tls",
+							"owner_id":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"revoke_rules_on_delete": false,
+							"tags": {
+								"Name": "allow_all",
+							},
+							"vpc_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "Allow TLS inbound traffic",
+								"old":      "",
+							},
+							"egress.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.#": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"ingress.3167104115.cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.3167104115.from_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.3167104115.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.3167104115.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.self": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"ingress.3167104115.to_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.4122917492.cidr_blocks.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.4122917492.cidr_blocks.0": {
+								"computed": false,
+								"new":      "0.0.0.0/0",
+								"old":      "",
+							},
+							"ingress.4122917492.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.4122917492.from_port": {
+								"computed": false,
+								"new":      "444",
+								"old":      "",
+							},
+							"ingress.4122917492.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.4122917492.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.self": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"ingress.4122917492.to_port": {
+								"computed": false,
+								"new":      "444",
+								"old":      "",
+							},
+							"name": {
+								"computed": false,
+								"new":      "allow_tls",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"revoke_rules_on_delete": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "allow_all",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
 			"aws_security_group_rule": {
 				"allow_all": {
 					0: {

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-fail-0.12.sentinel
@@ -6,6 +6,161 @@ _modules = {
 		"data": {},
 		"path": [],
 		"resources": {
+			"aws_security_group": {
+				"allow_tls": {
+					0: {
+						"applied": {
+							"description": "Allow TLS inbound traffic",
+							"ingress": [
+								{
+									"cidr_blocks": [
+										"0.0.0.0/0",
+									],
+									"description":      "",
+									"from_port":        443,
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             false,
+									"to_port":          443,
+								},
+							],
+							"name":                   "allow_tls",
+							"name_prefix":            null,
+							"revoke_rules_on_delete": false,
+							"tags": {
+								"Name": "allow_all",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "Allow TLS inbound traffic",
+								"old":      "",
+							},
+							"egress.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.0.%": {
+								"computed": false,
+								"new":      "9",
+								"old":      "",
+							},
+							"ingress.0.cidr_blocks.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.0.cidr_blocks.0": {
+								"computed": false,
+								"new":      "0.0.0.0/0",
+								"old":      "",
+							},
+							"ingress.0.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.0.from_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.0.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.0.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.self": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"ingress.0.to_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"name": {
+								"computed": false,
+								"new":      "allow_tls",
+								"old":      "",
+							},
+							"name_prefix": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"revoke_rules_on_delete": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "allow_all",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
 			"aws_security_group_rule": {
 				"allow_all": {
 					0: {

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.11.sentinel
@@ -5,6 +5,205 @@ _modules = {
 		"data": {},
 		"path": [],
 		"resources": {
+			"aws_security_group": {
+				"allow_tls": {
+					0: {
+						"applied": {
+							"arn":         "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"description": "Allow TLS inbound traffic",
+							"egress":      "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"id":          "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"ingress": [
+								{
+									"cidr_blocks":      [],
+									"description":      "",
+									"from_port":        "443",
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             true,
+									"to_port":          "443",
+								},
+								{
+									"cidr_blocks": [
+										"10.100.0.0/16",
+									],
+									"description":      "",
+									"from_port":        "444",
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             false,
+									"to_port":          "444",
+								},
+							],
+							"name":                   "allow_tls",
+							"owner_id":               "74D93920-ED26-11E3-AC10-0800200C9A66",
+							"revoke_rules_on_delete": false,
+							"tags": {
+								"Name": "allow_all",
+							},
+							"vpc_id": "74D93920-ED26-11E3-AC10-0800200C9A66",
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "Allow TLS inbound traffic",
+								"old":      "",
+							},
+							"egress.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.#": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"ingress.3167104115.cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.3167104115.from_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.3167104115.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.3167104115.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.3167104115.self": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"ingress.3167104115.to_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.4122917492.cidr_blocks.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.4122917492.cidr_blocks.0": {
+								"computed": false,
+								"new":      "10.100.0.0/16",
+								"old":      "",
+							},
+							"ingress.4122917492.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.4122917492.from_port": {
+								"computed": false,
+								"new":      "444",
+								"old":      "",
+							},
+							"ingress.4122917492.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.4122917492.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.4122917492.self": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"ingress.4122917492.to_port": {
+								"computed": false,
+								"new":      "444",
+								"old":      "",
+							},
+							"name": {
+								"computed": false,
+								"new":      "allow_tls",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"revoke_rules_on_delete": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "allow_all",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
 			"aws_security_group_rule": {
 				"allow_all": {
 					0: {

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-0.12.sentinel
@@ -6,6 +6,161 @@ _modules = {
 		"data": {},
 		"path": [],
 		"resources": {
+			"aws_security_group": {
+				"allow_tls": {
+					0: {
+						"applied": {
+							"description": "Allow TLS inbound traffic",
+							"ingress": [
+								{
+									"cidr_blocks": [
+										"10.100.0.0/16",
+									],
+									"description":      "",
+									"from_port":        443,
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             false,
+									"to_port":          443,
+								},
+							],
+							"name":                   "allow_tls",
+							"name_prefix":            null,
+							"revoke_rules_on_delete": false,
+							"tags": {
+								"Name": "allow_all",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "Allow TLS inbound traffic",
+								"old":      "",
+							},
+							"egress.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.0.%": {
+								"computed": false,
+								"new":      "9",
+								"old":      "",
+							},
+							"ingress.0.cidr_blocks.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.0.cidr_blocks.0": {
+								"computed": false,
+								"new":      "10.100.0.0/16",
+								"old":      "",
+							},
+							"ingress.0.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.0.from_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.0.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.0.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.self": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"ingress.0.to_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"name": {
+								"computed": false,
+								"new":      "allow_tls",
+								"old":      "",
+							},
+							"name_prefix": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"revoke_rules_on_delete": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "allow_all",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
 			"aws_security_group_rule": {
 				"allow_all": {
 					0: {

--- a/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-no-cidr-blocks-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ingress-sg-rule-cidr-blocks/mock-tfplan-pass-no-cidr-blocks-0.12.sentinel
@@ -6,6 +6,154 @@ _modules = {
 		"data": {},
 		"path": [],
 		"resources": {
+			"aws_security_group": {
+				"allow_tls": {
+					0: {
+						"applied": {
+							"description": "Allow TLS inbound traffic",
+							"ingress": [
+								{
+									"cidr_blocks":      [],
+									"description":      "",
+									"from_port":        443,
+									"ipv6_cidr_blocks": [],
+									"prefix_list_ids":  [],
+									"protocol":         "tcp",
+									"security_groups":  [],
+									"self":             true,
+									"to_port":          443,
+								},
+							],
+							"name":                   "allow_tls",
+							"name_prefix":            null,
+							"revoke_rules_on_delete": false,
+							"tags": {
+								"Name": "allow_all",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"description": {
+								"computed": false,
+								"new":      "Allow TLS inbound traffic",
+								"old":      "",
+							},
+							"egress.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.#": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"ingress.0.%": {
+								"computed": false,
+								"new":      "9",
+								"old":      "",
+							},
+							"ingress.0.cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.description": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ingress.0.from_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"ingress.0.ipv6_cidr_blocks.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.prefix_list_ids.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.protocol": {
+								"computed": false,
+								"new":      "tcp",
+								"old":      "",
+							},
+							"ingress.0.security_groups.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"ingress.0.self": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"ingress.0.to_port": {
+								"computed": false,
+								"new":      "443",
+								"old":      "",
+							},
+							"name": {
+								"computed": false,
+								"new":      "allow_tls",
+								"old":      "",
+							},
+							"name_prefix": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"revoke_rules_on_delete": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "1",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "allow_all",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
 			"aws_security_group_rule": {
 				"allow_all": {
 					0: {


### PR DESCRIPTION
In response to a customer request, I've modified the AWS policy that restricts security group rules, restrict-ingress-sg-rule-cidr-blocks.sentinel, that previously only looked at aws_security_group_rule resources to also examine aws_security_group resources.

I've also modified some the mocks used to test this policy to include a security group.