### PR TITLE
updated azure-vm example for 0.12

### DIFF
--- a/infrastructure-as-code/azure-vm/main.tf
+++ b/infrastructure-as-code/azure-vm/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.11.1"
+  required_version = ">= 0.12"
 }
 
 variable "location" {
   description = "Azure location in which to create resources"
-  default = "East US"
+  default     = "East US"
 }
 
 variable "windows_dns_prefix" {
@@ -13,29 +13,31 @@ variable "windows_dns_prefix" {
 
 variable "admin_password" {
   description = "admin password for Windows VM"
-  default = "pTFE1234!"
+  default     = "pTFE1234!"
 }
 
 module "windowsserver" {
   source              = "Azure/compute/azurerm"
-  version             = "1.1.5"
-  location            = "${var.location}"
+  version             = "1.3.0"
+  location            = var.location
   resource_group_name = "${var.windows_dns_prefix}-rc"
   vm_hostname         = "pwc-ptfe"
-  admin_password      = "${var.admin_password}"
+  admin_password      = var.admin_password
   vm_os_simple        = "WindowsServer"
-  public_ip_dns       = ["${var.windows_dns_prefix}"]
-  vnet_subnet_id      = "${module.network.vnet_subnets[0]}"
+  is_windows_image    = "true"
+  public_ip_dns       = [var.windows_dns_prefix]
+  vnet_subnet_id      = module.network.vnet_subnets[0]
 }
 
 module "network" {
   source              = "Azure/network/azurerm"
   version             = "1.1.1"
-  location            = "${var.location}"
+  location            = var.location
   resource_group_name = "${var.windows_dns_prefix}-rc"
   allow_ssh_traffic   = true
 }
 
-output "windows_vm_public_name"{
-  value = "${module.windowsserver.public_ip_dns_name}"
+output "windows_vm_public_name" {
+  value = module.windowsserver.public_ip_dns_name
 }
+


### PR DESCRIPTION
Changes made:
1. terraform 0.12 upgrade
2. updated azure compute module to 1.3.0 (latest official)
3. added is_windows_image    = "true" (in testing discovered that this parameter is required when provisioning a windows instance otherwise the module attempts to use the linux provisioning template)
4. terraform fmt
