### PR TITLE
TFE v202006-1 fully supports third-gen sentinel policies

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -5,21 +5,14 @@ Additionally, it contains [Policy Set](https://www.terraform.io/docs/cloud/senti
 
 These policies and the Terraform Sentinel v2 imports they use can only be used with Terraform 0.12.
 
-## Using These Policies with Terraform Cloud
 These policies use the new Terraform Sentinel v2 imports. They also use a new feature called [Sentinel Modules](https://docs.hashicorp.com/sentinel/extending/modules) which allows Sentinel functions and rules to be defined in one file and used by Sentinel policies in other files.
 
 To learn more about the new Terraform Sentinel v2 imports, see this [blog post](https://www.hashicorp.com/blog/terraform-sentinel-v2-imports-now-in-technology-preview).
 
 To learn more about Sentinel Modules, see this [blog post](https://discuss.hashicorp.com/t/sentinel-v0-15-0-introducing-modules/6579).
 
-## Using These Policies with Terraform Enterprise
-These policies and the common functions they use can be used with Terraform Enterprise (TFE) v202004-1 and higher. That version was released on April 24, 2020.
-
-However, while using Sentinel modules is now possible in Terraform Enterprise, the modules have to be in files located in or underneath the VCS directory containing the policy set definition file, `sentinel.hcl`.
-
-So, while these third-generation policies and common functions **can** be used as organized in this repository with the Sentinel CLI and Terraform Cloud, they **cannot** yet be used *as organized* in Terraform Enterprise. This will be remedied in a new TFE release at the end of June, 2020.
-
-For now, if you want to use these policies with Terraform Enterprise, you will need to create a repository like this [one](https://github.com/rberlind/sentinel-demo) in which the "common-functions" directory has been placed in the same VCS directory as the `sentinel.hcl` file. The directory does not have to be the top-level directory within the VCS repository.
+## Using These Policies with Terraform Cloud and Terraform Enterprise
+These policies and the common functions they use can be used as organized with the current version of Terraform Cloud (TFC) and with Terraform Enterprise (TFE) v202006-1 and higher. That version was released on June 23, 2020.
 
 ## Important Characterizations of the New Policies
 These new third-generation policies have several important characteristics:


### PR DESCRIPTION
I updated the third-gen README.md to indicate that TFE v202006-1 now fully supports the third-generation Sentinel policies as organized (meaning that modules that are not under the directory containing sentinel.hcl can be referenced using ../ notation).