### PR TITLE
fix cost policies for no cost_estimate

### DIFF
--- a/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
@@ -13,6 +13,15 @@ import "decimal"
 # Validate that the proposed monthly cost is less than the limit
 limit_cost_by_workspace_type = func(limits) {
 
+  # Check whether cost estimate is available
+  # It should be for Terraform 0.12.x
+  # It should not be for Terraform 0.11.x
+  if tfrun.cost_estimate else null is null {
+    print("No cost estimates available")
+    # Allow the policy to pass
+    return true
+  }
+
   # Get workspace name
   workspace_name = tfrun.workspace.name
 

--- a/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
@@ -12,6 +12,15 @@ import "decimal"
 # Validate that the proposed monthly cost is less than the limit
 limit_proposed_monthly_cost = func(limit) {
 
+  # Check whether cost estimate is available
+  # It should be for Terraform 0.12.x
+  # It should not be for Terraform 0.11.x
+  if tfrun.cost_estimate else null is null {
+    print("No cost estimates available")
+    # Allow the policy to pass
+    return true
+  }
+
   # Determine proposed monthly cost
   proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
 

--- a/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
+++ b/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
@@ -17,6 +17,15 @@ restrict_cost_and_percentage_increase = func(limit, max_percent) {
 
   validated = true
 
+  # Check whether cost estimate is available
+  # It should be for Terraform 0.12.x
+  # It should not be for Terraform 0.11.x
+  if tfrun.cost_estimate else null is null {
+    print("No cost estimates available")
+    # Allow the policy to pass
+    return true
+  }
+
   # Determine cost data
   prior_cost = decimal.new(tfrun.cost_estimate.prior_monthly_cost)
   proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-no-estimates-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/mock-tfrun-pass-no-estimates-0.12.sentinel
@@ -1,0 +1,15 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-no-estimates-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-cost-by-workspace-type/pass-no-estimates-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-no-estimates-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-pass-no-estimates-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/mock-tfrun-pass-no-estimates-0.12.sentinel
@@ -1,0 +1,15 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}

--- a/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/pass-no-estimates-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/limit-proposed-monthly-cost/pass-no-estimates-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-no-estimates-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-pass-no-estimates-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/mock-tfrun-pass-no-estimates-0.12.sentinel
@@ -1,0 +1,15 @@
+import "strings"
+import "types"
+
+workspace = {
+	"auto_apply":  false,
+	"description": null,
+	"name":        "gcp-compute-instance",
+	"vcs_repo": {
+		"branch":             "master",
+		"display_identifier": "rberlind/gcp_compute_instance",
+		"identifier":         "rberlind/gcp_compute_instance",
+		"ingress_submodules": false,
+	},
+	"working_directory": "",
+}

--- a/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/pass-no-estimates-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/restrict-cost-and-percentage-increase/pass-no-estimates-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-no-estimates-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}


### PR DESCRIPTION
Cost estimates are only available for Terraform 0.12.
In theory, customers should only use policies that check costimates against workspaces that are configured to use Terraform 0.12.

However, if they set up a policy set to work against all workspaces including some that are using Terraform 0.11, we don't want the cost estimate policies to give hard Sentinel failures.

The revised policies now test whether tfrun.cost_estimate is undefined.  If so, it prints out a message saying "No cost estimates available" and returns true, allowing the policy to pass.