### PR TITLE
use load_config_file = false in k8s provider

### DIFF
--- a/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
+++ b/infrastructure-as-code/k8s-cluster-openshift-aws/README.md
@@ -1,6 +1,8 @@
 # Openshift Cluster in AWS
 This guide provisions an OpenShift Origin 3.11 cluster in AWS with 1 master node, 1 client node, and 1 bastion host. It uses Terraform's [AWS Provider](https://www.terraform.io/docs/providers/aws/index.html) to provision AWS infrastructure. It then uses ansible-playbook to deploy OpenShift to the master and client nodes from the bastion host after using Terraform to provision the AWS infrastructure. It is based on a [terraform-aws-openshift](https://github.com/dwmkerr/terraform-aws-openshift) repository created by Dave Kerr.
 
+It was written for use with Terraform 0.11.x.
+
 While the original repository required the user to manually run ansible-playbook after provisioning the AWS infrastructure with Terraform, this guide uses a Terraform [remote-exec provisioner](https://www.terraform.io/docs/provisioners/remote-exec.html) to do that. It also uses several additional remote-exec and local-exec provisioners to automate the rest of the deployment, retrieve the OpenShift cluster keys, and write them to outputs. This is important since it allows workspaces that deploy pods and services to the cluster do that via workspace state sharing without any manual copying of the cluster keys.
 
 ## Reference Material
@@ -30,6 +32,7 @@ Note that this guide is intended for demo and development usage. You would proba
 1. Sign up for a free [AWS](https://aws.amazon.com/free/) account.
 1. Create AWS access keys for your account. See the [Managing Access Keys for Your AWS Account](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html).
 1. Create an AWS key pair for your AWS account. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+1. Use a Vault server with version 1.2 or higher.
 
 ## Steps
 Execute the following commands to deploy your OpenShift cluster to AWS.

--- a/self-serve-infrastructure/k8s-services-openshift/main.tf
+++ b/self-serve-infrastructure/k8s-services-openshift/main.tf
@@ -10,6 +10,7 @@ data "terraform_remote_state" "k8s_cluster" {
 }
 
 provider "kubernetes" {
+  load_config_file = false
   host = "${data.terraform_remote_state.k8s_cluster.k8s_endpoint}"
   client_certificate = "${base64decode(data.terraform_remote_state.k8s_cluster.k8s_master_auth_client_certificate)}"
   client_key = "${base64decode(data.terraform_remote_state.k8s_cluster.k8s_master_auth_client_key)}"


### PR DESCRIPTION
Kubernetes provider 1.11.x and higher now need `load_config_file = false` in the kubernetes provider block if using statically defined credentials.  See https://www.terraform.io/docs/providers/kubernetes/index.html#statically-defined-credentials

Additionallly It turned out that the change @kawsark  had made in commit f0c78c2 required using Vault server 1.2 or higher.  So, I updated relevant README.md files to say that.