### PR TITLE
change names of custom imports and use aliases

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -28,10 +28,10 @@ These new third-generation policies have several important characteristics:
 ## Common Functions
 You can find all of the functions used in the third-generation policies in the Sentinel modules in the [common functions](./common-functions) directory. Currently, there is only one module.
 
-Unlike the second-generation common functions that were each defined in a separate file, all of the common functions that use the tfplan/v2 import are defined in the single file, [tfplan-functions.sentinel](./common-functions/tfplan-functions.sentinel). This makse it easier to import all of these functions into the Sentinel CLI test cases, since those only need a single stanza such as this one:
+Unlike the second-generation common functions that were each defined in a separate file, all of the common functions that use the tfplan/v2 import are defined in the single file, [tfplan-functions.sentinel](./common-functions/tfplan-functions.sentinel). This makes it easier to import all of these functions into the Sentinel CLI test cases, since those only need a single stanza such as this one:
 ```
 "modules": {
-  "plan": {
+  "tfplan-functions": {
     "path": "../../../common-functions/tfplan-functions.sentinel"
   }
 }
@@ -39,11 +39,11 @@ Unlike the second-generation common functions that were each defined in a separa
 
 While having multiple functions in a single file and module does make examining the function code a bit harder, we think the reduced work associated with referencing the functions in the test cases justifies this.
 
-
 To use any of the functions in a new policy, be sure to include a line like this one:
 ```
-import "tfplan/v2" as tfplan
+import "tfplan-functions" as plan
 ```
+In this case, we are using "plan" as an alias for the "tfplan-functions" import to keep lines that use it shorter. You can use something different from "plan" as long as it is not the name of an existing import and is not a Sentinel keyword.
 
 ## Mock Files and Test Cases
 Sentinel [mock files](https://www.terraform.io/docs/enterprise/sentinel/mock.html) and [test cases](https://docs.hashicorp.com/sentinel/commands/config#test-cases) have been provided under the test directory of each cloud so that all the policies can be tested with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands). The mocks were generated from actual Terraform 0.12 plans run against Terraform code that provisioned resources in these clouds. The pass and fail mock files were edited to respectively pass and fail the associated Sentinel policies. Some policies, including those that have multiple rules, have multiple fail mock files with names that indicate which condition or conditions they fail.

--- a/governance/third-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/third-generation/aws/enforce-mandatory-tags.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 ### List of mandatory tags ###
 mandatory_tags = [

--- a/governance/third-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
+++ b/governance/third-generation/aws/require-private-acl-and-kms-for-s3-buckets.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 # Get all S3 buckets
 allS3Buckets = plan.find_resources("aws_s3_bucket")

--- a/governance/third-generation/aws/restrict-current-ec2-instance-type.sentinel
+++ b/governance/third-generation/aws/restrict-current-ec2-instance-type.sentinel
@@ -5,7 +5,7 @@
 import "tfstate/v2" as tfstate
 
 # Import common-functions/tfstate-functions.sentinel with alias "state"
-import "state"
+import "tfstate-functions" as state
 
 # Allowed EC2 Instance Types
 # Include null to allow computed values

--- a/governance/third-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/third-generation/aws/restrict-ec2-instance-type.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 # Allowed EC2 Instance Types
 # Include null to allow computed values

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/fail.json
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/fail.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/pass.json
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-acl-and-kms.json
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-acl-and-kms.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-kms.json
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-kms.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-no-ssec.json
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/fail-no-ssec.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/pass.json
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/restrict-current-ec2-instance-type/fail.json
+++ b/governance/third-generation/aws/test/restrict-current-ec2-instance-type/fail.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "state": {
+    "tfstate-functions": {
       "path": "../../../common-functions/tfstate-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/restrict-current-ec2-instance-type/pass.json
+++ b/governance/third-generation/aws/test/restrict-current-ec2-instance-type/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "state": {
+    "tfstate-functions": {
       "path": "../../../common-functions/tfstate-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/restrict-ec2-instance-type/fail.json
+++ b/governance/third-generation/aws/test/restrict-ec2-instance-type/fail.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/aws/test/restrict-ec2-instance-type/pass.json
+++ b/governance/third-generation/aws/test/restrict-ec2-instance-type/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/azure/restrict-vm-size.sentinel
+++ b/governance/third-generation/azure/restrict-vm-size.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 # Allowed Azure VM Sizes
 # Include null to allow computed values

--- a/governance/third-generation/azure/test/restrict-vm-size/fail.json
+++ b/governance/third-generation/azure/test/restrict-vm-size/fail.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/azure/test/restrict-vm-size/pass.json
+++ b/governance/third-generation/azure/test/restrict-vm-size/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/third-generation/gcp/restrict-gce-machine-type.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 # Allowed GCE Instance Types
 # Include null to allow computed values

--- a/governance/third-generation/gcp/test/restrict-gce-machine-type/fail.json
+++ b/governance/third-generation/gcp/test/restrict-gce-machine-type/fail.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/gcp/test/restrict-gce-machine-type/pass.json
+++ b/governance/third-generation/gcp/test/restrict-gce-machine-type/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/vmware/restrict-vm-cpu-and-memory.sentinel
+++ b/governance/third-generation/vmware/restrict-vm-cpu-and-memory.sentinel
@@ -5,7 +5,7 @@
 import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions.sentinel with alias "plan"
-import "plan"
+import "tfplan-functions" as plan
 
 # Get all VMs
 allVMs = plan.find_resources("vsphere_virtual_machine")

--- a/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-cpu-and-memory.json
+++ b/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-cpu-and-memory.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-cpu.json
+++ b/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-cpu.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-memory.json
+++ b/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/fail-memory.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },

--- a/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/pass.json
+++ b/governance/third-generation/vmware/test/restrict-vm-cpu-and-memory/pass.json
@@ -1,6 +1,6 @@
 {
   "modules": {
-    "plan": {
+    "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions.sentinel"
     }
   },


### PR DESCRIPTION
I decided to change the names of the custom Sentinel imports as defined in the test case files to match the names of the files containing them (without the .sentinel extension).

I then use import aliases to get back to using the short names like "plan" and "state".

So, the import statements look like this:
```
import "tfplan-functions" as plan
```
or
```
import "tfstate-functions" as state
```

This should avoid possible confusion with the tfplan/v2 and tfstate/v2 imports and also make clear what sentinel import file contains the functions of the import.

But it still keeps lines that use the custom functions short.