### PR TITLE
call validation functions before main rule

### DIFF
--- a/governance/second-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/aws/enforce-mandatory-tags.sentinel
@@ -114,7 +114,7 @@ mandatory_tags = [
 tags_validated = validate_attribute_contains_list("aws_instance",
                  "tags", mandatory_tags)
 
-#Main rule that evaluates results
+#Main rule
 main = rule {
   tags_validated
 }

--- a/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/second-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -104,7 +104,7 @@ validate_private_acl_and_kms_encryption = func() {
 
 ##### Rules #####
 
-# Call the validation function and assign results
+# Call the validation function
 validations = validate_private_acl_and_kms_encryption()
 all_buckets_private = validations["private"]
 all_buckets_encrypted_by_kms = validations["encrypted_by_kms"]

--- a/governance/second-generation/aws/restrict-assumed-role-by-workspace.sentinel
+++ b/governance/second-generation/aws/restrict-assumed-role-by-workspace.sentinel
@@ -169,7 +169,11 @@ allowed_roles_map = {
 }
 
 ##### Rules #####
+
+# Call the validation function
 roles_validated = validate_assumed_roles(allowed_roles_map)
+
+# Main rule
 main = rule {
   roles_validated
 }

--- a/governance/second-generation/aws/restrict-assumed-role.sentinel
+++ b/governance/second-generation/aws/restrict-assumed-role.sentinel
@@ -135,7 +135,11 @@ allowed_roles = [
 ]
 
 ##### Rules #####
+
+# Call the validation function
 roles_validated = validate_assumed_roles(allowed_roles)
+
+# Main rule
 main = rule {
   roles_validated
 }

--- a/governance/second-generation/aws/restrict-availability-zones.sentinel
+++ b/governance/second-generation/aws/restrict-availability-zones.sentinel
@@ -69,7 +69,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied[attribute] else "") not in allowed_values {
+      if r.applied[attribute] else "" not in allowed_values {
         print("Resource", address, "has attribute", attribute, "with value",
               r.applied[attribute] else "",
               "that is not in the allowed list:", allowed_values)
@@ -95,7 +95,10 @@ allowed_zones = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+zones_validated = validate_attribute_in_list("aws_instance", "availability_zone", allowed_zones)
+
+# Main rule
 main = rule {
-  validate_attribute_in_list("aws_instance", "availability_zone", allowed_zones)
+  zones_validated
 }

--- a/governance/second-generation/aws/restrict-db-instance-engines.sentinel
+++ b/governance/second-generation/aws/restrict-db-instance-engines.sentinel
@@ -68,7 +68,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied[attribute] else "") not in allowed_values {
+      if r.applied[attribute] else "" not in allowed_values {
         print("Resource", address, "has attribute", attribute, "with value",
               r.applied[attribute] else "",
               "that is not in the allowed list:", allowed_values)
@@ -91,7 +91,11 @@ allowed_engines = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+engines_validated = validate_attribute_in_list("aws_db_instance",
+                    "engine", allowed_engines)
+
+# Main rule
 main = rule {
-  validate_attribute_in_list("aws_db_instance", "engine", allowed_engines)
+  engines_validated
 }

--- a/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-ec2-instance-type.sentinel
@@ -68,7 +68,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied[attribute] else "") not in allowed_values {
+      if r.applied[attribute] else "" not in allowed_values {
         print("Resource", address, "has attribute", attribute, "with value",
               r.applied[attribute] else "",
               "that is not in the allowed list:", allowed_values)
@@ -92,7 +92,11 @@ allowed_types = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+instances_validated = validate_attribute_in_list("aws_instance",
+                      "instance_type", allowed_types)
+
+# Main rule
 main = rule {
-  validate_attribute_in_list("aws_instance", "instance_type", allowed_types)
+  instances_validated
 }

--- a/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/second-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -156,7 +156,7 @@ validate_cidr_blocks = func() {
 
 ##### Rules #####
 
-# Call the validation function and assign results
+# Call the validation function
 sgrs_validated = validate_cidr_blocks()
 
 # Main rule

--- a/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
+++ b/governance/second-generation/aws/restrict-launch-configuration-instance-type.sentinel
@@ -75,7 +75,7 @@ validate_instance_types = func(allowed_types) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied.instance_type else "") not in allowed_types {
+      if r.applied.instance_type else "" not in allowed_types {
         print("Launch configuration", address,
               "has attribute instance type with value", r.applied.instance_type,
               "that is not in the allowed list:", allowed_types)
@@ -100,7 +100,10 @@ allowed_types = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+lcs_validated = validate_instance_types(allowed_types)
+
+# Main rule
 main = rule {
-  validate_instance_types(allowed_types)
+  lcs_validated
 }

--- a/governance/second-generation/azure/enforce-mandatory-tags.sentinel
+++ b/governance/second-generation/azure/enforce-mandatory-tags.sentinel
@@ -119,7 +119,7 @@ mandatory_tags = [
 tags_validated = validate_attribute_contains_list("azurerm_virtual_machine",
                  "tags", mandatory_tags)
 
-#Main rule that evaluates results
+#Main rule
 main = rule {
   tags_validated
 }

--- a/governance/second-generation/azure/restrict-app-service-to-https.sentinel
+++ b/governance/second-generation/azure/restrict-app-service-to-https.sentinel
@@ -84,7 +84,11 @@ validate_attribute_has_value = func(type, attribute, value) {
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+app_services_validated = validate_attribute_has_value("azurerm_app_service",
+                         "https_only", true)
+
+# Main rule
 main = rule {
-  validate_attribute_has_value("azurerm_app_service", "https_only", true)
+  app_services_validated
 }

--- a/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
+++ b/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
@@ -81,7 +81,10 @@ allowed_publishers = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+publishers_validated = validate_publishers(allowed_publishers)
+
+# Main rule
 main = rule {
-  validate_publishers(allowed_publishers)
+  publishers_validated
 }

--- a/governance/second-generation/azure/restrict-vm-size.sentinel
+++ b/governance/second-generation/azure/restrict-vm-size.sentinel
@@ -68,7 +68,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied[attribute] else "") not in allowed_values {
+      if r.applied[attribute] else "" not in allowed_values {
         print("Resource", address, "has attribute", attribute, "with value",
               r.applied[attribute] else "",
               "that is not in the allowed list:", allowed_values)
@@ -92,7 +92,11 @@ allowed_sizes = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Calls the validation function
+vms_validated = validate_attribute_in_list("azurerm_virtual_machine",
+                "vm_size", allowed_sizes)
+
+# Main rule
 main = rule {
-  validate_attribute_in_list("azurerm_virtual_machine", "vm_size", allowed_sizes)
+  vms_validated
 }

--- a/governance/second-generation/cloud-agnostic/blacklist-datasources.sentinel
+++ b/governance/second-generation/cloud-agnostic/blacklist-datasources.sentinel
@@ -62,8 +62,10 @@ blacklist = [
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 datasources_validated = validate_datasources(blacklist)
+
+# Main rule
 main = rule {
   datasources_validated
 }

--- a/governance/second-generation/cloud-agnostic/blacklist-providers.sentinel
+++ b/governance/second-generation/cloud-agnostic/blacklist-providers.sentinel
@@ -44,8 +44,10 @@ blacklist = [
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 providers_validated = validate_providers(blacklist)
+
+# Main rule
 main = rule {
   providers_validated
 }

--- a/governance/second-generation/cloud-agnostic/blacklist-provisioners.sentinel
+++ b/governance/second-generation/cloud-agnostic/blacklist-provisioners.sentinel
@@ -76,8 +76,10 @@ blacklisted_provisioners = ["local-exec", "remote-exec"]
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 provisioners_validated = validate_provisioners(blacklisted_provisioners)
+
+# Main rule
 main = rule {
   provisioners_validated
 }

--- a/governance/second-generation/cloud-agnostic/blacklist-resources.sentinel
+++ b/governance/second-generation/cloud-agnostic/blacklist-resources.sentinel
@@ -63,7 +63,10 @@ blacklist = [
 
 ##### Rules #####
 
+# Call the validation function
+resources_validated = validate_resources(blacklist)
+
 # Main rule
 main = rule {
-  validate_resources(blacklist)
+  resources_validated
 }

--- a/governance/second-generation/cloud-agnostic/http-examples/check-external-http-api.sentinel
+++ b/governance/second-generation/cloud-agnostic/http-examples/check-external-http-api.sentinel
@@ -41,7 +41,11 @@ check_external_approval_system = func() {
 }
 
 ##### Rules #####
+
+# Call the validation function
 approved = check_external_approval_system()
+
+# Main rule
 main = rule {
   approved
 }

--- a/governance/second-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
+++ b/governance/second-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
@@ -124,8 +124,10 @@ validate_modules = func(public_registry, address, organization, token) {
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 modules_validated = validate_modules(public_registry, address, organization, token)
+
+# Main rule
 main = rule {
   modules_validated
 }

--- a/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-cost-by-workspace-type.sentinel
@@ -62,7 +62,11 @@ limits = {
 }
 
 ##### Rules #####
+
+# Call the validation function
 cost_validated = limit_cost_by_workspace_type(limits)
+
+# Main rule
 main = rule {
   cost_validated
 }

--- a/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
+++ b/governance/second-generation/cloud-agnostic/limit-proposed-monthly-cost.sentinel
@@ -40,7 +40,11 @@ limit_proposed_monthly_cost = func(limit) {
 limit = decimal.new(1000)
 
 ##### Rules #####
+
+# Call the validation function
 cost_validated = limit_proposed_monthly_cost(limit)
+
+# Main rule
 main = rule {
   cost_validated
 }

--- a/governance/second-generation/cloud-agnostic/prevent-destruction-of-blacklisted-resources.sentinel
+++ b/governance/second-generation/cloud-agnostic/prevent-destruction-of-blacklisted-resources.sentinel
@@ -68,8 +68,10 @@ blacklist = [
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 destroy_validated = validate_destroyed_resources(blacklist)
+
+# Main rule
 main = rule {
   destroy_validated
 }

--- a/governance/second-generation/cloud-agnostic/prevent-non-root-providers.sentinel
+++ b/governance/second-generation/cloud-agnostic/prevent-non-root-providers.sentinel
@@ -32,8 +32,10 @@ prevent_non_root_providers = func() {
 
 ##### Rules #####
 
-# Main rule
+# Call the validation function
 providers_validated = prevent_non_root_providers()
+
+# Main rule
 main = rule {
   providers_validated
 }

--- a/governance/second-generation/cloud-agnostic/prevent-remote-exec-provisioners-on-null-resources.sentinel
+++ b/governance/second-generation/cloud-agnostic/prevent-remote-exec-provisioners-on-null-resources.sentinel
@@ -64,7 +64,7 @@ validate_provisioners = func() {
 # Call the validation function
 no_remote_exec_on_null_resources = validate_provisioners()
 
-# Main rule that evaluates result
+# Main rule
 main = rule {
   no_remote_exec_on_null_resources
 }

--- a/governance/second-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
+++ b/governance/second-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
@@ -48,9 +48,11 @@ organization = "Cloud-Operations"
 
 ##### Rules #####
 
-# Main rule that requires other rules to be true
+# Call the validation functions
 no_resources_in_root_module = prevent_resources_in_root_module()
 all_non_root_modules_from_pmr = require_modules_from_pmr(address, organization)
+
+# Main rule
 main = rule {
   no_resources_in_root_module and all_non_root_modules_from_pmr
 }

--- a/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
+++ b/governance/second-generation/cloud-agnostic/restrict-cost-and-percentage-increase.sentinel
@@ -63,7 +63,11 @@ limit = decimal.new(1000)
 max_percent = decimal.new(10.0)
 
 ##### Rules #####
+
+# Call the validation function
 cost_validated = restrict_cost_and_percentage_increase(limit, max_percent)
+
+# Main rule
 main = rule {
   cost_validated
 }

--- a/governance/second-generation/cloud-agnostic/validate-all-variables-have-descriptions.sentinel
+++ b/governance/second-generation/cloud-agnostic/validate-all-variables-have-descriptions.sentinel
@@ -55,7 +55,11 @@ validate_variables_have_descriptions = func() {
 }
 
 ###### Rules ######
+
+# Call the validation function
 variables_validated = validate_variables_have_descriptions()
+
+# Main rule
 main = rule {
   variables_validated
 }

--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -115,7 +115,7 @@ mandatory_labels = [
 labels_validated = validate_attribute_contains_list("google_compute_instance",
                    "labels", mandatory_labels)
 
-#Main rule that evaluates results
+#Main rule
 main = rule {
   labels_validated
 }

--- a/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/second-generation/gcp/restrict-gce-machine-type.sentinel
@@ -68,7 +68,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
       # validated = false
     } else {
       # Validate that each instance has allowed value
-      if (r.applied[attribute] else "") not in allowed_values {
+      if r.applied[attribute] else "" not in allowed_values {
         print("Resource", address, "has attribute", attribute, "with value",
               r.applied[attribute] else "",
               "that is not in the allowed list:", allowed_values)
@@ -91,8 +91,10 @@ allowed_types = [
 
 ##### Rules #####
 
-# Main rule that calls the validation function and evaluates results
+# Call the validation function
+machines_validated = validate_attribute_in_list("google_compute_instance",
+                     "machine_type", allowed_types)
+# Main rule
 main = rule {
-  validate_attribute_in_list("google_compute_instance", "machine_type",
-                             allowed_types)
+  machines_validated
 }

--- a/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -91,7 +91,7 @@ validate_attribute_less_than_value = func(type, attribute, max_value) {
 
 ##### Rules #####
 
-# Call the validation function and assign results for both num_cpus and memory
+# Call the validation functions
 valid_cpu = validate_attribute_less_than_value("vsphere_virtual_machine", "num_cpus", 4)
 valid_memory = validate_attribute_less_than_value("vsphere_virtual_machine", "memory", 8192)
 

--- a/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
+++ b/governance/second-generation/vmware/restrict-vm-disk-size.sentinel
@@ -91,7 +91,7 @@ validate_disk_size = func(disk_limit) {
 
 ##### Rules #####
 
-# Call the validation function and assign results
+# Call the validation function
 vm_disks_validated = validate_disk_size(100)
 
 # Main rule


### PR DESCRIPTION
I standardized all second generation Sentinel policies to call their validation functions before the main rule to reduce default Sentinel logging.  I also standardized the comments.

Additionally, I changed `if (r.applied[attribute] else "") not in allowed_values` to `if r.applied[attribute] else "" not in allowed_values`, removing the parentheses which I had been forced to add to work around a Sentinel bug that was fixed a long time ago in all policies that had that.