### PR TITLE
added prevent-non-root-providers.sentinel

### DIFF
--- a/governance/second-generation/cloud-agnostic/prevent-non-root-providers.sentinel
+++ b/governance/second-generation/cloud-agnostic/prevent-non-root-providers.sentinel
@@ -1,0 +1,39 @@
+# This policy uses the tfconfig import to prevent providers from being declared
+# in non-root modules, aligning with the best practices given in:
+# https://www.terraform.io/docs/configuration/modules.html
+
+##### Imports #####
+import "tfconfig"
+import "strings"
+
+##### Functions #####
+
+# Prevent providers in non-root modules
+prevent_non_root_providers = func() {
+
+  validated = true
+
+  # Iterate over all modules in the tfconfig import
+  for tfconfig.module_paths as path {
+    # Check non-root modules
+    if length(path) > 0 {
+      # Iterate over providers of given type in module
+      providers = tfconfig.module(path).providers
+      if length(providers) > 0 {
+        print("Module module." + strings.join(path, ".module.") +
+              " has providers.")
+        validated = false
+      }
+    }
+  }
+
+  return validated
+}
+
+##### Rules #####
+
+# Main rule
+providers_validated = prevent_non_root_providers()
+main = rule {
+  providers_validated
+}

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/fail-0.11.json
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/fail-0.11.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.11.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/fail-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/fail-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail-0.11.sentinel
@@ -1,0 +1,205 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config":  {},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"root-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"root-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "root module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first": {
+		"data": {},
+		"modules": {
+			"second": {
+				"config":  {},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"first-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"first-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "first module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first.module.second": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"second-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"second-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "second module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+	[
+		"first",
+		"second",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail-0.12.sentinel
@@ -1,0 +1,252 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config":     {},
+				"references": {},
+				"source":     "./module",
+				"version":    "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"root-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"root-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"references": {
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "root module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first": {
+		"data": {},
+		"modules": {
+			"second": {
+				"config":     {},
+				"references": {},
+				"source":     "./module",
+				"version":    "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"first-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"first-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"references": {
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "first module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first.module.second": {
+		"data":    {},
+		"modules": {},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"second-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"second-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"references": {
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "second module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+	[
+		"first",
+		"second",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass-0.11.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass-0.11.sentinel
@@ -1,0 +1,151 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config":  {},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"version": "",
+					},
+					"root-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"version": "",
+					},
+					"root-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "root module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first": {
+		"data": {},
+		"modules": {
+			"second": {
+				"config":  {},
+				"source":  "./module",
+				"version": "",
+			},
+		},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "first module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first.module.second": {
+		"data":      {},
+		"modules":   {},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": [
+							{
+								"Name": "second module instance",
+							},
+						],
+					},
+					"provisioners": null,
+				},
+			},
+		},
+		"variables": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+	[
+		"first",
+		"second",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass-0.12.sentinel
@@ -1,0 +1,174 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"modules": {
+			"first": {
+				"config":     {},
+				"references": {},
+				"source":     "./module",
+				"version":    "",
+			},
+		},
+		"outputs": {},
+		"providers": {
+			"aws": {
+				"alias": {
+					"": {
+						"config": {
+							"region": "us-east-2",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"root-east": {
+						"config": {
+							"region": "us-east-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+					"root-west": {
+						"config": {
+							"region": "us-west-1",
+						},
+						"references": {
+							"region": [],
+						},
+						"version": "",
+					},
+				},
+				"config": {
+					"region": "us-east-2",
+				},
+				"references": {
+					"region": [],
+				},
+				"version": "",
+			},
+		},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "root module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first": {
+		"data": {},
+		"modules": {
+			"second": {
+				"config":     {},
+				"references": {},
+				"source":     "./module",
+				"version":    "",
+			},
+		},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "first module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+
+	"module.first.module.second": {
+		"data":      {},
+		"modules":   {},
+		"outputs":   {},
+		"providers": {},
+		"resources": {
+			"aws_instance": {
+				"web": {
+					"config": {
+						"ami":           "ami-2e1ef954",
+						"instance_type": "t2.micro",
+						"tags": {
+							"Name": "second module instance",
+						},
+					},
+					"provisioners": null,
+					"references": {
+						"ami":           [],
+						"instance_type": [],
+						"tags":          [],
+					},
+				},
+			},
+		},
+		"variables": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"first",
+	],
+	[
+		"first",
+		"second",
+	],
+]
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+modules = _modules.root.modules
+providers = _modules.root.providers
+resources = _modules.root.resources
+variables = _modules.root.variables
+outputs = _modules.root.outputs

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/pass-0.11.json
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/pass-0.11.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.11.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/pass-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/prevent-non-root-providers/pass-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfconfig": "mock-tfconfig-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}


### PR DESCRIPTION
I've added a new policy called prevent-non-root-providers.sentinel and associated test cases and mocks to prevent any providers from being declared in non-root modules.  This is to allow customers to enforce our best practices in https://www.terraform.io/docs/configuration/modules.html#providers-within-modules