### PR TITLE
Handle cases of undefined destroy or requires_new

### DIFF
--- a/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -59,7 +59,7 @@ validate_private_acl_and_kms_encryption = func() {
     # Skip resources that are being destroyed
     # to avoid unnecessary policy violations.
     # Used to be: if length(r.diff) == 0
-    if r.destroy and not r.requires_new {
+    if r.destroy else false and not r.requires_new else false {
       print("Skipping resource", address, "that is being destroyed.")
       continue
     }


### PR DESCRIPTION
Ran into issues where conditional evaluated to undefined. Adding default (else) of false for both to clarify that if 'destroy' is undefined then the value is same as false in this context. Similarly, if requires_new is undefined, then it is the same as false in this context.