### PR TITLE
support multiple source_ranges

### DIFF
--- a/governance/first-generation/gcp/block-allow-all-cidr.sentinel
+++ b/governance/first-generation/gcp/block-allow-all-cidr.sentinel
@@ -15,11 +15,14 @@ disallowed_cidr_block = "0.0.0.0/0"
 block_allow_all = rule {
   all firewalls as _, instances {
     all instances as _, fw {
-      disallowed_cidr_block not in fw.applied.source_ranges[0]
+      length(fw.applied.source_ranges else []) > 0 and
+      all fw.applied.source_ranges as sr {
+      	print("source range:", sr) and disallowed_cidr_block not in sr
+      }
     }
   }
 }
 
 main = rule {
   (block_allow_all) else true
- }
+}


### PR DESCRIPTION
Fix first-generation Sentinel policy for GCP: block-allow-all-cidr.sentinel to support multiple ranges in source_ranges and to check that source_ranges actually exists (and has length > 0)