### PR TITLE
add source to all policies in sets

### DIFF
--- a/governance/first-generation/README.md
+++ b/governance/first-generation/README.md
@@ -11,4 +11,6 @@ While these policies have the virtue of being simple and can be useful, they hav
 
 Finally, none of these policies included [mock files](https://www.terraform.io/docs/enterprise/sentinel/mock.html) and [test files](https://docs.hashicorp.com/sentinel/commands/config#test-cases) that would allow them to be tested with the [Sentinel Simulator](https://docs.hashicorp.com/sentinel/commands).
 
-We encourage users to use the [second-generation policies](../second-generation) in this repository and to model new policies on them instead of on these first-generation policies.
+These policies use the older Terraform Sentinel v1 imports.
+
+We encourage users to use the [second-generation policies](../second-generation) in this repository if they are still using Terraform 0.11 and to use the [third-generation policies](../third-generation) if they are using Terraform 0.12 or higher and to model new policies on them instead of on these first-generation policies.

--- a/governance/second-generation/README.md
+++ b/governance/second-generation/README.md
@@ -6,6 +6,8 @@ Additionally, it contains [Policy Set](https://www.terraform.io/docs/cloud/senti
 
 These policies are generally intended for use with Terraform 0.11 and 0.12. But some policies such as those that check cost estimates can only be used with Terraform 0.12.
 
+These policies use the older Terraform Sentinel v1 imports. If you are only using Terraform 0.12 and higher, we recommend you use the newer [third-generation](../third-generation) policies which use the newer Terraform Sentinel v2 imports and Sentinel modules.
+
 ## Note about Using These Policies with Terraform Cloud and Enterprise
 These policies test whether resources are being destroyed using the [destroy](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-destroy) and [requires_new](https://www.terraform.io/docs/cloud/sentinel/import/tfplan.html#value-requires_new) values that were added to Terraform Cloud (https://app.terraform.io) on 8/15/2019 and to Terraform Enterprise (formerly known as PTFE) in the v201909-1 release on 9/13/2019. Please upgrade to that release or higher before using these policies on your Terraform Enterprise server. (If you are not currently able to upgrade your TFE server, see an older version of this document for a workaround that allows you to use these policies on older versions of TFE.)
 

--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -12,19 +12,19 @@ To learn more about the new Terraform Sentinel v2 imports, see this [blog post](
 
 To learn more about Sentinel Modules, see this [blog post](https://discuss.hashicorp.com/t/sentinel-v0-15-0-introducing-modules/6579).
 
-However, while using Sentinel modules is now possible in Terraform Cloud, the modules have to be in files located in or underneath the VCS directory containing the policy set definition file, `sentinel.hcl`.
-
-So, while these third-generation policies and common functions **can** be used as organized in this repository with the Sentinel CLI, they **cannot** yet be used *as organized* in Terraform Cloud. This will be remedied in the near future. We will update this document when that occurs.
-
-For now, if you want to use these policies with Terraform Cloud, you will need to create a repository like this [one](https://github.com/rberlind/sentinel-demo) in which the "common-functions" directory has been placed in the same VCS directory as the `sentinel.hcl` file. The directory does not have to be the top-level directory within the VCS repository.
-
 ## Using These Policies with Terraform Enterprise
 These policies and the common functions they use can be used with Terraform Enterprise (TFE) v202004-1 and higher. That version was released on April 24, 2020.
 
+However, while using Sentinel modules is now possible in Terraform Enterprise, the modules have to be in files located in or underneath the VCS directory containing the policy set definition file, `sentinel.hcl`.
+
+So, while these third-generation policies and common functions **can** be used as organized in this repository with the Sentinel CLI and Terraform Cloud, they **cannot** yet be used *as organized* in Terraform Enterprise. This will be remedied in a new TFE release at the end of June, 2020.
+
+For now, if you want to use these policies with Terraform Enterprise, you will need to create a repository like this [one](https://github.com/rberlind/sentinel-demo) in which the "common-functions" directory has been placed in the same VCS directory as the `sentinel.hcl` file. The directory does not have to be the top-level directory within the VCS repository.
+
 ## Important Characterizations of the New Policies
 These new third-generation policies have several important characteristics:
-1. As mentioned above, they use the new Terraform Sentinel v2 imports which are more closely aligned with Terraform 0.12's data model and leverage the recently added [filter expression](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression) and make it easier to restrict policies to specific operations performed by Terraform against resources.
-1. The new policies use new, parameterized functions defined in four [Sentinel modules]. Since they are defined in modules, their implementations do **not** need to be pasted into the policies. This is a **HUGE** improvement over the second-generation common functions! (As mentioned above, this benefit is only realized for now with the Sentinel CLI and TFC, but it will be extended to TFE soon.)
+1. As mentioned above, they use the new Terraform Sentinel v2 imports, which are more closely aligned with Terraform 0.12's data model and leverage the recently added [filter expression](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression), and make it easier to restrict policies to specific operations performed by Terraform against resources.
+1. The new policies use new, parameterized functions defined in four [Sentinel modules]. Since they are defined in modules, their implementations do **not** need to be pasted into the policies. This is a **HUGE** improvement over the second-generation common functions!
 1. A related benefit of using functions from modules is that the policies themselves do not have any `for` loops or `if/else` conditionals. This makes it easier for users to understand the sample policies and to write their own policies that copy them.
 1. The new policies have been written in a way that causes all violations to be reported. This means a user who violates a policy will be informed about all of their violations in a single shot without having to run multiple Sentinel CLI tests or TFC/TFE plans.
 1. The policies print out the full address of each resource instance that does violate a rule in the same format that is used in plan and apply logs, namely `module.<A>.module.<B>.<type>.<name>[<index>]`. (Note that `index` will only be present if multiple instances of a resource are defined either with the `count` or the `for_each` meta-arguments.) This allows writers of Terraform code to quickly determine the resources they need to fix even if the violations occur in modules that they did not write.
@@ -137,12 +137,14 @@ As mentioned in the introduction of this file, this repository contains [Policy 
 
 Each of these files is called "sentinel.hcl" and should list all policies in its directory with an [Enforcement Level](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#enforcement-levels) of "advisory". This means that registering these policy sets in a Terraform Cloud or Terraform Enterprise organization will not actually have any impact on provisioning of resources from those organizations even if some of the policy checks do report violations.
 
+The `sentinel.hcl` files list the source of each policy like this: `source = "./<policy>.sentinel"`. While including a source for a policy in the same directory as the `sentinel.hcl` file is not currently required, it will be required in the future. So, we added them now to avoid future problems.
+
 The `sentinel.hcl` files should also include any Sentinel modules used by any of the policies they list.
 
 Users who wish to actually enforce any of these policies should change the enforcement levels of them to "soft-mandatory" or "hard-mandatory" in their forks of this repository or in other VCS repositories that contain copies of the policies.
 
 ## Adding Policies
-If you add a new third-generation policy to one of the cloud directories or the cloud-agnostic directory, please add a new stanza to that directory's sentinel.hcl file listing the name of your new policy.
+If you add a new third-generation policy to one of the cloud directories or the cloud-agnostic directory, please add a new stanza to that directory's sentinel.hcl file listing the name and source of your new policy.
 
 The Sentinel Simulator expects test cases to be in a test/\<policy\> directory under the directory containing the policy being tested where \<policy\> is the name of the policy not including the ".sentinel" extension. When you add new policies for any of the clouds, please be sure to create a new directory with the same name of the policy under that cloud's directory and then add test cases and mock files to that directory.
 

--- a/governance/third-generation/aws/sentinel.hcl
+++ b/governance/third-generation/aws/sentinel.hcl
@@ -1,59 +1,70 @@
 module "tfplan-functions" {
-    source = "../common-functions/tfplan-functions/tfplan-functions.sentinel"
+  source = "../common-functions/tfplan-functions/tfplan-functions.sentinel"
 }
 
 module "tfstate-functions" {
-    source = "../common-functions/tfstate-functions/tfstate-functions.sentinel"
+  source = "../common-functions/tfstate-functions/tfstate-functions.sentinel"
 }
 
 module "tfconfig-functions" {
-    source = "../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+  source = "../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
 }
 
 module "aws-functions" {
-    source = "./aws-functions/aws-functions.sentinel"
+  source = "./aws-functions/aws-functions.sentinel"
 }
 
 policy "enforce-mandatory-tags" {
-    enforcement_level = "advisory"
+  source = "./enforce-mandatory-tags.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "require-private-acl-and-kms-for-s3-buckets" {
-    enforcement_level = "advisory"
+  source = "./require-private-acl-and-kms-for-s3-buckets.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-ami-owners" {
-    enforcement_level = "advisory"
+  source = "./restrict-ami-owners.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-assumed-roles-by-workspace" {
-    enforcement_level = "advisory"
+  source = "./restrict-assumed-roles-by-workspace.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-assumed-roles" {
-    enforcement_level = "advisory"
+  source = "./restrict-assumed-roles.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-availability-zones" {
-    enforcement_level = "advisory"
+  source = "./restrict-availability-zones.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-current-ec2-instance-type" {
-    enforcement_level = "advisory"
+  source = "./restrict-current-ec2-instance-type.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-db-instance-engines" {
-    enforcement_level = "advisory"
+  source = "./restrict-db-instance-engines.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-ec2-instance-type" {
-    enforcement_level = "advisory"
+  source = "./restrict-ec2-instance-type.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-ingress-sg-rule-cidr-blocks" {
-    enforcement_level = "advisory"
+  source = "./restrict-ingress-sg-rule-cidr-blocks.sentinel"
+  enforcement_level = "advisory"
 }
 
 policy "restrict-launch-configuration-instance-type" {
-    enforcement_level = "advisory"
+  source = "./restrict-launch-configuration-instance-type.sentinel"
+  enforcement_level = "advisory"
 }

--- a/governance/third-generation/azure/sentinel.hcl
+++ b/governance/third-generation/azure/sentinel.hcl
@@ -11,17 +11,21 @@ module "tfconfig-functions" {
 }
 
 policy "enforce-mandatory-tags" {
+    source = "./enforce-mandatory-tags.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "restrict-app-service-to-https" {
+    source = "./restrict-app-service-to-https.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "restrict-publishers-of-current-vms" {
+    source = "./restrict-publishers-of-current-vms.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "restrict-vm-size" {
+    source = "./restrict-vm-size.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
@@ -1,7 +1,9 @@
 policy "check-external-http-api" {
+    source = "./check-external-http-api.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "use-latest-module-versions" {
+    source = "./use-latest-module-versions.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/cloud-agnostic/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/sentinel.hcl
@@ -15,65 +15,81 @@ module "tfrun-functions" {
 }
 
 policy "blacklist-datasources" {
+    source = "./blacklist-datasources.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "blacklist-providers" {
+    source = "./blacklist-providers.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "blacklist-provisioners" {
+    source = "./blacklist-provisioners.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "blacklist-resources" {
+    source = "./blacklist-resources.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "limit-cost-and-percentage-increase" {
+    source = "./limit-cost-and-percentage-increase.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "limit-cost-by-workspace-type" {
+    source = "./limit-cost-by-workspace-type.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "limit-proposed-monthly-cost" {
+    source = "./limit-proposed-monthly-cost.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "prevent-destruction-of-blacklisted-resources" {
+    source = "./prevent-destruction-of-blacklisted-resources.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "prevent-non-root-providers" {
+    source = "./prevent-non-root-providers.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "prevent-remote-exec-provisioners-on-null-resources" {
+    source = "./prevent-remote-exec-provisioners-on-null-resources.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "require-all-resources-from-pmr" {
+    source = "./require-all-resources-from-pmr.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "validate-variables-have-descriptions" {
+    source = "./validate-variables-have-descriptions.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "whitelist-datasources" {
+    source = "./whitelist-datasources.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "whitelist-providers" {
+    source = "./whitelist-providers.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "whitelist-provisioners" {
+    source = "./whitelist-provisioners.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "whitelist-resources" {
+    source = "./whitelist-resources.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/gcp/sentinel.hcl
+++ b/governance/third-generation/gcp/sentinel.hcl
@@ -11,9 +11,11 @@ module "tfconfig-functions" {
 }
 
 policy "enforce-mandatory-labels" {
+    source = "./enforce-mandatory-labels.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "restrict-gce-machine-type" {
+    source = "./restrict-gce-machine-type.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/vmware/sentinel.hcl
+++ b/governance/third-generation/vmware/sentinel.hcl
@@ -11,9 +11,11 @@ module "tfconfig-functions" {
 }
 
 policy "restrict-vm-cpu-and-memory" {
+    source = "./restrict-vm-cpu-and-memory.sentinel"
     enforcement_level = "advisory"
 }
 
 policy "restrict-vm-disk-size" {
+    source = "./restrict-vm-disk-size.sentinel"
     enforcement_level = "advisory"
 }


### PR DESCRIPTION
I've added a source to every policy in each instance of sentinel.hcl in the third-generation policies. While this is not needed at this time, it will be required in the future and I wanted to avoid problems.

Also, I updated the first, second, and third-generation README.md files.  This includes pointing out that the common functions can now be used by TFC policy sets as currently organized and that this will also be possible in TFE starting with the next release targeted for the end of June.