### PR TITLE
Add enforce ami owners

### DIFF
--- a/governance/second-generation/aws/restrict-ami-owners.sentinel
+++ b/governance/second-generation/aws/restrict-ami-owners.sentinel
@@ -1,0 +1,89 @@
+# This policy uses the Sentinel tfstate import to restrict the owners set on
+# all instances of the aws_ami data source in all modules
+
+##### Imports #####
+import "tfstate"
+import "types"
+import "strings"
+
+##### Functions #####
+
+# Find all data sources of a specific type from all modules using the
+# tfstate import
+find_datasources_from_state = func(type) {
+
+  datasources = {}
+
+  # Iterate over all modules in the tfstate import
+  for tfstate.module_paths else [] as path {
+    # Iterate over the named datasources of desired type in the module
+    for tfstate.module(path).data[type] else {} as name, instances {
+      # Iterate over datasource instances
+      for instances as index, d {
+
+        # Get the address of the instance
+        if length(path) == 0 {
+          # root module
+          address = type + "." + name + "[" + string(index) + "]"
+        } else {
+          # non-root module
+          address = "module." + strings.join(path, ".module.") + "." +
+                    type + "." + name + "[" + string(index) + "]"
+        }
+
+        # Add the instance to datasources map, setting the key to the address
+        datasources[address] = d
+      }
+    }
+  }
+
+  return datasources
+}
+
+# Validate that owners of AMIs are in allowed list
+validate_ami_owners = func(allowed_list) {
+
+	validated = true
+
+	# Initialize empty map of owners of AMIs
+	owners = {}
+
+	# Get all AWS AMI data sources from tfconfig
+	aws_amis = find_datasources_from_state("aws_ami")
+
+	# Iterate through all AMIs
+	for aws_amis as address, d {
+		# Process config
+    if types.type_of(d.attr.owners else null) is "list" {
+			# Iterate over items in the owners list
+			for d.attr.owners as owner {
+        if owner not in allowed_list {
+          print("AMI", address, "has owner", owner,
+                "that is not in the allowed list:", allowed_list)
+          validated = false
+        } // end owner check
+			} // end for owners
+		} // end check that d.attr.owners is list
+
+	} // end for AMIs
+
+	return validated
+}
+
+
+##### Allowed Owners $$$$$
+allowed_owners = [
+  "self",
+  "099720109477",
+  "099720109478",
+]
+
+##### Rules #####
+
+# Call the validation function
+ami_owners_validated = validate_ami_owners(allowed_owners)
+
+# Main Rule
+main = rule {
+	ami_owners_validated
+}

--- a/governance/second-generation/aws/test/restrict-ami-owners/fail-0.11.json
+++ b/governance/second-generation/aws/test/restrict-ami-owners/fail-0.11.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfstate": "mock-tfstate-fail-0.11.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/restrict-ami-owners/fail-0.12.json
+++ b/governance/second-generation/aws/test/restrict-ami-owners/fail-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfstate": "mock-tfstate-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-fail-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-fail-0.11.sentinel
@@ -1,0 +1,399 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109475",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs":   {},
+		"path":      [],
+		"resources": {},
+	},
+
+	"module.more-amis-1": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109468",
+								"099720109469",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-1",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-2": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109477",
+								"099720109479",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-2",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-3": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109477",
+								"099720109480",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-3",
+		],
+		"resources": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"more-amis-1",
+	],
+	[
+		"more-amis-2",
+	],
+	[
+		"more-amis-3",
+	],
+]
+
+terraform_version = "0.11.14"
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+outputs = _modules.root.outputs
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-fail-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-fail-0.12.sentinel
@@ -1,0 +1,420 @@
+import "strings"
+import "types"
+
+outputs = {}
+
+_modules = {
+	"root": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109476",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path":      [],
+		"resources": {},
+	},
+
+	"module.more-amis-1": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109477",
+								"099720109478",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-1",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-2": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109476",
+								"099720109478",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-2",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-3": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109455",
+								"099720109456",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-3",
+		],
+		"resources": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"more-amis-1",
+	],
+	[
+		"more-amis-2",
+	],
+	[
+		"more-amis-3",
+	],
+]
+
+terraform_version = "0.12.18"
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-pass-0.11.sentinel
+++ b/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-pass-0.11.sentinel
@@ -1,0 +1,399 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109477",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs":   {},
+		"path":      [],
+		"resources": {},
+	},
+
+	"module.more-amis-1": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109477",
+								"099720109478",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-1",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-2": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"099720109477",
+								"self",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-2",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-3": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": true,
+										"encrypted":             false,
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date": "2019-11-11T13:12:33.000Z",
+							"description":   "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"filter": [
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+							],
+							"hypervisor":     "xen",
+							"id":             "ami-000b3a073fc20e415",
+							"image_id":       "ami-000b3a073fc20e415",
+							"image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_type":     "machine",
+							"most_recent":    true,
+							"name":           "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"owner_id":       "099720109477",
+							"owners": [
+								"self",
+								"099720109478",
+							],
+							"product_codes":     [],
+							"public":            true,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"outputs": {},
+		"path": [
+			"more-amis-3",
+		],
+		"resources": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"more-amis-1",
+	],
+	[
+		"more-amis-2",
+	],
+	[
+		"more-amis-3",
+	],
+]
+
+terraform_version = "0.11.14"
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+outputs = _modules.root.outputs
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-pass-0.12.sentinel
+++ b/governance/second-generation/aws/test/restrict-ami-owners/mock-tfstate-pass-0.12.sentinel
@@ -1,0 +1,420 @@
+import "strings"
+import "types"
+
+outputs = {}
+
+_modules = {
+	"root": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109477",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path":      [],
+		"resources": {},
+	},
+
+	"module.more-amis-1": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109477",
+								"099720109478",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-1",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-2": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"self",
+								"099720109478",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-2",
+		],
+		"resources": {},
+	},
+
+	"module.more-amis-3": {
+		"data": {
+			"aws_ami": {
+				"ubuntu": {
+					0: {
+						"attr": {
+							"architecture": "x86_64",
+							"block_device_mappings": [
+								{
+									"device_name": "/dev/sda1",
+									"ebs": {
+										"delete_on_termination": "true",
+										"encrypted":             "false",
+										"iops":                  "0",
+										"snapshot_id":           "snap-0d0c75281cdaf5fe5",
+										"volume_size":           "8",
+										"volume_type":           "gp2",
+									},
+									"no_device":    "",
+									"virtual_name": "",
+								},
+								{
+									"device_name":  "/dev/sdb",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral0",
+								},
+								{
+									"device_name":  "/dev/sdc",
+									"ebs":          {},
+									"no_device":    "",
+									"virtual_name": "ephemeral1",
+								},
+							],
+							"creation_date":    "2019-11-11T13:12:33.000Z",
+							"description":      "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image build on 2019-11-07",
+							"executable_users": null,
+							"filter": [
+								{
+									"name": "name",
+									"values": [
+										"ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+									],
+								},
+								{
+									"name": "virtualization-type",
+									"values": [
+										"hvm",
+									],
+								},
+							],
+							"hypervisor":        "xen",
+							"id":                "ami-000b3a073fc20e415",
+							"image_id":          "ami-000b3a073fc20e415",
+							"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"image_owner_alias": null,
+							"image_type":        "machine",
+							"kernel_id":         null,
+							"most_recent":       true,
+							"name":              "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20191107",
+							"name_regex":        null,
+							"owner_id":          "099720109477",
+							"owners": [
+								"099720109477",
+								"self",
+							],
+							"platform":          null,
+							"product_codes":     [],
+							"public":            true,
+							"ramdisk_id":        null,
+							"root_device_name":  "/dev/sda1",
+							"root_device_type":  "ebs",
+							"root_snapshot_id":  "snap-0d0c75281cdaf5fe5",
+							"sriov_net_support": "simple",
+							"state":             "available",
+							"state_reason": {
+								"code":    "UNSET",
+								"message": "UNSET",
+							},
+							"tags":                {},
+							"virtualization_type": "hvm",
+						},
+						"depends_on": [],
+						"id":         "ami-000b3a073fc20e415",
+						"tainted":    false,
+					},
+				},
+			},
+		},
+		"path": [
+			"more-amis-3",
+		],
+		"resources": {},
+	},
+}
+
+module_paths = [
+	[],
+	[
+		"more-amis-1",
+	],
+	[
+		"more-amis-2",
+	],
+	[
+		"more-amis-3",
+	],
+]
+
+terraform_version = "0.12.18"
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/aws/test/restrict-ami-owners/pass-0.11.json
+++ b/governance/second-generation/aws/test/restrict-ami-owners/pass-0.11.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfstate": "mock-tfstate-pass-0.11.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/aws/test/restrict-ami-owners/pass-0.12.json
+++ b/governance/second-generation/aws/test/restrict-ami-owners/pass-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfstate": "mock-tfstate-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
+++ b/governance/second-generation/azure/restrict-publishers-of-current-vms.sentinel
@@ -15,7 +15,7 @@ find_resources_from_state = func(type) {
   resources = {}
 
   # Iterate over all modules in the tfstate import
-  for tfstate.module_paths as path {
+  for tfstate.module_paths else [] as path {
     # Iterate over the named resources of desired type in the module
     for tfstate.module(path).resources[type] else {} as name, instances {
       # Iterate over resource instances

--- a/governance/second-generation/common-functions/state/find_datasources_from_state.md
+++ b/governance/second-generation/common-functions/state/find_datasources_from_state.md
@@ -41,4 +41,4 @@ find_datasources_from_state("google_compute_image")
 
 find_datasources_from_state("vsphere_datastore")
 ```
-You can see this function being used in context in the policy [blacklist-dataources](../../cloud-agnostic/blacklist-dataources.sentinel).
+You can see this function being used in context in the policies [blacklist-datasources](../../cloud-agnostic/blacklist-dataources.sentinel) and [restrict-ami-owners](../../aws/restrict-ami-owners.sentinel).

--- a/governance/second-generation/common-functions/state/find_datasources_from_state.sentinel
+++ b/governance/second-generation/common-functions/state/find_datasources_from_state.sentinel
@@ -1,10 +1,11 @@
-# Find all data sources of a specific type from all modules using the tfstate import
+# Find all data sources of a specific type from all modules using the
+# tfstate import
 find_datasources_from_state = func(type) {
 
   datasources = {}
 
   # Iterate over all modules in the tfstate import
-  for tfstate.module_paths as path {
+  for tfstate.module_paths else [] as path {
     # Iterate over the named datasources of desired type in the module
     for tfstate.module(path).data[type] else {} as name, instances {
       # Iterate over datasource instances

--- a/governance/second-generation/common-functions/state/find_resources_from_state.sentinel
+++ b/governance/second-generation/common-functions/state/find_resources_from_state.sentinel
@@ -4,7 +4,7 @@ find_resources_from_state = func(type) {
   resources = {}
 
   # Iterate over all modules in the tfstate import
-  for tfstate.module_paths as path {
+  for tfstate.module_paths else [] as path {
     # Iterate over the named resources of desired type in the module
     for tfstate.module(path).resources[type] else {} as name, instances {
       # Iterate over resource instances


### PR DESCRIPTION
This adds a second generation version of the first-generation policy enforce-ami-owners.sentinel, but I have called it restrict-ami-owners.sentinel to better align with naming of other policies.

It restricts all instances of the aws_ami data source to have owners in a specified list.

I have also updated the find_datasources_from_state and find_resources_from_state functions to use `for tfstate.module_paths else [] as path` to handle the case that the current state is empty.