### PR TITLE
fix cloud-agnostic sentinel.hcl

### DIFF
--- a/governance/third-generation/cloud-agnostic/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/sentinel.hcl
@@ -39,8 +39,8 @@ policy "limit-cost-and-percentage-increase" {
     enforcement_level = "advisory"
 }
 
-policy "limit-cost-by-workspace-type" {
-    source = "./limit-cost-by-workspace-type.sentinel"
+policy "limit-cost-by-workspace-name" {
+    source = "./limit-cost-by-workspace-name.sentinel"
     enforcement_level = "advisory"
 }
 


### PR DESCRIPTION
Had changed name of a policy that limits cost by workspace names, but had not updated sentinel.hcl