### PR TITLE
Get config 2 openshift

### DIFF
--- a/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
@@ -10,7 +10,7 @@ While the original repository required the user to manually run ansible-playbook
 * [ansible-playbook](https://docs.ansible.com/ansible/2.4/ansible-playbook.html): the actual ansible tool used to deploy the OpenShift cluster. This is used in the install-from-bastion.sh script.
 
 ## Estimated Time to Complete
-60 minutes
+120 minutes
 
 ## Personas
 Our target persona is a developer or operations engineer who wants to provision an OpenShift cluster into AWS.
@@ -47,7 +47,7 @@ vault write aws-tf/config/root \
   access_key=<your_aws_access_key> \
   secret_key=<your_aws_secret_key> \
   region=us-east-1
-  
+
 vault write aws-tf/roles/deploy policy_document=-<<EOF
 {
   "Version": "2012-10-17",
@@ -84,7 +84,9 @@ If you want to use open source Terraform instead of TFE, you can create a copy o
 1. On the Latest Run tab, you should see a new run. If the plan succeeds, you can view the plan and verify that the AWS infrastructure will be created and that various remote-exec and local-exec provisioners will run when you apply your plan.
 1. Click the "Confirm and Apply" button to actually provision your OpenShift cluster.
 
-You will see outputs providing the IPs and DNS addresses needed to access your OpenShift cluster in the AWS Console, TLS certs/keys for your cluster, the Vault Kubernetes auth method path, the Vault server address, and your Vault username. You will need these when using Terraform's Kubernetes Provider to provision Kubernetes pods and services in other workspaces that use your OpenShift cluster. You can also validate that the cluster was created in the AWS Console.
+Unfortunately, the Ansible playbook that provisions the OpenShift cluster takes 80-90 minutes to do it.  To accomodate this, we have set the `max_lease_ttl_seconds` attribute on the Vault provider to 7200 seconds (2 hours).
+
+When the Ansible playbook finally deploys the OpenShift cluster and a few other null resources are run by Terraform, you will see outputs providing the IPs and DNS addresses needed to access your OpenShift cluster in the AWS Console, TLS certs/keys for your cluster, the Vault Kubernetes auth method path, the Vault server address, and your Vault username. You will need these when using Terraform's Kubernetes Provider to provision Kubernetes pods and services in other workspaces that use your OpenShift cluster. You can also validate that the cluster was created in the AWS Console.
 
 You will be able to login to the OpenShift Console with username "admin" and password "123" at the URL contained in the k8s_endpoint output of the apply.log. To use the OpenShift `oc` CLI utility, you may SSH into the bastion host using `bastion_public_ip` output, then to the OpenShift master server using `master_private_ip` output from the apply log.
 

--- a/infrastructure-as-code/k8s-cluster-openshift-aws/main.tf
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/main.tf
@@ -177,6 +177,36 @@ resource "null_resource" "get_vault_reviewer_token" {
   depends_on = ["null_resource.configure_k8s"]
 }
 
+# Get certs again in case Ansible script takes too long to run
+# and Vault token is no longer valid.
+# We need the certs in Terraform worker container in second run
+# This resource can be tainted before doing new run if first fails
+resource "null_resource" "get_config_2" {
+
+  provisioner "local-exec" {
+    command = "echo \"${var.private_key_data}\" > private-key.pem"
+  }
+
+  provisioner "local-exec" {
+    command = "chmod 400 private-key.pem"
+  }
+
+  provisioner "local-exec" {
+    command = "scp -o StrictHostKeyChecking=no -i private-key.pem  ec2-user@${module.openshift.bastion_public_dns}:~/config config"
+  }
+  provisioner "local-exec" {
+    command = "sed -n 4,4p config | cut -d ':' -f 2 | sed 's/ //' > ca_certificate"
+  }
+  provisioner "local-exec" {
+    command = "sed -n 28,28p config | cut -d ':' -f 2 | sed 's/ //' > client_certificate"
+  }
+  provisioner "local-exec" {
+    command = "sed -n 29,29p config | cut -d ':' -f 2 | sed 's/ //' > client_key"
+  }
+
+  depends_on = ["null_resource.get_vault_reviewer_token"]
+}
+
 data "null_data_source" "get_certs" {
   inputs = {
     client_certificate = "${file("client_certificate")}"
@@ -184,7 +214,7 @@ data "null_data_source" "get_certs" {
     ca_certificate = "${file("ca_certificate")}"
     vault_reviewer_token = "${file("vault-reviewer-token")}"
   }
-  depends_on = ["null_resource.get_vault_reviewer_token"]
+  depends_on = ["null_resource.get_config_2"]
 }
 
 # Use the vault_kubernetes_auth_backend_config resource


### PR DESCRIPTION
This PR works around issue with Ansible playbook that installs the OpenShift cluster taking too long and causing the Vault token generated by the Vault provider to time out and the apply to fail.  My original idea was to add a second copy of the null_resource "get_config" that could be used on a second apply to finish the deployment and get the outputs.  And that actually did work.  But I then remembered that I could increase the `max_lease_ttl_seconds` attribute of the Vault provider from 1 hour to 2 hours.  This allows the first apply to succeed and give outputs.