### PR TITLE
Improve regex

### DIFF
--- a/governance/third-generation/cloud-agnostic/evaluate-variables-in-nested-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/evaluate-variables-in-nested-modules.sentinel
@@ -1,0 +1,33 @@
+# This policy uses the tfconfig/v2 import to evaluate
+# variables set in calls to nested modules, but only if
+# they are set as constant values. For module variables
+# that are set to references, it just prints the references.
+
+# Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
+# with alias "config"
+import "tfconfig-functions" as config
+
+# Get all modules called from root module
+rootModuleCalls = config.find_module_calls_in_module("")
+
+evaluate_variables = func() {
+  for rootModuleCalls as address, m {
+    for m.config else {} as key, value {
+      if "constant_value" in keys(value) {
+        print("module", address, "has variable", key,
+              "with value", value.constant_value)
+      } else if "references" in keys(value) {
+        print("module", address, "has variable", key,
+              "with references:", value.references)
+      } // end constant_value check
+    } //end keys loop
+  } // end modules loop
+
+  return true
+}
+
+# Main Rule
+validated = evaluate_variables()
+main = rule {
+  validated
+}

--- a/governance/third-generation/cloud-agnostic/prohibited-local-exec-commands.sentinel
+++ b/governance/third-generation/cloud-agnostic/prohibited-local-exec-commands.sentinel
@@ -1,0 +1,50 @@
+# This policy uses the tfconfig/v2 import to prohibit local-exec
+# provisioners from using commands in a prohibited list
+
+# Import tfconfig/v2
+import "tfconfig/v2" as tfconfig
+
+# List of prohibited commands for the local-exec provisioner
+prohibited_list = ["env", "sudo"]
+
+validate_command = func(prohibited) {
+
+  validated = true
+
+  # Get all local-exec provisioners
+  localExecProvisioners = filter tfconfig.provisioners as resource, p {
+  	p.type is "local-exec"
+  }
+
+  # Iterate over local-exec provisioners
+  for localExecProvisioners as resource, p {
+    command = p.config.command
+    # Check for constant value
+    if "constant_value" in keys(command) {
+      # Iterate over prohibited list
+      for prohibited as cur_command {
+        if command.constant_value matches "^" + cur_command {
+          print("Resource", resource, "used a local-exec provisioner that",
+            "started with a prohibited command,", command.constant_value, ", from the list", prohibited)
+          validated = false
+        } // end if
+      } // end for (over prohibited list)
+    } else if "references" in keys(command) {
+      print("Resource", resource, "used a local-exec provisioner with a command",
+            "that included a reference to a Terraform variable or resource.",
+            "Sentinel does not have access to the static part of the command",
+            "in this case and cannot validate that no prohibited command was used.")
+
+      # Comment out following line to allow local-exec provisoners with references
+      validated = false
+    } // end else
+  } // end for (over local-exec provisioners)
+
+  return validated
+}
+
+# Main rule
+validated = validate_command(prohibited_list)
+main = rule {
+  validated
+}

--- a/governance/third-generation/cloud-agnostic/test/evaluate-variables-in-nested-modules/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/evaluate-variables-in-nested-modules/mock-tfconfig-pass.sentinel
@@ -1,0 +1,281 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"max_retries": {
+				"constant_value": 5,
+			},
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+	"module.nested:aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "module.nested",
+		"name":                "aws",
+		"provider_config_key": "module.nested:aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_instance.ubuntu": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"module.nested.aws_instance.ubuntu": {
+		"address": "module.nested.aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.nested",
+		"name":                "ubuntu",
+		"provider_config_key": "module.nested:aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"null_resource.test": {
+		"address":             "null_resource.test",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "null",
+		"provisioners": [
+			{
+				"config": {
+					"command": {
+						"constant_value": "pwd",
+					},
+				},
+				"index":            0,
+				"resource_address": "null_resource.test",
+				"type":             "local-exec",
+			},
+		],
+		"type": "null_resource",
+	},
+}
+
+provisioners = {
+	"null_resource.test:0": {
+		"config": {
+			"command": {
+				"constant_value": "pwd",
+			},
+		},
+		"index":            0,
+		"resource_address": "null_resource.test",
+		"type":             "local-exec",
+	},
+}
+
+variables = {
+	"ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "",
+		"name":           "ami_id",
+	},
+	"associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "",
+		"name":           "associate_public_ip_address",
+	},
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "",
+		"name":           "instance_type",
+	},
+	"module.nested:ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "module.nested",
+		"name":           "ami_id",
+	},
+	"module.nested:associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "associate_public_ip_address",
+	},
+	"module.nested:aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "module.nested",
+		"name":           "aws_region",
+	},
+	"module.nested:instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "module.nested",
+		"name":           "instance_type",
+	},
+	"module.nested:name": {
+		"default":        "roger-demo-nested",
+		"description":    "name to pass to Name tag",
+		"module_address": "module.nested",
+		"name":           "name",
+	},
+	"name": {
+		"default":        "roger-demo",
+		"description":    "name to pass to Name tag",
+		"module_address": "",
+		"name":           "name",
+	},
+}
+
+outputs = {
+	"module.nested:public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+	"public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"nested": {
+		"config": {
+			"instance_type": {
+				"constant_value": "t2.xlarge",
+			},
+			"key_name": {
+				"constant_value": "vault",
+			},
+			"associate_public_ip_address": {
+				"constant_value": "true",
+			},
+			"vpc_security_group_ids": {
+				"references": [
+					"aws_security_group.vault.id",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/evaluate-variables-in-nested-modules/pass.json
+++ b/governance/third-generation/cloud-agnostic/test/evaluate-variables-in-nested-modules/pass.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/fail-constant-value.json
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/fail-constant-value.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-fail-constant-value.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/fail-reference.json
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/fail-reference.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-fail-reference.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-fail-constant-value.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-fail-constant-value.sentinel
@@ -1,0 +1,95 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"null_resource.no-provisioner": {
+		"address": "null_resource.no-provisioner",
+		"config": {
+			"triggers": {
+				"constant_value": null,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "no-provisioner",
+		"provider_config_key": "null",
+		"provisioners":        [],
+		"type":                "null_resource",
+	},
+	"null_resource.test": {
+		"address":             "null_resource.test",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "null",
+		"provisioners": [
+			{
+				"config": {
+					"command": {
+						"constant_value": "env",
+					},
+				},
+				"index":            0,
+				"resource_address": "null_resource.test",
+				"type":             "local-exec",
+			},
+		],
+		"type": "null_resource",
+	},
+}
+
+provisioners = {
+	"null_resource.test:0": {
+		"config": {
+			"command": {
+				"constant_value": "env",
+			},
+		},
+		"index":            0,
+		"resource_address": "null_resource.test",
+		"type":             "local-exec",
+	},
+}
+
+variables = {
+	"private_key": {
+		"default":        null,
+		"description":    "",
+		"module_address": "",
+		"name":           "private_key",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-fail-reference.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-fail-reference.sentinel
@@ -1,0 +1,99 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"null_resource.no-provisioner": {
+		"address": "null_resource.no-provisioner",
+		"config": {
+			"triggers": {
+				"constant_value": null,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "no-provisioner",
+		"provider_config_key": "null",
+		"provisioners":        [],
+		"type":                "null_resource",
+	},
+	"null_resource.test": {
+		"address":             "null_resource.test",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "null",
+		"provisioners": [
+			{
+				"config": {
+					"command": {
+						"references": [
+							"var.private_key",
+						],
+					},
+				},
+				"index":            0,
+				"resource_address": "null_resource.test",
+				"type":             "local-exec",
+			},
+		],
+		"type": "null_resource",
+	},
+}
+
+provisioners = {
+	"null_resource.test:0": {
+		"config": {
+			"command": {
+				"references": [
+					"var.private_key",
+				],
+			},
+		},
+		"index":            0,
+		"resource_address": "null_resource.test",
+		"type":             "local-exec",
+	},
+}
+
+variables = {
+	"private_key": {
+		"default":        null,
+		"description":    "",
+		"module_address": "",
+		"name":           "private_key",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/mock-tfconfig-pass.sentinel
@@ -1,0 +1,95 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"null_resource.no-provisioner": {
+		"address": "null_resource.no-provisioner",
+		"config": {
+			"triggers": {
+				"constant_value": null,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "no-provisioner",
+		"provider_config_key": "null",
+		"provisioners":        [],
+		"type":                "null_resource",
+	},
+	"null_resource.test": {
+		"address":             "null_resource.test",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "test",
+		"provider_config_key": "null",
+		"provisioners": [
+			{
+				"config": {
+					"command": {
+						"constant_value": "pwd",
+					},
+				},
+				"index":            0,
+				"resource_address": "null_resource.test",
+				"type":             "local-exec",
+			},
+		],
+		"type": "null_resource",
+	},
+}
+
+provisioners = {
+	"null_resource.test:0": {
+		"config": {
+			"command": {
+				"constant_value": "pwd",
+			},
+		},
+		"index":            0,
+		"resource_address": "null_resource.test",
+		"type":             "local-exec",
+	},
+}
+
+variables = {
+	"private_key": {
+		"default":        null,
+		"description":    "",
+		"module_address": "",
+		"name":           "private_key",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/pass.json
+++ b/governance/third-generation/cloud-agnostic/test/prohibited-local-exec-commands/pass.json
@@ -1,0 +1,13 @@
+{
+  "modules": {
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -45,7 +45,7 @@ find_resources_in_module = func(module_address) {
 # The parameter, provider, should be given as a string such as "aws".
 find_resources_by_provider = func(provider) {
   resources = filter tfconfig.resources as address, r {
-  	r.provider_config_key matches "(.*)" + provider + "(.*)" and
+  	r.provider_config_key matches "(.*:)?" + provider + "(\\..*)?" and
   	r.mode is "managed"
   }
 
@@ -90,7 +90,7 @@ find_datasources_in_module = func(module_address) {
 # The parameter, provider, should be given as a string such as "aws".
 find_datasources_by_provider = func(provider) {
   datasources = filter tfconfig.resources as address, d {
-  	d.provider_config_key matches "(.*)" + provider + "(.*)" and
+  	d.provider_config_key matches "(.*:)?" + provider + "(\\..*)?" and
   	d.mode is "data"
   }
 
@@ -125,7 +125,7 @@ find_all_providers = func() {
 # The parameter, provider, should be given as a string such as "aws".
 find_providers_by_type = func(type) {
   providers = filter tfconfig.providers as address, p {
-  	p.provider_config_key matches "(.*)" + type + "(.*)"
+  	p.provider_config_key matches "(.*:)?" + type + "(\\..*)?"
   }
 
   return providers


### PR DESCRIPTION
This improves regex in the tfconfig-functions.sentinel module on the advice of a customer who gave me better regex.

I also added two new cloud-agnostic policies that I wrote some time ago but never committed:

1. evaluate-variables-in-nested-modules.sentinel shows how to evaluate variables passed to modules in module calls.  It currently only evaluated constant values that are passed, but does print references if those are used without attempting to evaluate their values.  I might add that in the future. The policy always returns true. It is not really a policy but more of a policy snippet that could be used in other policies that did want to restrict the values of variables passed to modules.
2. prohibited-local-exec-commands.sentinel prevents certain commands from being used in local-exec provisioners.