### PR TITLE
add whitelist-resources.sentinel policy

### DIFF
--- a/governance/second-generation/cloud-agnostic/test/whitelist-resources/fail-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/whitelist-resources/fail-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-fail-0.12.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/second-generation/cloud-agnostic/test/whitelist-resources/mock-tfplan-fail-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/whitelist-resources/mock-tfplan-fail-0.12.sentinel
@@ -1,0 +1,452 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_subnet": {
+				"sentinel_demo_subnet": {
+					0: {
+						"applied": {
+							"assign_ipv6_address_on_creation": false,
+							"availability_zone":               "eu-west-2a",
+							"cidr_block":                      "10.1.1.0/24",
+							"map_public_ip_on_launch":         true,
+							"tags": {
+								"Name":  "sentinel-demo",
+								"owner": "Hashicorp",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"assign_ipv6_address_on_creation": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "eu-west-2a",
+								"old":      "",
+							},
+							"availability_zone_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cidr_block": {
+								"computed": false,
+								"new":      "10.1.1.0/24",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block_association_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"map_public_ip_on_launch": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "sentinel-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Hashicorp",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+					1: {
+						"applied": {
+							"assign_ipv6_address_on_creation": false,
+							"availability_zone":               "eu-west-2b",
+							"cidr_block":                      "10.1.2.0/24",
+							"map_public_ip_on_launch":         true,
+							"tags": {
+								"Name":  "sentinel-demo",
+								"owner": "Hashicorp",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"assign_ipv6_address_on_creation": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "eu-west-2b",
+								"old":      "",
+							},
+							"availability_zone_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cidr_block": {
+								"computed": false,
+								"new":      "10.1.2.0/24",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block_association_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"map_public_ip_on_launch": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "sentinel-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Hashicorp",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+					2: {
+						"applied": {
+							"assign_ipv6_address_on_creation": false,
+							"availability_zone":               "eu-west-2c",
+							"cidr_block":                      "10.1.3.0/24",
+							"map_public_ip_on_launch":         true,
+							"tags": {
+								"Name":  "sentinel-demo",
+								"owner": "Hashicorp",
+							},
+							"timeouts": null,
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"assign_ipv6_address_on_creation": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": false,
+								"new":      "eu-west-2c",
+								"old":      "",
+							},
+							"availability_zone_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cidr_block": {
+								"computed": false,
+								"new":      "10.1.3.0/24",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block_association_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"map_public_ip_on_launch": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "sentinel-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Hashicorp",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+			"aws_vpc": {
+				"sentinel_demo_vpc": {
+					0: {
+						"applied": {
+							"assign_generated_ipv6_cidr_block": false,
+							"cidr_block":                       "10.1.0.0/16",
+							"enable_dns_hostnames":             true,
+							"enable_dns_support":               true,
+							"instance_tenancy":                 "default",
+							"tags": {
+								"Name":  "sentinel-demo",
+								"owner": "Hashicorp",
+							},
+						},
+						"destroy": false,
+						"diff": {
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"assign_generated_ipv6_cidr_block": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"cidr_block": {
+								"computed": false,
+								"new":      "10.1.0.0/16",
+								"old":      "",
+							},
+							"default_network_acl_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"default_route_table_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"default_security_group_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"dhcp_options_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"enable_classiclink": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"enable_classiclink_dns_support": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"enable_dns_hostnames": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"enable_dns_support": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_tenancy": {
+								"computed": false,
+								"new":      "default",
+								"old":      "",
+							},
+							"ipv6_association_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_cidr_block": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"main_route_table_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"owner_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "sentinel-demo",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Hashicorp",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.9"
+
+variables = {
+	"cidr_blocks": [
+		"10.1.1.0/24",
+		"10.1.2.0/24",
+		"10.1.3.0/24",
+	],
+	"namespace":      "sentinel-demo",
+	"owner":          "Hashicorp",
+	"region":         "eu-west-2",
+	"vpc_cidr_block": "10.1.0.0/16",
+}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/whitelist-resources/mock-tfplan-pass-0.12.sentinel
+++ b/governance/second-generation/cloud-agnostic/test/whitelist-resources/mock-tfplan-pass-0.12.sentinel
@@ -1,0 +1,291 @@
+import "strings"
+import "types"
+
+_modules = {
+	"root": {
+		"data": {},
+		"path": [],
+		"resources": {
+			"aws_instance": {
+				"web": {
+					0: {
+						"applied": {
+							"ami": "ami-082f73b60cd9b99b2",
+							"credit_specification":                 [],
+							"disable_api_termination":              null,
+							"ebs_optimized":                        null,
+							"get_password_data":                    false,
+							"iam_instance_profile":                 null,
+							"instance_initiated_shutdown_behavior": null,
+							"instance_type":                        "t2.micro",
+							"monitoring":                           null,
+							"source_dest_check":                    true,
+							"subnet_id":                            "subnet-09dcab94a220f8c16",
+							"tags": {
+								"Name":  "test_server",
+								"owner": "Hashicorp",
+							},
+							"timeouts":         null,
+							"user_data":        null,
+							"user_data_base64": null,
+						},
+						"destroy": false,
+						"diff": {
+							"ami": {
+								"computed": false,
+								"new":      "ami-082f73b60cd9b99b2",
+								"old":      "",
+							},
+							"arn": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"associate_public_ip_address": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"availability_zone": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_core_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"cpu_threads_per_core": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"credit_specification.#": {
+								"computed": false,
+								"new":      "0",
+								"old":      "",
+							},
+							"disable_api_termination": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ebs_optimized": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"ephemeral_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"get_password_data": {
+								"computed": false,
+								"new":      "false",
+								"old":      "",
+							},
+							"host_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"iam_instance_profile": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_initiated_shutdown_behavior": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_state": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"instance_type": {
+								"computed": false,
+								"new":      "t2.micro",
+								"old":      "",
+							},
+							"ipv6_address_count": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"ipv6_addresses.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"key_name": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"monitoring": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"password_data": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"placement_group": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"primary_network_interface_id": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"private_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_dns": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"public_ip": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"root_block_device.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"security_groups.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"source_dest_check": {
+								"computed": false,
+								"new":      "true",
+								"old":      "",
+							},
+							"subnet_id": {
+								"computed": false,
+								"new":      "subnet-09dcab94a220f8c16",
+								"old":      "",
+							},
+							"tags.%": {
+								"computed": false,
+								"new":      "2",
+								"old":      "",
+							},
+							"tags.Name": {
+								"computed": false,
+								"new":      "test_server",
+								"old":      "",
+							},
+							"tags.owner": {
+								"computed": false,
+								"new":      "Hashicorp",
+								"old":      "",
+							},
+							"tenancy": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"timeouts": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"user_data_base64": {
+								"computed": false,
+								"new":      "",
+								"old":      "",
+							},
+							"volume_tags.%": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+							"vpc_security_group_ids.#": {
+								"computed": true,
+								"new":      "",
+								"old":      "",
+							},
+						},
+						"requires_new": false,
+					},
+				},
+			},
+		},
+	},
+}
+
+module_paths = [
+	[],
+]
+
+terraform_version = "0.12.9"
+
+variables = {}
+
+module = func(path) {
+	if types.type_of(path) is not "list" {
+		error("expected list, got", types.type_of(path))
+	}
+
+	if length(path) < 1 {
+		return _modules.root
+	}
+
+	addr = []
+	for path as p {
+		append(addr, "module")
+		append(addr, p)
+	}
+
+	return _modules[strings.join(addr, ".")]
+}
+
+data = _modules.root.data
+path = _modules.root.path
+resources = _modules.root.resources

--- a/governance/second-generation/cloud-agnostic/test/whitelist-resources/pass-0.12.json
+++ b/governance/second-generation/cloud-agnostic/test/whitelist-resources/pass-0.12.json
@@ -1,0 +1,8 @@
+{
+  "mock": {
+    "tfplan": "mock-tfplan-pass-0.12.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/second-generation/cloud-agnostic/whitelist-resources.sentinel
+++ b/governance/second-generation/cloud-agnostic/whitelist-resources.sentinel
@@ -1,0 +1,58 @@
+# This policy prevents any changes to resources that are not whitelisted
+
+##### Imports #####
+
+import "tfplan"
+
+##### Functions #####
+
+# Find all resource types from all modules using the tfplan import
+find_resource_types_from_plan = func() {
+
+  types = []
+
+  # Iterate over all modules in the tfplan import
+  for tfplan.module_paths as path {
+    # Find all types of resources used in the module
+    for tfplan.module(path).resources else {} as type {
+        #print("type is:", type)
+        # Add the type to the types list
+        append(types, type)
+    }
+  }
+
+  return types
+}
+
+# Validate that whitelisted resources are not present
+validate_resources = func(whitelist) {
+  valid = true
+
+  found_types = find_resource_types_from_plan()
+
+  for found_types as type {
+    if type not in whitelist {
+      print("Type", type, "is not in the resources whitelist", whitelist)
+      valid = false
+    }
+  }
+  return valid
+}
+
+##### Lists #####
+
+# List of whitelisted resources
+whitelist = [
+  "aws_vpc",
+  "aws_instance",
+]
+
+##### Rules #####
+
+# Call the validation function
+resources_validated = validate_resources(whitelist)
+
+# Main rule
+main = rule {
+  resources_validated
+}

--- a/governance/second-generation/common-functions/plan/find_resource_types_from_plan.md
+++ b/governance/second-generation/common-functions/plan/find_resource_types_from_plan.md
@@ -1,0 +1,37 @@
+# find_resource_types_from_plan
+This function finds all resource types from all modules using the [tfplan](https://www.terraform.io/docs/enterprise/sentinel/import/tfplan.html) import.
+
+## Scope
+Terraform plans
+
+## Declaration
+`find_resource_types_from_plan = func()`
+
+## Arguments
+* None
+
+## Required Imports
+This function requires the following imports:
+```
+import "tfplan"
+```
+Be sure to include it in any policy that uses this function.
+
+## Custom Functions Used
+None
+
+## What It Returns
+This function returns a single list of all resource types used within the plan.
+
+## What It Prints
+This function does not print anything.
+
+## Code
+The Sentinel code for this function is in [find_resource_types_from_plan.sentinel](./find_resource_types_from_plan.sentinel).
+
+## Examples
+Here is an example of using this function:
+```
+find_resource_types_from_plan()
+```
+You can see this function being used in context in the policy [whitelist_resources](../../cloud-agnostic/whitelist-resources.sentinel)in this repository.

--- a/governance/second-generation/common-functions/plan/find_resource_types_from_plan.sentinel
+++ b/governance/second-generation/common-functions/plan/find_resource_types_from_plan.sentinel
@@ -1,0 +1,17 @@
+# Find all resource types from all modules using the tfplan import
+find_resource_types_from_plan = func() {
+
+  types = []
+
+  # Iterate over all modules in the tfplan import
+  for tfplan.module_paths as path {
+    # Find all types of resources used in the module
+    for tfplan.module(path).resources else {} as type {
+        #print("type is:", type)
+        # Add the type to the types list
+        append(types, type)
+    }
+  }
+
+  return types
+}


### PR DESCRIPTION
This adds a whitelist-resources.sentinel policy that only allows resources from the given whitelist to be provisioned.