### PR TITLE
Make labels consistent

### DIFF
--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -1,7 +1,7 @@
 # This policy uses the Sentinel tfplan import to require that all GCP compute
-# instances have all mandatory tags.
+# instances have all mandatory labelsMake.
 
-# Note that the comparison is case-sensitive but also that Google network tags
+# Note that the comparison is case-sensitive but also that GCP labels
 # are only allowed to contain lowercase letters, numbers, and dashes.
 
 ##### Imports #####

--- a/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/second-generation/gcp/enforce-mandatory-labels.sentinel
@@ -1,8 +1,8 @@
 # This policy uses the Sentinel tfplan import to require that all GCP compute
-# instances have all mandatory labelsMake.
+# instances have all mandatory labels.
 
 # Note that the comparison is case-sensitive but also that GCP labels
-# are only allowed to contain lowercase letters, numbers, and dashes.
+# are only allowed to contain lowercase letters, numbers, hypens, and underscores.
 
 ##### Imports #####
 


### PR DESCRIPTION
Google's arbitrary key/value pairs attached to resources are called labels.  Let's not use the word tags in this Sentinel policy because it could be confusing to users. In GCP land, tags are a list of regexes for enabling firewall rules.