### PR TITLE
minor fix in comment on filter_resources_by_region

### DIFF
--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -160,7 +160,7 @@ validate_assumed_roles_with_map = func(roles_map, workspace_name) {
 # Filter resources to those from a specific provider alias in a specific region
 # using the tfconfig/v2 import.
 # The parameter, resources, should be a collection of AWS resources from tfconfig
-# The parameter, provider, should be given as a string such as "aws".
+# The parameter, provider, should be a provider derived from tfconfig.providers.
 # The parameter, region, should be given as a string such as "us-east-1"
 filter_resources_by_region = func(resources, provider, region) {
 


### PR DESCRIPTION
change description of provider parameter in filter_resources_by_region() function in aws-functions .sentinel.  I had said it should be a string like "aws", but it actually has to be an actual instance of a provider from tfconfig.providers.

https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/aws/aws-functions/docs/filter_resources_by_region.md was already correct.