### PR TITLE
add some more common functions

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -68,7 +68,8 @@ In this case, we are using `plan`, `state`, `config`, `run`, and `aws` as aliase
 We discuss these two modules together because they are essentially identical except for their use of the tfplan/v2 and tfstate/v2 imports.
 
 Each of these modules has several types of functions:
-  * `find_resources` and `find_datasources` functions that find resources or data sources of a specific type that are being created or updated. Note that the tfplan versions of these functions only find resources that are being created or changed and data sources that are being created, changed, or read.
+  * `find_resources` and `find_datasources` functions that find resources or data sources of a specific type. Note that the tfplan versions of these functions only find resources that are being created or changed and data sources that are being created, changed, or read.
+  * `find_resources_by_provider` and `find_datasources_by_provider` functions that find resources or data sources for a specific provider. Note that the tfplan versions of these functions only find resources that are being created or changed and data sources that are being created, changed, or read.
   * `find_resources_being_destroyed` and `find_datasources_being_destroyed` function that find resources or data sources that are being destroyed but not re-created.
   * The `find_blocks` function finds all blocks of a specific type in a single resource.
   * `filter_*` functions that filter a collection of resources, data sources, or blocks to a sub-collection that violates some condition. (When we say resources below, we are including data sources which are really just read-only resources.) The filter functions all accept a collection of resource changes (for tfplan/v2) or resources (for tfstate/v2), an attribute, a value or a list of values, and a boolean, `prtmsg`, which can be `true` or `false` and indicates whether the filter function should print violation messages. The filter functions return a map consisting of 2 items:
@@ -108,6 +109,7 @@ Documentation for each individual function can be found in this directory:
 
 ### The Functions of the aws-functions Module
 The `aws-functions` module (which is located under in the aws/aws-functions directory) has the following functions:
+  * The `find_resources_with_standard_tags` function finds all AWS resources that use standard AWS tags in the current plan that are being created or modified.
   * The `determine_role_arn` function determines the ARN of a role set in the `role_arn` parameter of an AWS provider. It can only determine the role_arn if it is set to either a hard-coded value or to a reference to a single Terraform variable. It sets the role to "complex" if it finds a single non-variable reference or if it finds multiple references. It sets the role to "none" if no role arn is found.
   * The `get_assumed_roles` function gets all roles assumed by AWS providers in the current Terraform configuration. It calls the `determine_role_arn` function.
   * The `validate_assumed_roles_with_list` function validates assumed roles found by the `get_assumed_roles` function against a list of role ARNs.

--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -7,6 +7,18 @@ import "strings"
 
 ##### Functions #####
 
+### find_resources_with_standard_tags ###
+find_resources_with_standard_tags = func() {
+  resources = filter tfplan.resource_changes as address, rc {
+    rc.provider_name is "aws" and
+    rc.type not in ["aws_autoscaling_group"] and
+  	rc.mode is "managed" and
+  	(rc.change.actions contains "create" or rc.change.actions contains "update")
+  }
+
+  return resources
+}
+
 ### determine_role_arn ###
 # This can only determine the role_arn if it is set to either a hard-coded value
 # or to a reference to a single Terraform variable.

--- a/governance/third-generation/aws/aws-functions/docs/find_resources_with_standard_tags.md
+++ b/governance/third-generation/aws/aws-functions/docs/find_resources_with_standard_tags.md
@@ -1,0 +1,30 @@
+# find_resources_with_standard_tags
+This function finds all resource instances for the AWS provider that use standard AWS tags in the current plan that are being created or modified using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+Currently, the only AWS resource excluded is `aws_autoscaling_group`. If you discover other AWS resources that do not use the `tags` attribute in the standard way, then add them to the list that already includes `aws_autoscaling_group`.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`find_resources_with_standard_tags = func()`
+
+## Arguments
+* None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+allAWSResourcesWithStandardTags = aws.find_resources_with_standard_tags()
+```
+
+This function is used by the [enforce-mandatory-tags.sentinel](../../enforce-mandatory-tags.sentinel) policy.

--- a/governance/third-generation/aws/enforce-mandatory-tags.sentinel
+++ b/governance/third-generation/aws/enforce-mandatory-tags.sentinel
@@ -1,22 +1,26 @@
 # This policy uses the Sentinel tfplan/v2 import to require that
-# all EC2 instances have all mandatory tags
+# all AWS resources that use standard AWS tags have all mandatory tags
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan
 
+# Import aws-functions/aws-functions.sentinel
+# with alias "aws"
+import "aws-functions" as aws
+
 # List of mandatory tags
 mandatory_tags = ["Name", "ttl", "Owner"]
 
-# Get all EC2 instances
-allEC2Instances = plan.find_resources("aws_instance")
+# Get all AWS Resources with standard tags
+allAWSResourcesWithStandardTags = aws.find_resources_with_standard_tags()
 
-# Filter to EC2 instances with violations
+# Filter to AWS resources with violations
 # Warnings will be printed for all violations since the last parameter is true
-violatingEC2Instances = plan.filter_attribute_not_contains_list(allEC2Instances,
+violatingAWSResources = plan.filter_attribute_not_contains_list(allAWSResourcesWithStandardTags,
                         "tags", mandatory_tags, true)
 
 # Main rule
 main = rule {
-  length(violatingEC2Instances["messages"]) is 0
+  length(violatingAWSResources["messages"]) is 0
 }

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/fail.json
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/fail.json
@@ -2,10 +2,17 @@
   "modules": {
     "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    },
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    },
+    "aws-functions": {
+      "path": "../../aws-functions/aws-functions.sentinel"
     }
   },
   "mock": {
-    "tfplan/v2": "mock-tfplan-fail.sentinel"
+    "tfplan/v2": "mock-tfplan-fail.sentinel",
+    "tfconfig/v2": "mock-tfconfig-fail.sentinel"
   },
   "test": {
     "main": false

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfconfig-fail.sentinel
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfconfig-fail.sentinel
@@ -1,0 +1,273 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+	"module.nested:aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "module.nested",
+		"name":                "aws",
+		"provider_config_key": "module.nested:aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket_name",
+				],
+			},
+			"logging": {
+				"constant_value": null,
+			},
+			"server_side_encryption_configuration": {
+				"constant_value": null,
+			},
+			"tags": {
+				"constant_value": {
+					"Owner": "roger@hashicorp.com",
+					"Name":  "Roger Test Bucket",
+				},
+			},
+			"website": {
+				"constant_value": null,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_instance.ubuntu": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"module.nested.aws_instance.ubuntu": {
+		"address": "module.nested.aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.nested",
+		"name":                "ubuntu",
+		"provider_config_key": "module.nested:aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "",
+		"name":           "ami_id",
+	},
+	"associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "",
+		"name":           "associate_public_ip_address",
+	},
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "",
+		"name":           "instance_type",
+	},
+	"module.nested:ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "module.nested",
+		"name":           "ami_id",
+	},
+	"module.nested:associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "associate_public_ip_address",
+	},
+	"module.nested:aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "module.nested",
+		"name":           "aws_region",
+	},
+	"module.nested:instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "module.nested",
+		"name":           "instance_type",
+	},
+	"module.nested:name": {
+		"default":        "roger-demo-nested",
+		"description":    "name to pass to Name tag",
+		"module_address": "module.nested",
+		"name":           "name",
+	},
+	"name": {
+		"default":        "roger-demo",
+		"description":    "name to pass to Name tag",
+		"module_address": "",
+		"name":           "name",
+	},
+}
+
+outputs = {
+	"module.nested:public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+	"public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"nested": {
+		"config": {
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfconfig-pass.sentinel
@@ -1,0 +1,274 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+	"module.nested:aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "module.nested",
+		"name":                "aws",
+		"provider_config_key": "module.nested:aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket_name",
+				],
+			},
+			"logging": {
+				"constant_value": null,
+			},
+			"server_side_encryption_configuration": {
+				"constant_value": null,
+			},
+			"tags": {
+				"constant_value": {
+					"Owner": "roger@hashicorp.com",
+					"Name":  "Roger Test Bucket",
+					"ttl":   "24",
+				},
+			},
+			"website": {
+				"constant_value": null,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_instance.ubuntu": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"module.nested.aws_instance.ubuntu": {
+		"address": "module.nested.aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.nested",
+		"name":                "ubuntu",
+		"provider_config_key": "module.nested:aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "",
+		"name":           "ami_id",
+	},
+	"associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "",
+		"name":           "associate_public_ip_address",
+	},
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "",
+		"name":           "instance_type",
+	},
+	"module.nested:ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "module.nested",
+		"name":           "ami_id",
+	},
+	"module.nested:associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "associate_public_ip_address",
+	},
+	"module.nested:aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "module.nested",
+		"name":           "aws_region",
+	},
+	"module.nested:instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "module.nested",
+		"name":           "instance_type",
+	},
+	"module.nested:name": {
+		"default":        "roger-demo-nested",
+		"description":    "name to pass to Name tag",
+		"module_address": "module.nested",
+		"name":           "name",
+	},
+	"name": {
+		"default":        "roger-demo",
+		"description":    "name to pass to Name tag",
+		"module_address": "",
+		"name":           "name",
+	},
+}
+
+outputs = {
+	"module.nested:public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+	"public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"nested": {
+		"config": {
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail.sentinel
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfplan-fail.sentinel
@@ -9,6 +9,102 @@ planned_values = {
 		},
 	},
 	"resources": {
+		"aws_s3_bucket.bucket": {
+			"address": "aws_s3_bucket.bucket",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"acl":            "private",
+					"bucket":         "roger-012-test",
+					"bucket_prefix":  null,
+					"cors_rule":      [],
+					"force_destroy":  false,
+					"grant":          [],
+					"lifecycle_rule": [],
+					"logging": [
+						{
+							"target_bucket": "roger-tf",
+							"target_prefix": "",
+						},
+					],
+					"object_lock_configuration": [],
+					"policy":                    null,
+					"replication_configuration": [],
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{
+											"kms_master_key_id": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+											"sse_algorithm":     "aws:kms",
+										},
+									],
+								},
+							],
+						},
+					],
+					"tags": {
+						"Owner": "roger@hashicorp.com",
+						"Name":  "Roger Test Bucket",
+					},
+					"website": [
+						{
+							"error_document":           null,
+							"index_document":           "index.html",
+							"redirect_all_requests_to": null,
+							"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+						},
+					],
+				},
+				"after_unknown": {
+					"acceleration_status": true,
+					"arn":                         true,
+					"bucket_domain_name":          true,
+					"bucket_regional_domain_name": true,
+					"cors_rule":                   [],
+					"grant":                       [],
+					"hosted_zone_id":              true,
+					"id":                          true,
+					"lifecycle_rule":              [],
+					"logging": [
+						{},
+					],
+					"object_lock_configuration": [],
+					"region":                    true,
+					"replication_configuration": [],
+					"request_payer":             true,
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{},
+									],
+								},
+							],
+						},
+					],
+					"tags":       {},
+					"versioning": true,
+					"website": [
+						{},
+					],
+					"website_domain":   true,
+					"website_endpoint": true,
+				},
+				"before": null,
+			},
+			"deposed":        "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "bucket",
+			"provider_name":  "aws",
+			"type":           "aws_s3_bucket",
+		},
 		"aws_instance.ubuntu[0]": {
 			"address":        "aws_instance.ubuntu[0]",
 			"depends_on":     [],
@@ -134,6 +230,102 @@ variables = {
 }
 
 resource_changes = {
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":            "private",
+				"bucket":         "roger-012-test",
+				"bucket_prefix":  null,
+				"cors_rule":      [],
+				"force_destroy":  false,
+				"grant":          [],
+				"lifecycle_rule": [],
+				"logging": [
+					{
+						"target_bucket": "roger-tf",
+						"target_prefix": "",
+					},
+				],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+										"sse_algorithm":     "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags": {
+					"Owner": "roger@hashicorp.com",
+					"Name":  "Roger Test Bucket",
+				},
+				"website": [
+					{
+						"error_document":           null,
+						"index_document":           "index.html",
+						"redirect_all_requests_to": null,
+						"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+					},
+				],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging": [
+					{},
+				],
+				"object_lock_configuration": [],
+				"region":                    true,
+				"replication_configuration": [],
+				"request_payer":             true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{},
+								],
+							},
+						],
+					},
+				],
+				"tags":       {},
+				"versioning": true,
+				"website": [
+					{},
+				],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket",
+		"provider_name":  "aws",
+		"type":           "aws_s3_bucket",
+	},
 	"aws_instance.ubuntu[0]": {
 		"address": "aws_instance.ubuntu[0]",
 		"change": {

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/mock-tfplan-pass.sentinel
@@ -9,6 +9,103 @@ planned_values = {
 		},
 	},
 	"resources": {
+		"aws_s3_bucket.bucket": {
+			"address": "aws_s3_bucket.bucket",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"acl":            "private",
+					"bucket":         "roger-012-test",
+					"bucket_prefix":  null,
+					"cors_rule":      [],
+					"force_destroy":  false,
+					"grant":          [],
+					"lifecycle_rule": [],
+					"logging": [
+						{
+							"target_bucket": "roger-tf",
+							"target_prefix": "",
+						},
+					],
+					"object_lock_configuration": [],
+					"policy":                    null,
+					"replication_configuration": [],
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{
+											"kms_master_key_id": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+											"sse_algorithm":     "aws:kms",
+										},
+									],
+								},
+							],
+						},
+					],
+					"tags": {
+						"Owner": "roger@hashicorp.com",
+						"Name":  "Roger Test Bucket",
+						"ttl":   "24",
+					},
+					"website": [
+						{
+							"error_document":           null,
+							"index_document":           "index.html",
+							"redirect_all_requests_to": null,
+							"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+						},
+					],
+				},
+				"after_unknown": {
+					"acceleration_status": true,
+					"arn":                         true,
+					"bucket_domain_name":          true,
+					"bucket_regional_domain_name": true,
+					"cors_rule":                   [],
+					"grant":                       [],
+					"hosted_zone_id":              true,
+					"id":                          true,
+					"lifecycle_rule":              [],
+					"logging": [
+						{},
+					],
+					"object_lock_configuration": [],
+					"region":                    true,
+					"replication_configuration": [],
+					"request_payer":             true,
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{},
+									],
+								},
+							],
+						},
+					],
+					"tags":       {},
+					"versioning": true,
+					"website": [
+						{},
+					],
+					"website_domain":   true,
+					"website_endpoint": true,
+				},
+				"before": null,
+			},
+			"deposed":        "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "bucket",
+			"provider_name":  "aws",
+			"type":           "aws_s3_bucket",
+		},
 		"aws_instance.ubuntu[0]": {
 			"address":        "aws_instance.ubuntu[0]",
 			"depends_on":     [],
@@ -141,6 +238,103 @@ variables = {
 }
 
 resource_changes = {
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":            "private",
+				"bucket":         "roger-012-test",
+				"bucket_prefix":  null,
+				"cors_rule":      [],
+				"force_destroy":  false,
+				"grant":          [],
+				"lifecycle_rule": [],
+				"logging": [
+					{
+						"target_bucket": "roger-tf",
+						"target_prefix": "",
+					},
+				],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+										"sse_algorithm":     "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags": {
+					"Owner": "roger@hashicorp.com",
+					"Name":  "Roger Test Bucket",
+					"ttl":   "24",
+				},
+				"website": [
+					{
+						"error_document":           null,
+						"index_document":           "index.html",
+						"redirect_all_requests_to": null,
+						"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+					},
+				],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging": [
+					{},
+				],
+				"object_lock_configuration": [],
+				"region":                    true,
+				"replication_configuration": [],
+				"request_payer":             true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{},
+								],
+							},
+						],
+					},
+				],
+				"tags":       {},
+				"versioning": true,
+				"website": [
+					{},
+				],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket",
+		"provider_name":  "aws",
+		"type":           "aws_s3_bucket",
+	},
 	"aws_instance.ubuntu[0]": {
 		"address": "aws_instance.ubuntu[0]",
 		"change": {

--- a/governance/third-generation/aws/test/enforce-mandatory-tags/pass.json
+++ b/governance/third-generation/aws/test/enforce-mandatory-tags/pass.json
@@ -2,10 +2,17 @@
   "modules": {
     "tfplan-functions": {
       "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    },
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    },
+    "aws-functions": {
+      "path": "../../aws-functions/aws-functions.sentinel"
     }
   },
   "mock": {
-    "tfplan/v2": "mock-tfplan-pass.sentinel"
+    "tfplan/v2": "mock-tfplan-pass.sentinel",
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
   },
   "test": {
     "main": true

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
@@ -1,0 +1,34 @@
+# find_datasources_by_provider
+This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) Sentinel module.
+
+## Declaration
+`find_datasources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allAWSDataSources = plan.find_datasources_by_provider("aws")
+
+allAzureDataSources = plan.find_datasources_by_provider("azurerm")
+
+allGCPDataSources = plan.find_datasources_by_provider("google")
+
+allVMwareDataSources = plan.find_datasources("vsphere")
+```

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
@@ -1,0 +1,32 @@
+# find_resources_by_provider
+This function finds all resource instances for a specific provider in the current plan that are being created or modified using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allAWSResources = plan.find_resources_by_provider("aws")
+
+allAzureResources = plan.find_resources_by_provider("azurerm")
+
+allGCPResources = plan.find_resources_by_provider("google")
+
+allVMwareResources = plan.find_resources_by_provider("vsphere")
+```

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -32,6 +32,20 @@ find_resources = func(type) {
   return resources
 }
 
+### find_resources_by_provider ###
+# Find all resources for a specific provider using the tfplan/v2 import.
+# Only include resources that are being created or updated.
+# Technically, this returns a map of resource changes.
+find_resources_by_provider = func(provider) {
+  resources = filter tfplan.resource_changes as address, rc {
+    rc.provider_name is provider and
+  	rc.mode is "managed" and
+  	(rc.change.actions contains "create" or rc.change.actions contains "update")
+  }
+
+  return resources
+}
+
 ### find_datasources ###
 # Find all data sources of a specific type using the tfplan/v2 import.
 # Only include data sources that are being created, updated, or read.
@@ -39,6 +53,22 @@ find_resources = func(type) {
 find_datasources = func(type) {
   datasources = filter tfplan.resource_changes as address, rc {
   	rc.type is type and
+  	rc.mode is "data" and
+  	(rc.change.actions contains "create" or
+    rc.change.actions contains "update" or
+    rc.change.actions contains "read")
+  }
+
+  return datasources
+}
+
+### find_datasources_by_provider ###
+# Find all data sources for a specific provider using the tfplan/v2 import.
+# Only include data sources that are being created, updated, or read.
+# Technically, this returns a map of resource changes.
+find_datasources_by_provider = func(provider) {
+  datasources = filter tfplan.resource_changes as address, rc {
+  	rc.provider_name is provider and
   	rc.mode is "data" and
   	(rc.change.actions contains "create" or
     rc.change.actions contains "update" or

--- a/governance/third-generation/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
@@ -1,0 +1,32 @@
+# find_datasources_by_provider
+This function finds all data source instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_datasources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentAWSDataSources = state.find_datasources_by_provider("aws")
+
+currentAzureDataSources = state.find_datasources_by_provider("azurerm")
+
+currentGCPDataSources = state.find_datasources_by_provider("google")
+
+currentVMwareDataSources = state.find_datasources_by_provider("vsphere")
+```

--- a/governance/third-generation/common-functions/tfstate-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/find_resources_by_provider.md
@@ -1,0 +1,32 @@
+# find_resources_by_provider
+This function finds all resource instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentEC2Resources = state.find_resources_by_provider("aws")
+
+currentAzureResources = state.find_resources_by_provider("azurerm")
+
+currentGCPResources = state.find_resources_by_provider("google")
+
+currentVMwareResources = state.find_resources_by_provider("vsphere")
+```

--- a/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -29,11 +29,33 @@ find_resources = func(type) {
   return resources
 }
 
+### find_resources_by_provider ###
+# Find all resources for a specific provider using the tfstate/v2 import.
+find_resources_by_provider = func(provider) {
+  resources = filter tfstate.resources as address, r {
+  	r.provider_name is provider and
+  	r.mode is "managed"
+  }
+
+  return resources
+}
+
 ### find_datasources ###
 # Find all data sources of a specific type using the tfstate/v2 import.
 find_datasources = func(type) {
   datasources = filter tfstate.resources as address, d {
   	d.type is type and
+  	d.mode is "data"
+  }
+
+  return datasources
+}
+
+### find_datasources_by_provider ###
+# Find all data sources for a specific provider using the tfstate/v2 import.
+find_datasources_by_provider = func(provider) {
+  datasources = filter tfstate.resources as address, d {
+  	d.provider_name is provider and
   	d.mode is "data"
   }
 


### PR DESCRIPTION
I've added the following new common functions:
tfstate-functions: find_datasources_by_provider and find_resources_by_provider
tfplan-functions: find_datasources_by_provider and find_resources_by_provider
aws-functions: find_resources_with_standard_tags

Also, I updated the AWS enforce-mandatory-tags.sentinel policy to use the new find_resources_with_standard_tags function and expanded the test case to include an S3 bucket in addition to the EC2 instances that it previously included.