### PR TITLE
added aws-functions module to aws policy set

### DIFF
--- a/governance/third-generation/aws/sentinel.hcl
+++ b/governance/third-generation/aws/sentinel.hcl
@@ -10,6 +10,10 @@ module "tfconfig-functions" {
     source = "../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
 }
 
+module "aws-functions" {
+    source = "./aws-functions/aws-functions.sentinel"
+}
+
 policy "enforce-mandatory-tags" {
     enforcement_level = "advisory"
 }


### PR DESCRIPTION
I had forgotten to add the aws-functions Sentinel module to the sentinel.hcl policy set file under the aws directory.