### PR TITLE
add require-most-recent-AMI-version policy

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -85,7 +85,9 @@ The `tfconfig-functions` module has several types of functions:
   * `find_*_by_provider` functions that find resources or data sources created by a specific provider.
   * The `find_outputs_by_sensitivity` function that finds outputs based on their `sensitive` setting.
   * The `find_descendant_modules` function that finds all module addresses called directly or indirectly by a specific module including that module itself. Calling `find_descendant_modules("")` will return all module addresses within the Terraform configuration.
-  * Two filter functions, `filter_attribute_not_in_list` and `filter_attribute_in_list`, that are similar to the filter functions in the tfplan-functions module. However, these can only be used against top-level attributes of the items in the collection passed to them. Those collections can be any type of entity covered by the tfconfig/v2 import including resources, data sources, providers, provisioners, variables, outputs, and module calls.
+  * Various filter functions such as `filter_attribute_not_in_list` and `filter_attribute_in_list` that are similar to the filter functions in the tfplan-functions module. However, these can only be used against top-level attributes of the items in the collection passed to them. Those collections can be any type of entity covered by the tfconfig/v2 import including resources, data sources, providers, provisioners, variables, outputs, and module calls. The filter functions return a map consisting of 2 items:
+    * `items`: a map consisting of items that violate a condition.
+    * `messages`: a map of violation messages associated with the items.
   * The same `to_string` and `print_violations` functions that are in the tfplan-functions module.
 
 Documentation for each individual function can be found in this directory:

--- a/governance/third-generation/aws/require-most-recent-AMI-version.sentinel
+++ b/governance/third-generation/aws/require-most-recent-AMI-version.sentinel
@@ -1,0 +1,42 @@
+# This policy requires all EC2 instances to have their ami field
+# set to an aws_ami datasource (using data.aws_ami.<name>.id)
+# and that all aws_ami data sources have most_recent set to true
+
+# Import common-functions/tfstate-functions/tfstate-functions.sentinel
+# with alias "state"
+import "tfstate-functions" as state
+
+# Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
+# with alias "config"
+import "tfconfig-functions" as config
+
+# Get all EC2 instances
+allEC2Instances = config.find_resources_by_type("aws_instance")
+
+# Filter to EC2 instances with violations
+# Warnings will be printed for all violations since the last parameter is true
+# Note that we test "config.ami" and expect a reference like "data.aws_ami.ubuntu"
+# While the actual reference might be "data.aws_ami.ubuntu.id", Terraform only
+# gives Sentinel references to resources and data sources, not to their attributes.
+violatingEC2Instances = config.filter_attribute_does_not_match_regex(allEC2Instances,
+                        "config.ami", "^data\\.aws_ami\\.(.*)$", true)
+
+# Count EC2 instance violations
+EC2InstanceViolations = length(violatingEC2Instances["messages"])
+
+# Get all aws_ami data sources
+allAMIs = state.find_datasources("aws_ami")
+
+# Filter to AMIs with violations
+violatingAMIs = state.filter_attribute_is_not_value(allAMIs, "most_recent", true, true)
+
+# Count AMI violations
+AMIViolations = length(violatingAMIs["messages"])
+
+# Add both kinds of violations
+violations = EC2InstanceViolations + AMIViolations
+
+# Main rule
+main = rule {
+  violations is 0
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/fail.json
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/fail.json
@@ -1,0 +1,17 @@
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    },
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-fail.sentinel",
+    "tfconfig/v2": "mock-tfconfig-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfconfig-fail.sentinel
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfconfig-fail.sentinel
@@ -1,0 +1,207 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"max_retries": {
+				"constant_value": 5,
+			},
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_instance.ubuntu": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"aws_instance.ubuntu-2": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+					"var.prefix",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"aws_instance.ubuntu-3": {
+		"address": "aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"constant_value": "ami-2e1ef954",
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count": {
+			"constant_value": 2,
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "",
+		"name":           "ami_id",
+	},
+	"associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "",
+		"name":           "associate_public_ip_address",
+	},
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "",
+		"name":           "instance_type",
+	},
+	"name": {
+		"default":        "roger-demo",
+		"description":    "name to pass to Name tag",
+		"module_address": "",
+		"name":           "name",
+	},
+}
+
+outputs = {
+	"public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfconfig-pass.sentinel
@@ -1,0 +1,150 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"max_retries": {
+				"constant_value": 5,
+			},
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_instance.web": {
+		"address": "aws_instance.web",
+		"config": {
+			"ami": {
+				"references": [
+					"data.aws_ami.ubuntu",
+				],
+			},
+			"instance_type": {
+				"constant_value": "t3.micro",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "HelloWorld",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "web",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+	"data.aws_ami.ubuntu": {
+		"address": "data.aws_ami.ubuntu",
+		"config": {
+			"filter": [
+				{
+					"name": {
+						"constant_value": "name",
+					},
+					"values": {
+						"constant_value": [
+							"ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+						],
+					},
+				},
+				{
+					"name": {
+						"constant_value": "virtualization-type",
+					},
+					"values": {
+						"constant_value": [
+							"hvm",
+						],
+					},
+				},
+			],
+			"most_recent": {
+				"constant_value": true,
+			},
+			"owners": {
+				"constant_value": [
+					"099720109477",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "ubuntu",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_ami",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "",
+		"name":           "associate_public_ip_address",
+	},
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "",
+		"name":           "instance_type",
+	},
+	"name": {
+		"default":        "roger-demo",
+		"description":    "name to pass to Name tag",
+		"module_address": "",
+		"name":           "name",
+	},
+}
+
+outputs = {
+	"public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfstate-fail.sentinel
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfstate-fail.sentinel
@@ -1,0 +1,15 @@
+terraform_version = "0.13.5"
+
+outputs = {
+	"public_dns": {
+		"name":      "public_dns",
+		"sensitive": false,
+		"value": [
+			null,
+			null,
+		],
+	},
+}
+
+resources = {
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfstate-pass.sentinel
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/mock-tfstate-pass.sentinel
@@ -1,0 +1,104 @@
+terraform_version = "0.13.5"
+
+outputs = {
+	"public_dns": {
+		"name":      "public_dns",
+		"sensitive": false,
+		"value": [
+			null,
+			null,
+		],
+	},
+}
+
+resources = {
+	"aws_ami.ubuntu": {
+		"address":        "aws_ami.ubuntu",
+		"depends_on":     [],
+		"deposed_key":    "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "ubuntu",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"tainted":        false,
+		"type":           "aws_ami",
+		"values": {
+			"architecture": "x86_64",
+			"arn":          "arn:aws:ec2:us-east-1::image/ami-0885b1f6bd170450c",
+			"block_device_mappings": [
+				{
+					"device_name": "/dev/sda1",
+					"ebs": {
+						"delete_on_termination": "true",
+						"encrypted":             "false",
+						"iops":                  "0",
+						"snapshot_id":           "snap-0846ce4394d115972",
+						"volume_size":           "8",
+						"volume_type":           "gp2",
+					},
+					"no_device":    "",
+					"virtual_name": "",
+				},
+				{
+					"device_name":  "/dev/sdb",
+					"ebs":          {},
+					"no_device":    "",
+					"virtual_name": "ephemeral0",
+				},
+				{
+					"device_name":  "/dev/sdc",
+					"ebs":          {},
+					"no_device":    "",
+					"virtual_name": "ephemeral1",
+				},
+			],
+			"creation_date":    "2020-10-27T01:01:48.000Z",
+			"description":      "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-10-26",
+			"executable_users": null,
+			"filter": [
+				{
+					"name": "name",
+					"values": [
+						"ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+					],
+				},
+				{
+					"name": "virtualization-type",
+					"values": [
+						"hvm",
+					],
+				},
+			],
+			"hypervisor":        "xen",
+			"id":                "ami-0885b1f6bd170450c",
+			"image_id":          "ami-0885b1f6bd170450c",
+			"image_location":    "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026",
+			"image_owner_alias": null,
+			"image_type":        "machine",
+			"kernel_id":         null,
+			"most_recent":       true,
+			"name":              "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026",
+			"name_regex":        null,
+			"owner_id":          "099720109477",
+			"owners": [
+				"099720109477",
+			],
+			"platform":          null,
+			"product_codes":     [],
+			"public":            true,
+			"ramdisk_id":        null,
+			"root_device_name":  "/dev/sda1",
+			"root_device_type":  "ebs",
+			"root_snapshot_id":  "snap-0846ce4394d115972",
+			"sriov_net_support": "simple",
+			"state":             "available",
+			"state_reason": {
+				"code":    "UNSET",
+				"message": "UNSET",
+			},
+			"tags":                {},
+			"virtualization_type": "hvm",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-most-recent-AMI-version/pass.json
+++ b/governance/third-generation/aws/test/require-most-recent-AMI-version/pass.json
@@ -1,0 +1,17 @@
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    },
+    "tfconfig-functions": {
+      "path": "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-pass.sentinel",
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/evaluate_attribute.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/evaluate_attribute.md
@@ -1,0 +1,29 @@
+# evaluate_attribute
+This function evaluates an attribute within an item in the Terraform configuration. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`evaluate_attribute = func(item, attribute)`
+
+## Arguments
+* **item**: a single item containing an attribute whose value you want to determine.
+* **attribute**: a string giving the attribute. In general, the attribute should be a top-level attribute of item, but it can also have the form "config.x".
+
+In practice, this function is only called by the filter functions, so the specification of the `attribute` parameter will be done when calling them.
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns the attribute as it occurred within the Terraform configuration. The type will vary depending on what kind of attribute is evaluated. If the attribute had the form "config.x", it will look for "constant_value" or "references" under `item.config.x` and then whichever one it finds. In the latter case, it will return a list with all the references that the attribute referenced. Note that this does not evaluate the values of the references.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by the `filter_attribute_does_not_match_regex` and `filter_attribute_matches_regex` filter functions in the tfconfig-functions.sentinel module like this:
+```
+val = evaluate_attribute(item, attr) else null
+```

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/filter_attribute_does_not_match_regex.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/filter_attribute_does_not_match_regex.md
@@ -1,0 +1,33 @@
+# filter_attribute_does_not_match_regex
+This function filters a collection of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls to those with an attribute that does not match a given regular expression (regex). A policy would call it when it wants the attribute to match that regex. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_match_regex = func(items, attr, expr, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute or an attribute directly under "config". In the fist case, give the attribute as a string. In the second case, give it as "config.x" where "x" is the attribute you're trying to restrict.
+* **expr**: the regex expression that should not be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to not match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the items that meet the condition of the filter function. The `items` map contains the actual resources for which the attribute (`attr`) does not match the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingEC2Instances = config.filter_attribute_does_not_match_regex(allEC2Instances,
+                        "config.ami", "^data\\.aws_ami\\.(.*)$", true)
+```
+This is from the [require-most-recent-AMI-version.sentinel](../../../aws/require-most-recent-AMI-version.sentinel) policy.

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/filter_attribute_matches_regex.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/filter_attribute_matches_regex.md
@@ -1,0 +1,32 @@
+# filter_attribute_matches_regex
+This function filters a collection of items such as resources, data sources, or blocks to those with an attribute that matches a given regular expression (regex). A policy would call it when it wants the attribute to not match that regex. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_matches_regex = func(items, attr, expr, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute or an attribute directly under "config". In the fist case, give the attribute as a string. In the second case, give it as "config.x" where "x" is the attribute you're trying to restrict.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the items that meet the condition of the filter function. The `items` map contains the actual resources for which the attribute (`attr`) matches the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingEC2Instances = config.filter_attribute_matches_regex(allEC2Instances,
+                        "config.ami", "^data\\.aws_ami\\.(.*)$", true)
+```

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -285,6 +285,37 @@ to_string = func(obj) {
   }
 }
 
+### evaluate_attribute ###
+# Evaluates an attribute
+# In general, the attribute should be a top-level attribute of item, but
+# we do special processing for attributes with form "config.x"
+# `item` is the item with the attribute
+# `attribute` is the attribute
+evaluate_attribute = func(item, attribute) {
+  # Split the attribute into a list, using "." as the separator
+  attributes = strings.split(attribute, ".")
+  if length(attributes) > 2 {
+    print("An attribute passed to evaluate_attribute can only have 1 or 2 fields")
+    return null
+  }
+  if attributes[0] is "config" {
+    config = item.config[attributes[1]]
+    if "constant_value" in config {
+      # Found constant_value in config
+      return config.constant_value
+    } else if "references" in config {
+      # Found references in config
+      return config.references
+    } else {
+      # Did not find constant_value or references in config
+      return null
+    }
+  } else {
+    # Return the original attribute or the item
+    return item[attribute]
+  }
+}
+
 ### filter_attribute_not_in_list ###
 # Filter a list of items such as providers to those with a specified
 # attribute (attr) that is not in a given list of allowed values (allowed).
@@ -350,5 +381,118 @@ filter_attribute_in_list = func(items, attr, forbidden, prtmsg) {
     } // end if forbidden
   } // end for items
 
+  return {"items":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of items such as resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# The parameter, attr, can only be a top-level attribute of items or
+# an attribute in the form "config.x".
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_match_regex = func(items, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for items as index, item {
+    val = evaluate_attribute(item, attr) else null
+    if val is null {
+      # Add the item and a warning message to the violators list
+      message = to_string(index) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[index] = item
+			messages[index] = message
+      if prtmsg {
+        print(message)
+      }
+    } else {
+      # Process lists and maps
+      if types.type_of(val) in ["list", "map"] {
+        message = ""
+        # Check each item of list or map
+        for val as i, v {
+          if v not matches expr {
+            # Add to the warning message
+            message += to_string(index) + " has " + to_string(attr) +
+                      " with value " + to_string(v) +
+                      " that does not match the regex " + to_string(expr) + "\n"
+          }
+          if message is not "" {
+            # Add the item and warning message to the violators list
+            violators[index] = item
+      			messages[index] = message
+            if prtmsg {
+              print(message)
+            }
+          } // end message not ""
+        } // end for
+      } else {
+        # Process single item
+        if val not matches expr {
+          # Add the item and a warning message to the violators list
+          message = to_string(index) + " has " + to_string(attr) +
+                    " with value " + to_string(val) +
+                    " that does not match the regex " + to_string(expr)
+          violators[index] = item
+          messages[index] = message
+          if prtmsg {
+            print(message)
+          }
+        } // end if single item not matches
+      } // end single item
+    } // end not null
+  } // end for items
+  return {"items":violators,"messages":messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of items such as resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# The parameter, attr, can only be a top-level attribute of items or
+# an attribute in the form "config.x".
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
+filter_attribute_matches_regex = func(items, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for items as index, item {
+    val = evaluate_attribute(item, attr) else null
+    if val is null {
+      val = "null"
+    }
+    # Process lists and maps
+    if types.type_of(val) in ["list", "map"] {
+      message = ""
+      # Check each item of list or map
+      for val as i, v {
+        if v matches expr {
+          # Add to the warning message
+          message += to_string(index) + " has " + to_string(attr) +
+                    " with value " + to_string(v) +
+                    " that matches the regex " + to_string(expr) + "\n"
+        }
+        if message is not "" {
+          # Add the item and warning message to the violators list
+          violators[index] = item
+          messages[index] = message
+          if prtmsg {
+            print(message)
+          }
+        } // end message not ""
+      } // end for
+    } else {
+      # Process single item
+      if val matches expr {
+        # Add the item and a warning message to the violators list
+        message = to_string(index) + " has " + to_string(attr) +
+                  " with value " + to_string(val) +
+                  " that matches the regex " + to_string(expr)
+        violators[index] = item
+        messages[index] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end if single item not matches
+    } // end single item
+  } // end for items
   return {"items":violators,"messages":messages}
 }

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_contains_items_from_list.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_contains_items_from_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should not contain any items in a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
-* **forbidden**: a list of values the attribute should not contain.
+* **forbidden**: a list of values the attribute should not contain. If you want to disallow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_contains_items_not_in_list.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_contains_items_not_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should should only contain items from a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
-* **allowed**: a list of values the attribute is allowed to contain.
+* **allowed**: a list of values the attribute is allowed to contain. If you want to allow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_in_list.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that must not be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **forbidden**: a list of values the attribute is forbidden to have.
+* **forbidden**: a list of values the attribute is forbidden to have. If you want to disallow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_is_value.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_is_value.md
@@ -10,7 +10,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should not equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **value**: the value the attribute should not have. This can be any primitive data type.
+* **value**: the value the attribute should not have. This can be any primitive data type. If you want to match null, set value to "null".
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_matches_regex.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_matches_regex.md
@@ -12,7 +12,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_not_in_list.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/filter_attribute_not_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfplan-functions.sentinel](../tfplan-function
 ## Arguments
 * **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that must be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **allowed**: a list of values the attribute is allowed to have.
+* **allowed**: a list of values the attribute is allowed to have. If you want to allow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -507,21 +507,16 @@ filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
 # attribute (attr) that has a given value.
 # Resources should be derived by applying filters to tfplan.resource_changes.
 # Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
 filter_attribute_is_value = func(resources, attr, value, prtmsg) {
   violators = {}
 	messages = {}
   for resources as address, rc {
     v = evaluate_attribute(rc, attr) else null
     if v is null {
-      # Add the resource and a warning message to the violators list
-      message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined"
-      violators[address] = rc
-			messages[address] = message
-      if prtmsg {
-        print(message)
-      }
-    } else if v is value {
+      v = "null"
+    }
+    if v is value {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that is equal to " + to_string(value)
@@ -639,21 +634,16 @@ filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
 # attribute (attr) that matches a regular expression (expr).
 # Resources should be derived by applying filters to tfplan.resource_changes.
 # Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
 filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
   violators = {}
 	messages = {}
   for resources as address, rc {
     v = evaluate_attribute(rc, attr) else null
     if v is null {
-      # Add the resource and a warning message to the violators list
-      message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined"
-      violators[address] = rc
-			messages[address] = message
-      if prtmsg {
-        print(message)
-      }
-    } else if v matches expr {
+      v = "null"
+    }
+    if v matches expr {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that matches the regex " + to_string(expr)

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_contains_items_from_list.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_contains_items_from_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should not contain any items in a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
-* **forbidden**: a list of values the attribute should not contain.
+* **forbidden**: a list of values the attribute should not contain. If you want to disallow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_contains_items_not_in_list.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_contains_items_not_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should should only contain items from a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
-* **allowed**: a list of values the attribute is allowed to contain.
+* **allowed**: a list of values the attribute is allowed to contain. If you want to allow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_in_list.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that must not be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **forbidden**: a list of values the attribute is forbidden to have.
+* **forbidden**: a list of values the attribute is forbidden to have. If you want to disallow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_is_value.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_is_value.md
@@ -10,7 +10,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should not equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **value**: the value the attribute should not have. This can be any primitive data type.
+* **value**: the value the attribute should not have. This can be any primitive data type. If you want to match null, set value to "null".
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_matches_regex.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_matches_regex.md
@@ -12,7 +12,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_not_in_list.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/filter_attribute_not_in_list.md
@@ -10,7 +10,7 @@ This function is contained in the [tfstate-functions.sentinel](../tfstate-functi
 ## Arguments
 * **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
 * **attr**: the name of a resource attribute given as a string that must be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
-* **allowed**: a list of values the attribute is allowed to have.
+* **allowed**: a list of values the attribute is allowed to have. If you want to allow null, include "null" in the list.
 * **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
 
 ## Common Functions Used

--- a/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -463,21 +463,16 @@ filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
 # attribute (attr) that has a given value.
 # Resources should be derived by applying filters to tfstate.resources.
 # Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
 filter_attribute_is_value = func(resources, attr, value, prtmsg) {
   violators = {}
 	messages = {}
   for resources as address, r {
     v = evaluate_attribute(r, attr) else null
     if v is null {
-      # Add the resource and a warning message to the violators list
-      message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined"
-      violators[address] = r
-			messages[address] = message
-      if prtmsg {
-        print(message)
-      }
-    } else if v is value {
+      v = "null"
+    }
+    if v is value {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that is equal to " + to_string(value)
@@ -595,21 +590,16 @@ filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
 # attribute (attr) that matches a regular expression (expr).
 # Resources should be derived by applying filters to tfstate.resources.
 # Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
 filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
   violators = {}
 	messages = {}
   for resources as address, r {
     v = evaluate_attribute(r, attr) else null
     if v is null {
-      # Add the resource and a warning message to the violators list
-      message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined"
-      violators[address] = r
-			messages[address] = message
-      if prtmsg {
-        print(message)
-      }
-    } else if v matches expr {
+      v = "null"
+    }
+    if v matches expr {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that matches the regex " + to_string(expr)


### PR DESCRIPTION
Added require-most-recent-AMI-version.sentinel policy
Also added new regex matching function in tfconfig-functions module and evaluate_attribute() function that they use.
I aldo updated some of the tfplan-functions and tfstate-functions functions to handle null differently.
And I updated the corresponding docs for the functions.