### PR TITLE
count violations before main rule

### DIFF
--- a/governance/third-generation/aws/restrict-ec2-instance-type.sentinel
+++ b/governance/third-generation/aws/restrict-ec2-instance-type.sentinel
@@ -17,7 +17,10 @@ allEC2Instances = plan.find_resources("aws_instance")
 violatingEC2Instances = plan.filter_attribute_not_in_list(allEC2Instances,
                         "instance_type", allowed_types, true)
 
+# Count violations
+violations = length(violatingEC2Instances["messages"])
+
 # Main rule
 main = rule {
-  length(violatingEC2Instances["messages"]) is 0
+  violations is 0
 }

--- a/governance/third-generation/azure/restrict-vm-size.sentinel
+++ b/governance/third-generation/azure/restrict-vm-size.sentinel
@@ -17,7 +17,10 @@ allAzureVMs = plan.find_resources("azurerm_virtual_machine")
 violatingAzureVMs = plan.filter_attribute_not_in_list(allAzureVMs,
                     "vm_size", allowed_sizes, true)
 
+# Count violations
+violations = length(violatingAzureVMs["messages"])
+
 # Main rule
 main = rule {
-  length(violatingAzureVMs["messages"]) is 0
+  violations is 0
 }

--- a/governance/third-generation/gcp/restrict-gce-machine-type.sentinel
+++ b/governance/third-generation/gcp/restrict-gce-machine-type.sentinel
@@ -17,7 +17,10 @@ allGCEInstances = plan.find_resources("google_compute_instance")
 violatingGCEInstances = plan.filter_attribute_not_in_list(allGCEInstances,
                         "machine_type", allowed_types, true)
 
+# Count violations
+violations = length(violatingGCEInstances["messages"])
+
 # Main rule
 main = rule {
-  length(violatingGCEInstances["messages"]) is 0
+  violations is 0
 }


### PR DESCRIPTION
I want to count the violations in some of the prototypical third-generation policies before the main rule to better match what I do in the Sentinel for Terraform workshop.