### PR TITLE
migrate 2 gen1 policies to gen3

### DIFF
--- a/governance/third-generation/aws/require-dns-support-for-vpcs.sentinel
+++ b/governance/third-generation/aws/require-dns-support-for-vpcs.sentinel
@@ -1,0 +1,25 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all VPCs support DNS so that EC2 instances created in them
+# will have public DNS if they have public IPs
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all VPCs
+allVPCs = plan.find_resources("aws_vpc")
+
+# Filter to VPCs with violations
+# Warnings will be printed for all violations since the last parameter is true
+# The first finds VPCs with enable_dns_support not set to true
+# The second finds VPCs with enable_dns_hostnames not set to true
+violatingSupportVPCs = plan.filter_attribute_is_not_value(allVPCs,
+                        "enable_dns_support", true, true)
+violatingHostnameVPCs = plan.filter_attribute_is_not_value(allVPCs,
+                        "enable_dns_hostnames", true, true)
+
+# Main rule
+validated = length(violatingSupportVPCs["messages"]) is 0 and length(violatingHostnameVPCs["messages"]) is 0
+main = rule {
+  validated
+}

--- a/governance/third-generation/aws/require-vpc-and-kms-for-lambda-functions.sentinel
+++ b/governance/third-generation/aws/require-vpc-and-kms-for-lambda-functions.sentinel
@@ -1,0 +1,28 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all Lambda functions specify a KMS key and use VPC subnets
+# and security groups
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all Lambda functions
+allLambdaFunctions = plan.find_resources("aws_lambda_function")
+
+# Filter to Lambda Function with violations
+# Warnings will be printed for all violations since the last parameter is true
+
+# Lambda functions that have not set a KMS key
+LambdasWithoutKMSKey = plan.filter_attribute_is_value(allLambdaFunctions,
+                        "kms_key_arn", null, true)
+
+# Lambda functions that have not set VPC subnets and security groups
+LambdasWithoutVPCs = plan.filter_attribute_is_value(allLambdaFunctions,
+                        "vpc_config", [], true)
+
+# Main rule
+validated = length(LambdasWithoutKMSKey["messages"]) is 0 and
+            length(LambdasWithoutVPCs["messages"]) is 0
+main = rule {
+  validated
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-dns-hostnames.json
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-dns-hostnames.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-dns-hostnames.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-dns-support.json
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-dns-support.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-dns-support.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-vpc-support-and-hostnames.json
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/fail-vpc-support-and-hostnames.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-dns-support-and-hostnames.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-hostnames.sentinel
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-hostnames.sentinel
@@ -1,0 +1,208 @@
+terraform_version = "0.12.24"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_vpc.vpc_from_root_module": {
+			"address":        "aws_vpc.vpc_from_root_module",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "vpc_from_root_module",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_vpc",
+			"values": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_support":               true,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+		},
+	},
+}
+
+variables = {
+	"cidr_for_nested_module": {
+		"name":  "cidr_for_nested_module",
+		"value": "172.17.0.0/16",
+	},
+	"cidr_for_pmr_module": {
+		"name":  "cidr_for_pmr_module",
+		"value": "172.18.0.0/16",
+	},
+	"cidr_for_root": {
+		"name":  "cidr_for_root",
+		"value": "172.16.0.0/16",
+	},
+}
+
+resource_changes = {
+	"aws_vpc.vpc_from_root_module": {
+		"address": "aws_vpc.vpc_from_root_module",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_support":               true,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_network_acl_id":         true,
+				"default_route_table_id":         true,
+				"default_security_group_id":      true,
+				"dhcp_options_id":                true,
+				"enable_classiclink":             true,
+				"enable_classiclink_dns_support": true,
+				"enable_dns_hostnames":           true,
+				"id": true,
+				"ipv6_association_id": true,
+				"ipv6_cidr_block":     true,
+				"main_route_table_id": true,
+				"owner_id":            true,
+				"tags":                {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vpc_from_root_module",
+		"provider_name":  "aws",
+		"type":           "aws_vpc",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_vpc.vpc_from_root_module",
+					"expressions": {
+						"cidr_block": {
+							"references": [
+								"var.cidr_for_root",
+							],
+						},
+						"tags": {
+							"constant_value": {
+								"Name": "vpc-from-root-module",
+							},
+						},
+					},
+					"mode":                "managed",
+					"name":                "vpc_from_root_module",
+					"provider_config_key": "aws",
+					"schema_version":      1,
+					"type":                "aws_vpc",
+				},
+			],
+			"variables": {
+				"cidr_for_nested_module": {
+					"default":     "172.17.0.0/16",
+					"description": "CIDR for use in nested module VPC",
+				},
+				"cidr_for_pmr_module": {
+					"default":     "172.18.0.0/16",
+					"description": "CIDR for use in PMR VPC",
+				},
+				"cidr_for_root": {
+					"default":     "172.16.0.0/16",
+					"description": "CIDR for use in root module VPC",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_vpc.vpc_from_root_module",
+					"mode":           "managed",
+					"name":           "vpc_from_root_module",
+					"provider_name":  "aws",
+					"schema_version": 1,
+					"type":           "aws_vpc",
+					"values": {
+						"assign_generated_ipv6_cidr_block": false,
+						"cidr_block":                       "172.16.0.0/16",
+						"enable_dns_support":               true,
+						"instance_tenancy":                 "default",
+						"tags": {
+							"Name": "vpc-from-root-module",
+						},
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_vpc.vpc_from_root_module",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assign_generated_ipv6_cidr_block": false,
+					"cidr_block":                       "172.16.0.0/16",
+					"enable_dns_support":               true,
+					"instance_tenancy":                 "default",
+					"tags": {
+						"Name": "vpc-from-root-module",
+					},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_network_acl_id":         true,
+					"default_route_table_id":         true,
+					"default_security_group_id":      true,
+					"dhcp_options_id":                true,
+					"enable_classiclink":             true,
+					"enable_classiclink_dns_support": true,
+					"enable_dns_hostnames":           true,
+					"id": true,
+					"ipv6_association_id": true,
+					"ipv6_cidr_block":     true,
+					"main_route_table_id": true,
+					"owner_id":            true,
+					"tags":                {},
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "vpc_from_root_module",
+			"provider_name": "aws",
+			"type":          "aws_vpc",
+		},
+	],
+	"terraform_version": "0.12.24",
+	"variables": {
+		"cidr_for_nested_module": {
+			"value": "172.17.0.0/16",
+		},
+		"cidr_for_pmr_module": {
+			"value": "172.18.0.0/16",
+		},
+		"cidr_for_root": {
+			"value": "172.16.0.0/16",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-support-and-hostnames.sentinel
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-support-and-hostnames.sentinel
@@ -1,0 +1,216 @@
+terraform_version = "0.12.24"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_vpc.vpc_from_root_module": {
+			"address":        "aws_vpc.vpc_from_root_module",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "vpc_from_root_module",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_vpc",
+			"values": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             false,
+				"enable_dns_support":               false,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+		},
+	},
+}
+
+variables = {
+	"cidr_for_nested_module": {
+		"name":  "cidr_for_nested_module",
+		"value": "172.17.0.0/16",
+	},
+	"cidr_for_pmr_module": {
+		"name":  "cidr_for_pmr_module",
+		"value": "172.18.0.0/16",
+	},
+	"cidr_for_root": {
+		"name":  "cidr_for_root",
+		"value": "172.16.0.0/16",
+	},
+}
+
+resource_changes = {
+	"aws_vpc.vpc_from_root_module": {
+		"address": "aws_vpc.vpc_from_root_module",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             false,
+				"enable_dns_support":               false,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_network_acl_id":         true,
+				"default_route_table_id":         true,
+				"default_security_group_id":      true,
+				"dhcp_options_id":                true,
+				"enable_classiclink":             true,
+				"enable_classiclink_dns_support": true,
+				"id": true,
+				"ipv6_association_id": true,
+				"ipv6_cidr_block":     true,
+				"main_route_table_id": true,
+				"owner_id":            true,
+				"tags":                {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vpc_from_root_module",
+		"provider_name":  "aws",
+		"type":           "aws_vpc",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_vpc.vpc_from_root_module",
+					"expressions": {
+						"cidr_block": {
+							"references": [
+								"var.cidr_for_root",
+							],
+						},
+						"enable_dns_hostnames": {
+							"constant_value": false,
+						},
+						"enable_dns_support": {
+							"constant_value": false,
+						},
+						"tags": {
+							"constant_value": {
+								"Name": "vpc-from-root-module",
+							},
+						},
+					},
+					"mode":                "managed",
+					"name":                "vpc_from_root_module",
+					"provider_config_key": "aws",
+					"schema_version":      1,
+					"type":                "aws_vpc",
+				},
+			],
+			"variables": {
+				"cidr_for_nested_module": {
+					"default":     "172.17.0.0/16",
+					"description": "CIDR for use in nested module VPC",
+				},
+				"cidr_for_pmr_module": {
+					"default":     "172.18.0.0/16",
+					"description": "CIDR for use in PMR VPC",
+				},
+				"cidr_for_root": {
+					"default":     "172.16.0.0/16",
+					"description": "CIDR for use in root module VPC",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_vpc.vpc_from_root_module",
+					"mode":           "managed",
+					"name":           "vpc_from_root_module",
+					"provider_name":  "aws",
+					"schema_version": 1,
+					"type":           "aws_vpc",
+					"values": {
+						"assign_generated_ipv6_cidr_block": false,
+						"cidr_block":                       "172.16.0.0/16",
+						"enable_dns_hostnames":             false,
+						"enable_dns_support":               false,
+						"instance_tenancy":                 "default",
+						"tags": {
+							"Name": "vpc-from-root-module",
+						},
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_vpc.vpc_from_root_module",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assign_generated_ipv6_cidr_block": false,
+					"cidr_block":                       "172.16.0.0/16",
+					"enable_dns_hostnames":             false,
+					"enable_dns_support":               false,
+					"instance_tenancy":                 "default",
+					"tags": {
+						"Name": "vpc-from-root-module",
+					},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_network_acl_id":         true,
+					"default_route_table_id":         true,
+					"default_security_group_id":      true,
+					"dhcp_options_id":                true,
+					"enable_classiclink":             true,
+					"enable_classiclink_dns_support": true,
+					"id": true,
+					"ipv6_association_id": true,
+					"ipv6_cidr_block":     true,
+					"main_route_table_id": true,
+					"owner_id":            true,
+					"tags":                {},
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "vpc_from_root_module",
+			"provider_name": "aws",
+			"type":          "aws_vpc",
+		},
+	],
+	"terraform_version": "0.12.24",
+	"variables": {
+		"cidr_for_nested_module": {
+			"value": "172.17.0.0/16",
+		},
+		"cidr_for_pmr_module": {
+			"value": "172.18.0.0/16",
+		},
+		"cidr_for_root": {
+			"value": "172.16.0.0/16",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-support.sentinel
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-fail-dns-support.sentinel
@@ -1,0 +1,216 @@
+terraform_version = "0.12.24"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_vpc.vpc_from_root_module": {
+			"address":        "aws_vpc.vpc_from_root_module",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "vpc_from_root_module",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_vpc",
+			"values": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             false,
+				"enable_dns_support":               false,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+		},
+	},
+}
+
+variables = {
+	"cidr_for_nested_module": {
+		"name":  "cidr_for_nested_module",
+		"value": "172.17.0.0/16",
+	},
+	"cidr_for_pmr_module": {
+		"name":  "cidr_for_pmr_module",
+		"value": "172.18.0.0/16",
+	},
+	"cidr_for_root": {
+		"name":  "cidr_for_root",
+		"value": "172.16.0.0/16",
+	},
+}
+
+resource_changes = {
+	"aws_vpc.vpc_from_root_module": {
+		"address": "aws_vpc.vpc_from_root_module",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             true,
+				"enable_dns_support":               false,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_network_acl_id":         true,
+				"default_route_table_id":         true,
+				"default_security_group_id":      true,
+				"dhcp_options_id":                true,
+				"enable_classiclink":             true,
+				"enable_classiclink_dns_support": true,
+				"id": true,
+				"ipv6_association_id": true,
+				"ipv6_cidr_block":     true,
+				"main_route_table_id": true,
+				"owner_id":            true,
+				"tags":                {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vpc_from_root_module",
+		"provider_name":  "aws",
+		"type":           "aws_vpc",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_vpc.vpc_from_root_module",
+					"expressions": {
+						"cidr_block": {
+							"references": [
+								"var.cidr_for_root",
+							],
+						},
+						"enable_dns_hostnames": {
+							"constant_value": false,
+						},
+						"enable_dns_support": {
+							"constant_value": false,
+						},
+						"tags": {
+							"constant_value": {
+								"Name": "vpc-from-root-module",
+							},
+						},
+					},
+					"mode":                "managed",
+					"name":                "vpc_from_root_module",
+					"provider_config_key": "aws",
+					"schema_version":      1,
+					"type":                "aws_vpc",
+				},
+			],
+			"variables": {
+				"cidr_for_nested_module": {
+					"default":     "172.17.0.0/16",
+					"description": "CIDR for use in nested module VPC",
+				},
+				"cidr_for_pmr_module": {
+					"default":     "172.18.0.0/16",
+					"description": "CIDR for use in PMR VPC",
+				},
+				"cidr_for_root": {
+					"default":     "172.16.0.0/16",
+					"description": "CIDR for use in root module VPC",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_vpc.vpc_from_root_module",
+					"mode":           "managed",
+					"name":           "vpc_from_root_module",
+					"provider_name":  "aws",
+					"schema_version": 1,
+					"type":           "aws_vpc",
+					"values": {
+						"assign_generated_ipv6_cidr_block": false,
+						"cidr_block":                       "172.16.0.0/16",
+						"enable_dns_hostnames":             false,
+						"enable_dns_support":               false,
+						"instance_tenancy":                 "default",
+						"tags": {
+							"Name": "vpc-from-root-module",
+						},
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_vpc.vpc_from_root_module",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assign_generated_ipv6_cidr_block": false,
+					"cidr_block":                       "172.16.0.0/16",
+					"enable_dns_hostnames":             false,
+					"enable_dns_support":               false,
+					"instance_tenancy":                 "default",
+					"tags": {
+						"Name": "vpc-from-root-module",
+					},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_network_acl_id":         true,
+					"default_route_table_id":         true,
+					"default_security_group_id":      true,
+					"dhcp_options_id":                true,
+					"enable_classiclink":             true,
+					"enable_classiclink_dns_support": true,
+					"id": true,
+					"ipv6_association_id": true,
+					"ipv6_cidr_block":     true,
+					"main_route_table_id": true,
+					"owner_id":            true,
+					"tags":                {},
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "vpc_from_root_module",
+			"provider_name": "aws",
+			"type":          "aws_vpc",
+		},
+	],
+	"terraform_version": "0.12.24",
+	"variables": {
+		"cidr_for_nested_module": {
+			"value": "172.17.0.0/16",
+		},
+		"cidr_for_pmr_module": {
+			"value": "172.18.0.0/16",
+		},
+		"cidr_for_root": {
+			"value": "172.16.0.0/16",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/mock-tfplan-pass.sentinel
@@ -1,0 +1,216 @@
+terraform_version = "0.12.24"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_vpc.vpc_from_root_module": {
+			"address":        "aws_vpc.vpc_from_root_module",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "vpc_from_root_module",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_vpc",
+			"values": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             false,
+				"enable_dns_support":               false,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+		},
+	},
+}
+
+variables = {
+	"cidr_for_nested_module": {
+		"name":  "cidr_for_nested_module",
+		"value": "172.17.0.0/16",
+	},
+	"cidr_for_pmr_module": {
+		"name":  "cidr_for_pmr_module",
+		"value": "172.18.0.0/16",
+	},
+	"cidr_for_root": {
+		"name":  "cidr_for_root",
+		"value": "172.16.0.0/16",
+	},
+}
+
+resource_changes = {
+	"aws_vpc.vpc_from_root_module": {
+		"address": "aws_vpc.vpc_from_root_module",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assign_generated_ipv6_cidr_block": false,
+				"cidr_block":                       "172.16.0.0/16",
+				"enable_dns_hostnames":             true,
+				"enable_dns_support":               true,
+				"instance_tenancy":                 "default",
+				"tags": {
+					"Name": "vpc-from-root-module",
+				},
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_network_acl_id":         true,
+				"default_route_table_id":         true,
+				"default_security_group_id":      true,
+				"dhcp_options_id":                true,
+				"enable_classiclink":             true,
+				"enable_classiclink_dns_support": true,
+				"id": true,
+				"ipv6_association_id": true,
+				"ipv6_cidr_block":     true,
+				"main_route_table_id": true,
+				"owner_id":            true,
+				"tags":                {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vpc_from_root_module",
+		"provider_name":  "aws",
+		"type":           "aws_vpc",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_vpc.vpc_from_root_module",
+					"expressions": {
+						"cidr_block": {
+							"references": [
+								"var.cidr_for_root",
+							],
+						},
+						"enable_dns_hostnames": {
+							"constant_value": false,
+						},
+						"enable_dns_support": {
+							"constant_value": false,
+						},
+						"tags": {
+							"constant_value": {
+								"Name": "vpc-from-root-module",
+							},
+						},
+					},
+					"mode":                "managed",
+					"name":                "vpc_from_root_module",
+					"provider_config_key": "aws",
+					"schema_version":      1,
+					"type":                "aws_vpc",
+				},
+			],
+			"variables": {
+				"cidr_for_nested_module": {
+					"default":     "172.17.0.0/16",
+					"description": "CIDR for use in nested module VPC",
+				},
+				"cidr_for_pmr_module": {
+					"default":     "172.18.0.0/16",
+					"description": "CIDR for use in PMR VPC",
+				},
+				"cidr_for_root": {
+					"default":     "172.16.0.0/16",
+					"description": "CIDR for use in root module VPC",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_vpc.vpc_from_root_module",
+					"mode":           "managed",
+					"name":           "vpc_from_root_module",
+					"provider_name":  "aws",
+					"schema_version": 1,
+					"type":           "aws_vpc",
+					"values": {
+						"assign_generated_ipv6_cidr_block": false,
+						"cidr_block":                       "172.16.0.0/16",
+						"enable_dns_hostnames":             false,
+						"enable_dns_support":               false,
+						"instance_tenancy":                 "default",
+						"tags": {
+							"Name": "vpc-from-root-module",
+						},
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_vpc.vpc_from_root_module",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assign_generated_ipv6_cidr_block": false,
+					"cidr_block":                       "172.16.0.0/16",
+					"enable_dns_hostnames":             false,
+					"enable_dns_support":               false,
+					"instance_tenancy":                 "default",
+					"tags": {
+						"Name": "vpc-from-root-module",
+					},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_network_acl_id":         true,
+					"default_route_table_id":         true,
+					"default_security_group_id":      true,
+					"dhcp_options_id":                true,
+					"enable_classiclink":             true,
+					"enable_classiclink_dns_support": true,
+					"id": true,
+					"ipv6_association_id": true,
+					"ipv6_cidr_block":     true,
+					"main_route_table_id": true,
+					"owner_id":            true,
+					"tags":                {},
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "vpc_from_root_module",
+			"provider_name": "aws",
+			"type":          "aws_vpc",
+		},
+	],
+	"terraform_version": "0.12.24",
+	"variables": {
+		"cidr_for_nested_module": {
+			"value": "172.17.0.0/16",
+		},
+		"cidr_for_pmr_module": {
+			"value": "172.18.0.0/16",
+		},
+		"cidr_for_root": {
+			"value": "172.16.0.0/16",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-dns-support-for-vpcs/pass.json
+++ b/governance/third-generation/aws/test/require-dns-support-for-vpcs/pass.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-kms.json
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-kms.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-kms.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-vpc-and-kms.json
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-vpc-and-kms.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-vpc-and-kms.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-vpc.json
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/fail-vpc.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-vpc.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-kms.sentinel
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-kms.sentinel
@@ -1,0 +1,1183 @@
+terraform_version = "0.12.28"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_policy.lambda_basic_execution": {
+			"address":        "aws_iam_policy.lambda_basic_execution",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_basic_execution",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_kms": {
+			"address":        "aws_iam_policy.lambda_kms",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_kms",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_vpc_access": {
+			"address":        "aws_iam_policy.lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_role.role_for_lambda": {
+			"address":        "aws_iam_role.role_for_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "role_for_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_basic_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_basic_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_kms_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_kms_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+			"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_lambda_function.test_lambda": {
+			"address":        "aws_lambda_function.test_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_lambda_function",
+			"values": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    null,
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							"sg-042b9f3ab379aeb11",
+						],
+						"subnet_ids": [
+							"subnet-0395df0d90a099214",
+						],
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {
+	"aws_account_id": {
+		"name":  "aws_account_id",
+		"value": "753646501470",
+	},
+	"aws_region": {
+		"name":  "aws_region",
+		"value": "us-east-1",
+	},
+	"iam_basic_execution_policy": {
+		"name":  "iam_basic_execution_policy",
+		"value": "roger-basic-lambda-policy",
+	},
+	"iam_kms_lambda_policy": {
+		"name":  "iam_kms_lambda_policy",
+		"value": "roger-lambda-kms-policy",
+	},
+	"iam_role_name": {
+		"name":  "iam_role_name",
+		"value": "roger-lambda-role",
+	},
+	"iam_vpc_access_policy": {
+		"name":  "iam_vpc_access_policy",
+		"value": "roger-lambda-vpc_access-policy",
+	},
+	"kms_key": {
+		"name":  "kms_key",
+		"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+	},
+	"lambda_function_name": {
+		"name":  "lambda_function_name",
+		"value": "roger-test-lambda",
+	},
+	"security_group_id": {
+		"name":  "security_group_id",
+		"value": "sg-042b9f3ab379aeb11",
+	},
+	"subnet_id": {
+		"name":  "subnet_id",
+		"value": "subnet-0395df0d90a099214",
+	},
+}
+
+resource_changes = {
+	"aws_iam_policy.lambda_basic_execution": {
+		"address": "aws_iam_policy.lambda_basic_execution",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_basic_execution",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_kms": {
+		"address": "aws_iam_policy.lambda_kms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_kms",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_vpc_access": {
+		"address": "aws_iam_policy.lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_role.role_for_lambda": {
+		"address": "aws_iam_role.role_for_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+			"after_unknown": {
+				"arn":         true,
+				"create_date": true,
+				"id":          true,
+				"unique_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "role_for_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role",
+	},
+	"aws_iam_role_policy_attachment.attach_basic_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_basic_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_kms_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_kms_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+		"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_lambda_function.test_lambda": {
+		"address": "aws_lambda_function.test_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    null,
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							"sg-042b9f3ab379aeb11",
+						],
+						"subnet_ids": [
+							"subnet-0395df0d90a099214",
+						],
+					},
+				],
+			},
+			"after_unknown": {
+				"arn":                true,
+				"dead_letter_config": [],
+				"environment": [
+					{
+						"variables": {},
+					},
+				],
+				"file_system_config": [],
+				"id":                 true,
+				"invoke_arn":         true,
+				"last_modified":      true,
+				"qualified_arn":      true,
+				"role":               true,
+				"source_code_size":   true,
+				"tracing_config":     true,
+				"version":            true,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							false,
+						],
+						"subnet_ids": [
+							false,
+						],
+						"vpc_id": true,
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "test_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_lambda_function",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"references": [
+							"var.aws_region",
+						],
+					},
+				},
+				"name": "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_iam_policy.lambda_basic_execution",
+					"expressions": {
+						"description": {
+							"constant_value": "A basic lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_basic_execution_policy",
+							],
+						},
+						"policy": {
+							"references": [
+								"var.aws_region",
+								"var.aws_account_id",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_basic_execution",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_kms",
+					"expressions": {
+						"description": {
+							"constant_value": "A kms lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_kms_lambda_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_kms",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_vpc_access",
+					"expressions": {
+						"description": {
+							"constant_value": "A lambda vpc access policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_vpc_access_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_role.role_for_lambda",
+					"expressions": {
+						"assume_role_policy": {
+							"constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						},
+						"name": {
+							"references": [
+								"var.iam_role_name",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "role_for_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_basic_execution",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_basic_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_kms",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_kms_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_vpc_access",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_lambda_function.test_lambda",
+					"expressions": {
+						"environment": [
+							{
+								"variables": {
+									"constant_value": {
+										"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+									},
+								},
+							},
+						],
+						"filename": {
+							"constant_value": "app.zip",
+						},
+						"function_name": {
+							"references": [
+								"var.lambda_function_name",
+							],
+						},
+						"handler": {
+							"constant_value": "app.handler",
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+						"runtime": {
+							"constant_value": "python2.7",
+						},
+						"source_code_hash": {},
+						"vpc_config": [
+							{
+								"security_group_ids": {
+									"references": [
+										"var.security_group_id",
+									],
+								},
+								"subnet_ids": {
+									"references": [
+										"var.subnet_id",
+									],
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "test_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_lambda_function",
+				},
+			],
+			"variables": {
+				"aws_account_id": {
+					"default":     "753646501470",
+					"description": "ID of your AWS account",
+				},
+				"aws_region": {
+					"default":     "us-east-1",
+					"description": "AWS region",
+				},
+				"iam_basic_execution_policy": {
+					"default":     "roger-basic-lambda-policy",
+					"description": "name of basic execution policy",
+				},
+				"iam_kms_lambda_policy": {
+					"default":     "roger-lambda-kms-policy",
+					"description": "name of KMS Lambda policy",
+				},
+				"iam_role_name": {
+					"default":     "roger-lambda-role",
+					"description": "name of IAM role",
+				},
+				"iam_vpc_access_policy": {
+					"default":     "roger-lambda-vpc_access-policy",
+					"description": "name of vpc access policy",
+				},
+				"kms_key": {
+					"default":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"description": "arn of KMS key",
+				},
+				"lambda_function_name": {
+					"default":     "roger-test-lambda",
+					"description": "name of Lambda function",
+				},
+				"security_group_id": {
+					"default":     "sg-042b9f3ab379aeb11",
+					"description": "ID of security group",
+				},
+				"subnet_id": {
+					"default":     "subnet-0395df0d90a099214",
+					"description": "ID of subnet",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_iam_policy.lambda_basic_execution",
+					"mode":           "managed",
+					"name":           "lambda_basic_execution",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A basic lambda policy",
+						"name":        "roger-basic-lambda-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_kms",
+					"mode":           "managed",
+					"name":           "lambda_kms",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A kms lambda policy",
+						"name":        "roger-lambda-kms-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A lambda vpc access policy",
+						"name":        "roger-lambda-vpc_access-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_role.role_for_lambda",
+					"mode":           "managed",
+					"name":           "role_for_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role",
+					"values": {
+						"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						"description":           null,
+						"force_detach_policies": false,
+						"max_session_duration":  3600,
+						"name":                  "roger-lambda-role",
+						"name_prefix":           null,
+						"path":                  "/",
+						"permissions_boundary":  null,
+						"tags":                  null,
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"mode":           "managed",
+					"name":           "attach_basic_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"mode":           "managed",
+					"name":           "attach_kms_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "attach_lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_lambda_function.test_lambda",
+					"mode":           "managed",
+					"name":           "test_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_lambda_function",
+					"values": {
+						"dead_letter_config": [],
+						"description":        null,
+						"environment": [
+							{
+								"variables": {
+									"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+								},
+							},
+						],
+						"file_system_config":             [],
+						"filename":                       "app.zip",
+						"function_name":                  "roger-test-lambda",
+						"handler":                        "app.handler",
+						"kms_key_arn":                    null,
+						"layers":                         null,
+						"memory_size":                    128,
+						"publish":                        false,
+						"reserved_concurrent_executions": -1,
+						"runtime":                        "python2.7",
+						"s3_bucket":                      null,
+						"s3_key":                         null,
+						"s3_object_version":              null,
+						"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+						"tags":                           null,
+						"timeout":                        3,
+						"timeouts":                       null,
+						"vpc_config": [
+							{
+								"security_group_ids": [
+									"sg-042b9f3ab379aeb11",
+								],
+								"subnet_ids": [
+									"subnet-0395df0d90a099214",
+								],
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_iam_policy.lambda_basic_execution",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A basic lambda policy",
+					"name":        "roger-basic-lambda-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_basic_execution",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_kms",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A kms lambda policy",
+					"name":        "roger-lambda-kms-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_kms",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A lambda vpc access policy",
+					"name":        "roger-lambda-vpc_access-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_role.role_for_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+					"description":           null,
+					"force_detach_policies": false,
+					"max_session_duration":  3600,
+					"name":                  "roger-lambda-role",
+					"name_prefix":           null,
+					"path":                  "/",
+					"permissions_boundary":  null,
+					"tags":                  null,
+				},
+				"after_unknown": {
+					"arn":         true,
+					"create_date": true,
+					"id":          true,
+					"unique_id":   true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "role_for_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_basic_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_kms_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_lambda_function.test_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"dead_letter_config": [],
+					"description":        null,
+					"environment": [
+						{
+							"variables": {
+								"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+							},
+						},
+					],
+					"file_system_config":             [],
+					"filename":                       "app.zip",
+					"function_name":                  "roger-test-lambda",
+					"handler":                        "app.handler",
+					"kms_key_arn":                    null,
+					"layers":                         null,
+					"memory_size":                    128,
+					"publish":                        false,
+					"reserved_concurrent_executions": -1,
+					"runtime":                        "python2.7",
+					"s3_bucket":                      null,
+					"s3_key":                         null,
+					"s3_object_version":              null,
+					"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+					"tags":                           null,
+					"timeout":                        3,
+					"timeouts":                       null,
+					"vpc_config": [
+						{
+							"security_group_ids": [
+								"sg-042b9f3ab379aeb11",
+							],
+							"subnet_ids": [
+								"subnet-0395df0d90a099214",
+							],
+						},
+					],
+				},
+				"after_unknown": {
+					"arn":                true,
+					"dead_letter_config": [],
+					"environment": [
+						{
+							"variables": {},
+						},
+					],
+					"file_system_config": [],
+					"id":                 true,
+					"invoke_arn":         true,
+					"last_modified":      true,
+					"qualified_arn":      true,
+					"role":               true,
+					"source_code_size":   true,
+					"tracing_config":     true,
+					"version":            true,
+					"vpc_config": [
+						{
+							"security_group_ids": [
+								false,
+							],
+							"subnet_ids": [
+								false,
+							],
+							"vpc_id": true,
+						},
+					],
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "test_lambda",
+			"provider_name": "aws",
+			"type":          "aws_lambda_function",
+		},
+	],
+	"terraform_version": "0.12.28",
+	"variables": {
+		"aws_account_id": {
+			"value": "753646501470",
+		},
+		"aws_region": {
+			"value": "us-east-1",
+		},
+		"iam_basic_execution_policy": {
+			"value": "roger-basic-lambda-policy",
+		},
+		"iam_kms_lambda_policy": {
+			"value": "roger-lambda-kms-policy",
+		},
+		"iam_role_name": {
+			"value": "roger-lambda-role",
+		},
+		"iam_vpc_access_policy": {
+			"value": "roger-lambda-vpc_access-policy",
+		},
+		"kms_key": {
+			"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+		},
+		"lambda_function_name": {
+			"value": "roger-test-lambda",
+		},
+		"security_group_id": {
+			"value": "sg-042b9f3ab379aeb11",
+		},
+		"subnet_id": {
+			"value": "subnet-0395df0d90a099214",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-vpc-and-kms.sentinel
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-vpc-and-kms.sentinel
@@ -1,0 +1,1118 @@
+terraform_version = "0.12.28"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_policy.lambda_basic_execution": {
+			"address":        "aws_iam_policy.lambda_basic_execution",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_basic_execution",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_kms": {
+			"address":        "aws_iam_policy.lambda_kms",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_kms",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_vpc_access": {
+			"address":        "aws_iam_policy.lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_role.role_for_lambda": {
+			"address":        "aws_iam_role.role_for_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "role_for_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_basic_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_basic_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_kms_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_kms_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+			"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_lambda_function.test_lambda": {
+			"address":        "aws_lambda_function.test_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_lambda_function",
+			"values": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config":                     [],
+			},
+		},
+	},
+}
+
+variables = {
+	"aws_account_id": {
+		"name":  "aws_account_id",
+		"value": "753646501470",
+	},
+	"aws_region": {
+		"name":  "aws_region",
+		"value": "us-east-1",
+	},
+	"iam_basic_execution_policy": {
+		"name":  "iam_basic_execution_policy",
+		"value": "roger-basic-lambda-policy",
+	},
+	"iam_kms_lambda_policy": {
+		"name":  "iam_kms_lambda_policy",
+		"value": "roger-lambda-kms-policy",
+	},
+	"iam_role_name": {
+		"name":  "iam_role_name",
+		"value": "roger-lambda-role",
+	},
+	"iam_vpc_access_policy": {
+		"name":  "iam_vpc_access_policy",
+		"value": "roger-lambda-vpc_access-policy",
+	},
+	"kms_key": {
+		"name":  "kms_key",
+		"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+	},
+	"lambda_function_name": {
+		"name":  "lambda_function_name",
+		"value": "roger-test-lambda",
+	},
+	"security_group_id": {
+		"name":  "security_group_id",
+		"value": "sg-042b9f3ab379aeb11",
+	},
+	"subnet_id": {
+		"name":  "subnet_id",
+		"value": "subnet-0395df0d90a099214",
+	},
+}
+
+resource_changes = {
+	"aws_iam_policy.lambda_basic_execution": {
+		"address": "aws_iam_policy.lambda_basic_execution",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_basic_execution",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_kms": {
+		"address": "aws_iam_policy.lambda_kms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_kms",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_vpc_access": {
+		"address": "aws_iam_policy.lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_role.role_for_lambda": {
+		"address": "aws_iam_role.role_for_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+			"after_unknown": {
+				"arn":         true,
+				"create_date": true,
+				"id":          true,
+				"unique_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "role_for_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role",
+	},
+	"aws_iam_role_policy_attachment.attach_basic_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_basic_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_kms_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_kms_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+		"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_lambda_function.test_lambda": {
+		"address": "aws_lambda_function.test_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    null,
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config":                     [],
+			},
+			"after_unknown": {
+				"arn":                true,
+				"dead_letter_config": [],
+				"environment": [
+					{
+						"variables": {},
+					},
+				],
+				"file_system_config": [],
+				"id":                 true,
+				"invoke_arn":         true,
+				"last_modified":      true,
+				"qualified_arn":      true,
+				"role":               true,
+				"source_code_size":   true,
+				"tracing_config":     true,
+				"version":            true,
+				"vpc_config":         [],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "test_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_lambda_function",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"references": [
+							"var.aws_region",
+						],
+					},
+				},
+				"name": "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_iam_policy.lambda_basic_execution",
+					"expressions": {
+						"description": {
+							"constant_value": "A basic lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_basic_execution_policy",
+							],
+						},
+						"policy": {
+							"references": [
+								"var.aws_region",
+								"var.aws_account_id",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_basic_execution",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_kms",
+					"expressions": {
+						"description": {
+							"constant_value": "A kms lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_kms_lambda_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_kms",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_vpc_access",
+					"expressions": {
+						"description": {
+							"constant_value": "A lambda vpc access policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_vpc_access_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_role.role_for_lambda",
+					"expressions": {
+						"assume_role_policy": {
+							"constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						},
+						"name": {
+							"references": [
+								"var.iam_role_name",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "role_for_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_basic_execution",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_basic_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_kms",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_kms_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_vpc_access",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_lambda_function.test_lambda",
+					"expressions": {
+						"environment": [
+							{
+								"variables": {
+									"constant_value": {
+										"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+									},
+								},
+							},
+						],
+						"filename": {
+							"constant_value": "app.zip",
+						},
+						"function_name": {
+							"references": [
+								"var.lambda_function_name",
+							],
+						},
+						"handler": {
+							"constant_value": "app.handler",
+						},
+						"kms_key_arn": {
+							"references": [
+								"var.kms_key",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+						"runtime": {
+							"constant_value": "python2.7",
+						},
+						"source_code_hash": {},
+					},
+					"mode":                "managed",
+					"name":                "test_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_lambda_function",
+				},
+			],
+			"variables": {
+				"aws_account_id": {
+					"default":     "753646501470",
+					"description": "ID of your AWS account",
+				},
+				"aws_region": {
+					"default":     "us-east-1",
+					"description": "AWS region",
+				},
+				"iam_basic_execution_policy": {
+					"default":     "roger-basic-lambda-policy",
+					"description": "name of basic execution policy",
+				},
+				"iam_kms_lambda_policy": {
+					"default":     "roger-lambda-kms-policy",
+					"description": "name of KMS Lambda policy",
+				},
+				"iam_role_name": {
+					"default":     "roger-lambda-role",
+					"description": "name of IAM role",
+				},
+				"iam_vpc_access_policy": {
+					"default":     "roger-lambda-vpc_access-policy",
+					"description": "name of vpc access policy",
+				},
+				"kms_key": {
+					"default":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"description": "arn of KMS key",
+				},
+				"lambda_function_name": {
+					"default":     "roger-test-lambda",
+					"description": "name of Lambda function",
+				},
+				"security_group_id": {
+					"default":     "sg-042b9f3ab379aeb11",
+					"description": "ID of security group",
+				},
+				"subnet_id": {
+					"default":     "subnet-0395df0d90a099214",
+					"description": "ID of subnet",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_iam_policy.lambda_basic_execution",
+					"mode":           "managed",
+					"name":           "lambda_basic_execution",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A basic lambda policy",
+						"name":        "roger-basic-lambda-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_kms",
+					"mode":           "managed",
+					"name":           "lambda_kms",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A kms lambda policy",
+						"name":        "roger-lambda-kms-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A lambda vpc access policy",
+						"name":        "roger-lambda-vpc_access-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_role.role_for_lambda",
+					"mode":           "managed",
+					"name":           "role_for_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role",
+					"values": {
+						"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						"description":           null,
+						"force_detach_policies": false,
+						"max_session_duration":  3600,
+						"name":                  "roger-lambda-role",
+						"name_prefix":           null,
+						"path":                  "/",
+						"permissions_boundary":  null,
+						"tags":                  null,
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"mode":           "managed",
+					"name":           "attach_basic_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"mode":           "managed",
+					"name":           "attach_kms_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "attach_lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_lambda_function.test_lambda",
+					"mode":           "managed",
+					"name":           "test_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_lambda_function",
+					"values": {
+						"dead_letter_config": [],
+						"description":        null,
+						"environment": [
+							{
+								"variables": {
+									"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+								},
+							},
+						],
+						"file_system_config":             [],
+						"filename":                       "app.zip",
+						"function_name":                  "roger-test-lambda",
+						"handler":                        "app.handler",
+						"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+						"layers":                         null,
+						"memory_size":                    128,
+						"publish":                        false,
+						"reserved_concurrent_executions": -1,
+						"runtime":                        "python2.7",
+						"s3_bucket":                      null,
+						"s3_key":                         null,
+						"s3_object_version":              null,
+						"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+						"tags":                           null,
+						"timeout":                        3,
+						"timeouts":                       null,
+						"vpc_config":                     [],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_iam_policy.lambda_basic_execution",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A basic lambda policy",
+					"name":        "roger-basic-lambda-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_basic_execution",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_kms",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A kms lambda policy",
+					"name":        "roger-lambda-kms-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_kms",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A lambda vpc access policy",
+					"name":        "roger-lambda-vpc_access-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_role.role_for_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+					"description":           null,
+					"force_detach_policies": false,
+					"max_session_duration":  3600,
+					"name":                  "roger-lambda-role",
+					"name_prefix":           null,
+					"path":                  "/",
+					"permissions_boundary":  null,
+					"tags":                  null,
+				},
+				"after_unknown": {
+					"arn":         true,
+					"create_date": true,
+					"id":          true,
+					"unique_id":   true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "role_for_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_basic_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_kms_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_lambda_function.test_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"dead_letter_config": [],
+					"description":        null,
+					"environment": [
+						{
+							"variables": {
+								"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+							},
+						},
+					],
+					"file_system_config":             [],
+					"filename":                       "app.zip",
+					"function_name":                  "roger-test-lambda",
+					"handler":                        "app.handler",
+					"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"layers":                         null,
+					"memory_size":                    128,
+					"publish":                        false,
+					"reserved_concurrent_executions": -1,
+					"runtime":                        "python2.7",
+					"s3_bucket":                      null,
+					"s3_key":                         null,
+					"s3_object_version":              null,
+					"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+					"tags":                           null,
+					"timeout":                        3,
+					"timeouts":                       null,
+					"vpc_config":                     [],
+				},
+				"after_unknown": {
+					"arn":                true,
+					"dead_letter_config": [],
+					"environment": [
+						{
+							"variables": {},
+						},
+					],
+					"file_system_config": [],
+					"id":                 true,
+					"invoke_arn":         true,
+					"last_modified":      true,
+					"qualified_arn":      true,
+					"role":               true,
+					"source_code_size":   true,
+					"tracing_config":     true,
+					"version":            true,
+					"vpc_config":         [],
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "test_lambda",
+			"provider_name": "aws",
+			"type":          "aws_lambda_function",
+		},
+	],
+	"terraform_version": "0.12.28",
+	"variables": {
+		"aws_account_id": {
+			"value": "753646501470",
+		},
+		"aws_region": {
+			"value": "us-east-1",
+		},
+		"iam_basic_execution_policy": {
+			"value": "roger-basic-lambda-policy",
+		},
+		"iam_kms_lambda_policy": {
+			"value": "roger-lambda-kms-policy",
+		},
+		"iam_role_name": {
+			"value": "roger-lambda-role",
+		},
+		"iam_vpc_access_policy": {
+			"value": "roger-lambda-vpc_access-policy",
+		},
+		"kms_key": {
+			"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+		},
+		"lambda_function_name": {
+			"value": "roger-test-lambda",
+		},
+		"security_group_id": {
+			"value": "sg-042b9f3ab379aeb11",
+		},
+		"subnet_id": {
+			"value": "subnet-0395df0d90a099214",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-vpc.sentinel
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-fail-vpc.sentinel
@@ -1,0 +1,1118 @@
+terraform_version = "0.12.28"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_policy.lambda_basic_execution": {
+			"address":        "aws_iam_policy.lambda_basic_execution",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_basic_execution",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_kms": {
+			"address":        "aws_iam_policy.lambda_kms",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_kms",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_vpc_access": {
+			"address":        "aws_iam_policy.lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_role.role_for_lambda": {
+			"address":        "aws_iam_role.role_for_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "role_for_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_basic_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_basic_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_kms_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_kms_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+			"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_lambda_function.test_lambda": {
+			"address":        "aws_lambda_function.test_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_lambda_function",
+			"values": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config":                     [],
+			},
+		},
+	},
+}
+
+variables = {
+	"aws_account_id": {
+		"name":  "aws_account_id",
+		"value": "753646501470",
+	},
+	"aws_region": {
+		"name":  "aws_region",
+		"value": "us-east-1",
+	},
+	"iam_basic_execution_policy": {
+		"name":  "iam_basic_execution_policy",
+		"value": "roger-basic-lambda-policy",
+	},
+	"iam_kms_lambda_policy": {
+		"name":  "iam_kms_lambda_policy",
+		"value": "roger-lambda-kms-policy",
+	},
+	"iam_role_name": {
+		"name":  "iam_role_name",
+		"value": "roger-lambda-role",
+	},
+	"iam_vpc_access_policy": {
+		"name":  "iam_vpc_access_policy",
+		"value": "roger-lambda-vpc_access-policy",
+	},
+	"kms_key": {
+		"name":  "kms_key",
+		"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+	},
+	"lambda_function_name": {
+		"name":  "lambda_function_name",
+		"value": "roger-test-lambda",
+	},
+	"security_group_id": {
+		"name":  "security_group_id",
+		"value": "sg-042b9f3ab379aeb11",
+	},
+	"subnet_id": {
+		"name":  "subnet_id",
+		"value": "subnet-0395df0d90a099214",
+	},
+}
+
+resource_changes = {
+	"aws_iam_policy.lambda_basic_execution": {
+		"address": "aws_iam_policy.lambda_basic_execution",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_basic_execution",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_kms": {
+		"address": "aws_iam_policy.lambda_kms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_kms",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_vpc_access": {
+		"address": "aws_iam_policy.lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_role.role_for_lambda": {
+		"address": "aws_iam_role.role_for_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+			"after_unknown": {
+				"arn":         true,
+				"create_date": true,
+				"id":          true,
+				"unique_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "role_for_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role",
+	},
+	"aws_iam_role_policy_attachment.attach_basic_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_basic_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_kms_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_kms_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+		"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_lambda_function.test_lambda": {
+		"address": "aws_lambda_function.test_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config":                     [],
+			},
+			"after_unknown": {
+				"arn":                true,
+				"dead_letter_config": [],
+				"environment": [
+					{
+						"variables": {},
+					},
+				],
+				"file_system_config": [],
+				"id":                 true,
+				"invoke_arn":         true,
+				"last_modified":      true,
+				"qualified_arn":      true,
+				"role":               true,
+				"source_code_size":   true,
+				"tracing_config":     true,
+				"version":            true,
+				"vpc_config":         [],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "test_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_lambda_function",
+	},
+}
+
+output_changes = {}
+
+raw = {
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"references": [
+							"var.aws_region",
+						],
+					},
+				},
+				"name": "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_iam_policy.lambda_basic_execution",
+					"expressions": {
+						"description": {
+							"constant_value": "A basic lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_basic_execution_policy",
+							],
+						},
+						"policy": {
+							"references": [
+								"var.aws_region",
+								"var.aws_account_id",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_basic_execution",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_kms",
+					"expressions": {
+						"description": {
+							"constant_value": "A kms lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_kms_lambda_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_kms",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_vpc_access",
+					"expressions": {
+						"description": {
+							"constant_value": "A lambda vpc access policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_vpc_access_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_role.role_for_lambda",
+					"expressions": {
+						"assume_role_policy": {
+							"constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						},
+						"name": {
+							"references": [
+								"var.iam_role_name",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "role_for_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_basic_execution",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_basic_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_kms",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_kms_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_vpc_access",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_lambda_function.test_lambda",
+					"expressions": {
+						"environment": [
+							{
+								"variables": {
+									"constant_value": {
+										"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+									},
+								},
+							},
+						],
+						"filename": {
+							"constant_value": "app.zip",
+						},
+						"function_name": {
+							"references": [
+								"var.lambda_function_name",
+							],
+						},
+						"handler": {
+							"constant_value": "app.handler",
+						},
+						"kms_key_arn": {
+							"references": [
+								"var.kms_key",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+						"runtime": {
+							"constant_value": "python2.7",
+						},
+						"source_code_hash": {},
+					},
+					"mode":                "managed",
+					"name":                "test_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_lambda_function",
+				},
+			],
+			"variables": {
+				"aws_account_id": {
+					"default":     "753646501470",
+					"description": "ID of your AWS account",
+				},
+				"aws_region": {
+					"default":     "us-east-1",
+					"description": "AWS region",
+				},
+				"iam_basic_execution_policy": {
+					"default":     "roger-basic-lambda-policy",
+					"description": "name of basic execution policy",
+				},
+				"iam_kms_lambda_policy": {
+					"default":     "roger-lambda-kms-policy",
+					"description": "name of KMS Lambda policy",
+				},
+				"iam_role_name": {
+					"default":     "roger-lambda-role",
+					"description": "name of IAM role",
+				},
+				"iam_vpc_access_policy": {
+					"default":     "roger-lambda-vpc_access-policy",
+					"description": "name of vpc access policy",
+				},
+				"kms_key": {
+					"default":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"description": "arn of KMS key",
+				},
+				"lambda_function_name": {
+					"default":     "roger-test-lambda",
+					"description": "name of Lambda function",
+				},
+				"security_group_id": {
+					"default":     "sg-042b9f3ab379aeb11",
+					"description": "ID of security group",
+				},
+				"subnet_id": {
+					"default":     "subnet-0395df0d90a099214",
+					"description": "ID of subnet",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_iam_policy.lambda_basic_execution",
+					"mode":           "managed",
+					"name":           "lambda_basic_execution",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A basic lambda policy",
+						"name":        "roger-basic-lambda-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_kms",
+					"mode":           "managed",
+					"name":           "lambda_kms",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A kms lambda policy",
+						"name":        "roger-lambda-kms-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A lambda vpc access policy",
+						"name":        "roger-lambda-vpc_access-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_role.role_for_lambda",
+					"mode":           "managed",
+					"name":           "role_for_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role",
+					"values": {
+						"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						"description":           null,
+						"force_detach_policies": false,
+						"max_session_duration":  3600,
+						"name":                  "roger-lambda-role",
+						"name_prefix":           null,
+						"path":                  "/",
+						"permissions_boundary":  null,
+						"tags":                  null,
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"mode":           "managed",
+					"name":           "attach_basic_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"mode":           "managed",
+					"name":           "attach_kms_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "attach_lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_lambda_function.test_lambda",
+					"mode":           "managed",
+					"name":           "test_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_lambda_function",
+					"values": {
+						"dead_letter_config": [],
+						"description":        null,
+						"environment": [
+							{
+								"variables": {
+									"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+								},
+							},
+						],
+						"file_system_config":             [],
+						"filename":                       "app.zip",
+						"function_name":                  "roger-test-lambda",
+						"handler":                        "app.handler",
+						"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+						"layers":                         null,
+						"memory_size":                    128,
+						"publish":                        false,
+						"reserved_concurrent_executions": -1,
+						"runtime":                        "python2.7",
+						"s3_bucket":                      null,
+						"s3_key":                         null,
+						"s3_object_version":              null,
+						"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+						"tags":                           null,
+						"timeout":                        3,
+						"timeouts":                       null,
+						"vpc_config":                     [],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_iam_policy.lambda_basic_execution",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A basic lambda policy",
+					"name":        "roger-basic-lambda-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_basic_execution",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_kms",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A kms lambda policy",
+					"name":        "roger-lambda-kms-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_kms",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A lambda vpc access policy",
+					"name":        "roger-lambda-vpc_access-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_role.role_for_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+					"description":           null,
+					"force_detach_policies": false,
+					"max_session_duration":  3600,
+					"name":                  "roger-lambda-role",
+					"name_prefix":           null,
+					"path":                  "/",
+					"permissions_boundary":  null,
+					"tags":                  null,
+				},
+				"after_unknown": {
+					"arn":         true,
+					"create_date": true,
+					"id":          true,
+					"unique_id":   true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "role_for_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_basic_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_kms_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_lambda_function.test_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"dead_letter_config": [],
+					"description":        null,
+					"environment": [
+						{
+							"variables": {
+								"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+							},
+						},
+					],
+					"file_system_config":             [],
+					"filename":                       "app.zip",
+					"function_name":                  "roger-test-lambda",
+					"handler":                        "app.handler",
+					"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"layers":                         null,
+					"memory_size":                    128,
+					"publish":                        false,
+					"reserved_concurrent_executions": -1,
+					"runtime":                        "python2.7",
+					"s3_bucket":                      null,
+					"s3_key":                         null,
+					"s3_object_version":              null,
+					"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+					"tags":                           null,
+					"timeout":                        3,
+					"timeouts":                       null,
+					"vpc_config":                     [],
+				},
+				"after_unknown": {
+					"arn":                true,
+					"dead_letter_config": [],
+					"environment": [
+						{
+							"variables": {},
+						},
+					],
+					"file_system_config": [],
+					"id":                 true,
+					"invoke_arn":         true,
+					"last_modified":      true,
+					"qualified_arn":      true,
+					"role":               true,
+					"source_code_size":   true,
+					"tracing_config":     true,
+					"version":            true,
+					"vpc_config":         [],
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "test_lambda",
+			"provider_name": "aws",
+			"type":          "aws_lambda_function",
+		},
+	],
+	"terraform_version": "0.12.28",
+	"variables": {
+		"aws_account_id": {
+			"value": "753646501470",
+		},
+		"aws_region": {
+			"value": "us-east-1",
+		},
+		"iam_basic_execution_policy": {
+			"value": "roger-basic-lambda-policy",
+		},
+		"iam_kms_lambda_policy": {
+			"value": "roger-lambda-kms-policy",
+		},
+		"iam_role_name": {
+			"value": "roger-lambda-role",
+		},
+		"iam_vpc_access_policy": {
+			"value": "roger-lambda-vpc_access-policy",
+		},
+		"kms_key": {
+			"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+		},
+		"lambda_function_name": {
+			"value": "roger-test-lambda",
+		},
+		"security_group_id": {
+			"value": "sg-042b9f3ab379aeb11",
+		},
+		"subnet_id": {
+			"value": "subnet-0395df0d90a099214",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/mock-tfplan-pass.sentinel
@@ -1,0 +1,1231 @@
+terraform_version = "0.12.28"
+
+planned_values = {
+	"outputs": {
+		"kms_key_arn": {
+			"name":      "kms_key_arn",
+			"sensitive": false,
+			"value":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+		},
+	},
+	"resources": {
+		"aws_iam_policy.lambda_basic_execution": {
+			"address":        "aws_iam_policy.lambda_basic_execution",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_basic_execution",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_kms": {
+			"address":        "aws_iam_policy.lambda_kms",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_kms",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_policy.lambda_vpc_access": {
+			"address":        "aws_iam_policy.lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_policy",
+			"values": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+		},
+		"aws_iam_role.role_for_lambda": {
+			"address":        "aws_iam_role.role_for_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "role_for_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_basic_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_basic_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_kms_lambda": {
+			"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_kms_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+			"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "attach_lambda_vpc_access",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "roger-lambda-role",
+			},
+		},
+		"aws_lambda_function.test_lambda": {
+			"address":        "aws_lambda_function.test_lambda",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_lambda",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_lambda_function",
+			"values": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							"sg-042b9f3ab379aeb11",
+						],
+						"subnet_ids": [
+							"subnet-0395df0d90a099214",
+						],
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {
+	"aws_account_id": {
+		"name":  "aws_account_id",
+		"value": "753646501470",
+	},
+	"aws_region": {
+		"name":  "aws_region",
+		"value": "us-east-1",
+	},
+	"iam_basic_execution_policy": {
+		"name":  "iam_basic_execution_policy",
+		"value": "roger-basic-lambda-policy",
+	},
+	"iam_kms_lambda_policy": {
+		"name":  "iam_kms_lambda_policy",
+		"value": "roger-lambda-kms-policy",
+	},
+	"iam_role_name": {
+		"name":  "iam_role_name",
+		"value": "roger-lambda-role",
+	},
+	"iam_vpc_access_policy": {
+		"name":  "iam_vpc_access_policy",
+		"value": "roger-lambda-vpc_access-policy",
+	},
+	"kms_key": {
+		"name":  "kms_key",
+		"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+	},
+	"lambda_function_name": {
+		"name":  "lambda_function_name",
+		"value": "roger-test-lambda",
+	},
+	"security_group_id": {
+		"name":  "security_group_id",
+		"value": "sg-042b9f3ab379aeb11",
+	},
+	"subnet_id": {
+		"name":  "subnet_id",
+		"value": "subnet-0395df0d90a099214",
+	},
+}
+
+resource_changes = {
+	"aws_iam_policy.lambda_basic_execution": {
+		"address": "aws_iam_policy.lambda_basic_execution",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A basic lambda policy",
+				"name":        "roger-basic-lambda-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_basic_execution",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_kms": {
+		"address": "aws_iam_policy.lambda_kms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A kms lambda policy",
+				"name":        "roger-lambda-kms-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_kms",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_policy.lambda_vpc_access": {
+		"address": "aws_iam_policy.lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "A lambda vpc access policy",
+				"name":        "roger-lambda-vpc_access-policy",
+				"name_prefix": null,
+				"path":        "/",
+				"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_policy",
+	},
+	"aws_iam_role.role_for_lambda": {
+		"address": "aws_iam_role.role_for_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "roger-lambda-role",
+				"name_prefix":           null,
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags":                  null,
+			},
+			"after_unknown": {
+				"arn":         true,
+				"create_date": true,
+				"id":          true,
+				"unique_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "role_for_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role",
+	},
+	"aws_iam_role_policy_attachment.attach_basic_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_basic_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_kms_lambda": {
+		"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_kms_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_iam_role_policy_attachment.attach_lambda_vpc_access": {
+		"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"role": "roger-lambda-role",
+			},
+			"after_unknown": {
+				"id":         true,
+				"policy_arn": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "attach_lambda_vpc_access",
+		"provider_name":  "aws",
+		"type":           "aws_iam_role_policy_attachment",
+	},
+	"aws_lambda_function.test_lambda": {
+		"address": "aws_lambda_function.test_lambda",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"dead_letter_config": [],
+				"description":        null,
+				"environment": [
+					{
+						"variables": {
+							"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+						},
+					},
+				],
+				"file_system_config":             [],
+				"filename":                       "app.zip",
+				"function_name":                  "roger-test-lambda",
+				"handler":                        "app.handler",
+				"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+				"layers":                         null,
+				"memory_size":                    128,
+				"publish":                        false,
+				"reserved_concurrent_executions": -1,
+				"runtime":                        "python2.7",
+				"s3_bucket":                      null,
+				"s3_key":                         null,
+				"s3_object_version":              null,
+				"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+				"tags":                           null,
+				"timeout":                        3,
+				"timeouts":                       null,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							"sg-042b9f3ab379aeb11",
+						],
+						"subnet_ids": [
+							"subnet-0395df0d90a099214",
+						],
+					},
+				],
+			},
+			"after_unknown": {
+				"arn":                true,
+				"dead_letter_config": [],
+				"environment": [
+					{
+						"variables": {},
+					},
+				],
+				"file_system_config": [],
+				"id":                 true,
+				"invoke_arn":         true,
+				"last_modified":      true,
+				"qualified_arn":      true,
+				"role":               true,
+				"source_code_size":   true,
+				"tracing_config":     true,
+				"version":            true,
+				"vpc_config": [
+					{
+						"security_group_ids": [
+							false,
+						],
+						"subnet_ids": [
+							false,
+						],
+						"vpc_id": true,
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "test_lambda",
+		"provider_name":  "aws",
+		"type":           "aws_lambda_function",
+	},
+}
+
+output_changes = {
+	"kms_key_arn": {
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after":         "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+			"after_unknown": false,
+			"before":        null,
+		},
+		"name": "kms_key_arn",
+	},
+}
+
+raw = {
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"references": [
+							"var.aws_region",
+						],
+					},
+				},
+				"name": "aws",
+			},
+		},
+		"root_module": {
+			"outputs": {
+				"kms_key_arn": {
+					"expression": {
+						"references": [
+							"aws_lambda_function.test_lambda",
+						],
+					},
+				},
+			},
+			"resources": [
+				{
+					"address": "aws_iam_policy.lambda_basic_execution",
+					"expressions": {
+						"description": {
+							"constant_value": "A basic lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_basic_execution_policy",
+							],
+						},
+						"policy": {
+							"references": [
+								"var.aws_region",
+								"var.aws_account_id",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_basic_execution",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_kms",
+					"expressions": {
+						"description": {
+							"constant_value": "A kms lambda policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_kms_lambda_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_kms",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_policy.lambda_vpc_access",
+					"expressions": {
+						"description": {
+							"constant_value": "A lambda vpc access policy",
+						},
+						"name": {
+							"references": [
+								"var.iam_vpc_access_policy",
+							],
+						},
+						"policy": {
+							"constant_value": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+						},
+					},
+					"mode":                "managed",
+					"name":                "lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_policy",
+				},
+				{
+					"address": "aws_iam_role.role_for_lambda",
+					"expressions": {
+						"assume_role_policy": {
+							"constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						},
+						"name": {
+							"references": [
+								"var.iam_role_name",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "role_for_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_basic_execution",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_basic_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_kms",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_kms_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"expressions": {
+						"policy_arn": {
+							"references": [
+								"aws_iam_policy.lambda_vpc_access",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "attach_lambda_vpc_access",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_iam_role_policy_attachment",
+				},
+				{
+					"address": "aws_lambda_function.test_lambda",
+					"expressions": {
+						"environment": [
+							{
+								"variables": {
+									"constant_value": {
+										"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+									},
+								},
+							},
+						],
+						"filename": {
+							"constant_value": "app.zip",
+						},
+						"function_name": {
+							"references": [
+								"var.lambda_function_name",
+							],
+						},
+						"handler": {
+							"constant_value": "app.handler",
+						},
+						"kms_key_arn": {
+							"references": [
+								"var.kms_key",
+							],
+						},
+						"role": {
+							"references": [
+								"aws_iam_role.role_for_lambda",
+							],
+						},
+						"runtime": {
+							"constant_value": "python2.7",
+						},
+						"source_code_hash": {},
+						"vpc_config": [
+							{
+								"security_group_ids": {
+									"references": [
+										"var.security_group_id",
+									],
+								},
+								"subnet_ids": {
+									"references": [
+										"var.subnet_id",
+									],
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "test_lambda",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_lambda_function",
+				},
+			],
+			"variables": {
+				"aws_account_id": {
+					"default":     "753646501470",
+					"description": "ID of your AWS account",
+				},
+				"aws_region": {
+					"default":     "us-east-1",
+					"description": "AWS region",
+				},
+				"iam_basic_execution_policy": {
+					"default":     "roger-basic-lambda-policy",
+					"description": "name of basic execution policy",
+				},
+				"iam_kms_lambda_policy": {
+					"default":     "roger-lambda-kms-policy",
+					"description": "name of KMS Lambda policy",
+				},
+				"iam_role_name": {
+					"default":     "roger-lambda-role",
+					"description": "name of IAM role",
+				},
+				"iam_vpc_access_policy": {
+					"default":     "roger-lambda-vpc_access-policy",
+					"description": "name of vpc access policy",
+				},
+				"kms_key": {
+					"default":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"description": "arn of KMS key",
+				},
+				"lambda_function_name": {
+					"default":     "roger-test-lambda",
+					"description": "name of Lambda function",
+				},
+				"security_group_id": {
+					"default":     "sg-042b9f3ab379aeb11",
+					"description": "ID of security group",
+				},
+				"subnet_id": {
+					"default":     "subnet-0395df0d90a099214",
+					"description": "ID of subnet",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"output_changes": {
+		"kms_key_arn": {
+			"actions": [
+				"create",
+			],
+			"after":         "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+			"after_unknown": false,
+			"before":        null,
+		},
+	},
+	"planned_values": {
+		"outputs": {
+			"kms_key_arn": {
+				"sensitive": false,
+				"value":     "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_iam_policy.lambda_basic_execution",
+					"mode":           "managed",
+					"name":           "lambda_basic_execution",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A basic lambda policy",
+						"name":        "roger-basic-lambda-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_kms",
+					"mode":           "managed",
+					"name":           "lambda_kms",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A kms lambda policy",
+						"name":        "roger-lambda-kms-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_policy.lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_policy",
+					"values": {
+						"description": "A lambda vpc access policy",
+						"name":        "roger-lambda-vpc_access-policy",
+						"name_prefix": null,
+						"path":        "/",
+						"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+					},
+				},
+				{
+					"address":        "aws_iam_role.role_for_lambda",
+					"mode":           "managed",
+					"name":           "role_for_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role",
+					"values": {
+						"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+						"description":           null,
+						"force_detach_policies": false,
+						"max_session_duration":  3600,
+						"name":                  "roger-lambda-role",
+						"name_prefix":           null,
+						"path":                  "/",
+						"permissions_boundary":  null,
+						"tags":                  null,
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_basic_lambda",
+					"mode":           "managed",
+					"name":           "attach_basic_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_kms_lambda",
+					"mode":           "managed",
+					"name":           "attach_kms_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+					"mode":           "managed",
+					"name":           "attach_lambda_vpc_access",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_iam_role_policy_attachment",
+					"values": {
+						"role": "roger-lambda-role",
+					},
+				},
+				{
+					"address":        "aws_lambda_function.test_lambda",
+					"mode":           "managed",
+					"name":           "test_lambda",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_lambda_function",
+					"values": {
+						"dead_letter_config": [],
+						"description":        null,
+						"environment": [
+							{
+								"variables": {
+									"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+								},
+							},
+						],
+						"file_system_config":             [],
+						"filename":                       "app.zip",
+						"function_name":                  "roger-test-lambda",
+						"handler":                        "app.handler",
+						"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+						"layers":                         null,
+						"memory_size":                    128,
+						"publish":                        false,
+						"reserved_concurrent_executions": -1,
+						"runtime":                        "python2.7",
+						"s3_bucket":                      null,
+						"s3_key":                         null,
+						"s3_object_version":              null,
+						"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+						"tags":                           null,
+						"timeout":                        3,
+						"timeouts":                       null,
+						"vpc_config": [
+							{
+								"security_group_ids": [
+									"sg-042b9f3ab379aeb11",
+								],
+								"subnet_ids": [
+									"subnet-0395df0d90a099214",
+								],
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_iam_policy.lambda_basic_execution",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A basic lambda policy",
+					"name":        "roger-basic-lambda-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n            ],\n            \"Resource\": \"arn:aws:logs:us-east-1:753646501470:log-group:*:*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_basic_execution",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_kms",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A kms lambda policy",
+					"name":        "roger-lambda-kms-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"kms:*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_kms",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_policy.lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"description": "A lambda vpc access policy",
+					"name":        "roger-lambda-vpc_access-policy",
+					"name_prefix": null,
+					"path":        "/",
+					"policy":      "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:DeleteNetworkInterface\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}\n",
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_policy",
+		},
+		{
+			"address": "aws_iam_role.role_for_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"assume_role_policy":    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+					"description":           null,
+					"force_detach_policies": false,
+					"max_session_duration":  3600,
+					"name":                  "roger-lambda-role",
+					"name_prefix":           null,
+					"path":                  "/",
+					"permissions_boundary":  null,
+					"tags":                  null,
+				},
+				"after_unknown": {
+					"arn":         true,
+					"create_date": true,
+					"id":          true,
+					"unique_id":   true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "role_for_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_basic_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_basic_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_kms_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_kms_lambda",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_iam_role_policy_attachment.attach_lambda_vpc_access",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"role": "roger-lambda-role",
+				},
+				"after_unknown": {
+					"id":         true,
+					"policy_arn": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "attach_lambda_vpc_access",
+			"provider_name": "aws",
+			"type":          "aws_iam_role_policy_attachment",
+		},
+		{
+			"address": "aws_lambda_function.test_lambda",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"dead_letter_config": [],
+					"description":        null,
+					"environment": [
+						{
+							"variables": {
+								"my_secret": "AQICAHhj5kWyeprUqLbu+1gkK2UeO5WuwRcjaI/IG27Us8zBRwHH745dQMacM8zkqhaRNB7cAAAAbDBqBgkqhkiG9w0BBwagXTBbAgEAMFYGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/QPGAjv5Ak2faX6aAgEQgCm+snwc3SmmGGpAc6kahKKnOCZFWkg4hA3OpYt7Pp0yDGb9JYJJjDX9Nw==",
+							},
+						},
+					],
+					"file_system_config":             [],
+					"filename":                       "app.zip",
+					"function_name":                  "roger-test-lambda",
+					"handler":                        "app.handler",
+					"kms_key_arn":                    "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+					"layers":                         null,
+					"memory_size":                    128,
+					"publish":                        false,
+					"reserved_concurrent_executions": -1,
+					"runtime":                        "python2.7",
+					"s3_bucket":                      null,
+					"s3_key":                         null,
+					"s3_object_version":              null,
+					"source_code_hash":               "C8Q8zp0W6bsonUgxgV/ZRsGd8QuouLDSEAGtTVu9cdk=",
+					"tags":                           null,
+					"timeout":                        3,
+					"timeouts":                       null,
+					"vpc_config": [
+						{
+							"security_group_ids": [
+								"sg-042b9f3ab379aeb11",
+							],
+							"subnet_ids": [
+								"subnet-0395df0d90a099214",
+							],
+						},
+					],
+				},
+				"after_unknown": {
+					"arn":                true,
+					"dead_letter_config": [],
+					"environment": [
+						{
+							"variables": {},
+						},
+					],
+					"file_system_config": [],
+					"id":                 true,
+					"invoke_arn":         true,
+					"last_modified":      true,
+					"qualified_arn":      true,
+					"role":               true,
+					"source_code_size":   true,
+					"tracing_config":     true,
+					"version":            true,
+					"vpc_config": [
+						{
+							"security_group_ids": [
+								false,
+							],
+							"subnet_ids": [
+								false,
+							],
+							"vpc_id": true,
+						},
+					],
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "test_lambda",
+			"provider_name": "aws",
+			"type":          "aws_lambda_function",
+		},
+	],
+	"terraform_version": "0.12.28",
+	"variables": {
+		"aws_account_id": {
+			"value": "753646501470",
+		},
+		"aws_region": {
+			"value": "us-east-1",
+		},
+		"iam_basic_execution_policy": {
+			"value": "roger-basic-lambda-policy",
+		},
+		"iam_kms_lambda_policy": {
+			"value": "roger-lambda-kms-policy",
+		},
+		"iam_role_name": {
+			"value": "roger-lambda-role",
+		},
+		"iam_vpc_access_policy": {
+			"value": "roger-lambda-vpc_access-policy",
+		},
+		"kms_key": {
+			"value": "arn:aws:kms:us-east-1:753646501470:key/00c892e8-40c4-4048-a650-0f755876503d",
+		},
+		"lambda_function_name": {
+			"value": "roger-test-lambda",
+		},
+		"security_group_id": {
+			"value": "sg-042b9f3ab379aeb11",
+		},
+		"subnet_id": {
+			"value": "subnet-0395df0d90a099214",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/pass.json
+++ b/governance/third-generation/aws/test/require-vpc-and-kms-for-lambda-functions/pass.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -263,9 +263,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(value) + ", "
         } else {
-          output += to_string(value) + "]"
+          output += to_string(value)
         }
       }
+      output += "]"
       return output
     when "map":
       output = "{"

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -153,9 +153,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(value) + ", "
         } else {
-          output += to_string(value) + "]"
+          output += to_string(value)
         }
       }
+      output += "]"
       return output
     when "map":
       output = "{"

--- a/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -97,9 +97,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(value) + ", "
         } else {
-          output += to_string(value) + "]"
+          output += to_string(value)
         }
       }
+      output += "]"
       return output
     when "map":
       output = "{"


### PR DESCRIPTION
This migrates two first-generation Sentinel policies to third-generation:
* require-dns-support-for-vpcs.sentinel
* require-vpc-and-kms-for-lambda-functions.sentinel

It also fixes a minor bug in the to_string() functions of the common functions so that it will now convert an empty list to "[]" instead of to "[".