### PR TITLE
improve validate-resources-from-desired-regions

### DIFF
--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -160,6 +160,16 @@ validate_assumed_roles_with_map = func(roles_map, workspace_name) {
 # Filter resources to those in a specific region using the tfconfig/v2 import.
 # The parameter, resources, should be a collection of AWS resources from tfconfig
 # The parameter, region, should be given as a string such as "us-east-1"
+# This function inspects the provider aliases associated with the resources.
+# It attempts to identify the region of the provider aliases in several ways
+# including constant values assigned to their `region` argument and resolution
+# of references to variables. It even tries to match provider aliases in proxy
+# configuration blocks (which do not specify regions) of child modules to
+# similarly-named provider aliases in the root module.
+# However, if the alias passed in the module call does not match the alias
+# in the root module, Sentinel has no way of linking the two provider aliases.
+# So, while this function does its best to restrict resources to the allowed
+# regions, it cannot guarantee 100% success.
 filter_resources_by_region = func(resources, region) {
 
   resources_from_region = {}

--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -168,33 +168,37 @@ filter_resources_by_region = func(resources, region) {
     pck = r.provider_config_key
     p = tfconfig.providers[pck]
 
-    # First, process p itself
-    if "config" in keys(p) and "region" in keys(p.config) {
-      if validate_provider_region(p, region) {
-        resources_from_region[address] = r
-      }
-    } else {
-      # provider used by resource does not have region
-      # So, we process it as an alias to a root module provider
-      # A provider that does not have its own region should look like
-      # <module_address>:<provider>.<alias>
-      # we want to look at <provider>.<alias>
-      p_segments = strings.split(p.provider_config_key, ":")
-      if length(p_segments) == 1 {
-        # Current provider is already in root module
-        # So, it is not an alias to another provider
-        # Continue on to next resource in for loop
-        continue
-      }
-      # Get the provider in root module that current provider aliases
-      p_alias_name = p_segments[1]
-      p_alias = tfconfig.providers[p_alias_name]
+    # First make sure p is not null
+    if p is not null {
+      # First, process p itself
+      if "config" in keys(p) and "region" in keys(p.config) {
+        if validate_provider_region(p, region) {
+          resources_from_region[address] = r
+        }
+      } else {
+        # provider used by resource does not have region
+        # So, we process it as an alias to a root module provider
+        # A provider that does not have its own region should look like
+        # <module_address>:<provider>.<alias>
+        # we want to look at <provider>.<alias>
+        # However, that might not exist
+        p_segments = strings.split(p.provider_config_key, ":")
+        if length(p_segments) == 1 {
+          # Current provider is already in root module
+          # So, it is not an alias to another provider
+          # Continue on to next resource in for loop
+          continue
+        }
+        # Get the provider in root module that current provider aliases
+        p_alias_name = p_segments[1]
+        p_alias = tfconfig.providers[p_alias_name]
 
-      # Process p_alias
-      if validate_provider_region(p_alias, region) {
-        resources_from_region[address] = r
-      }
-    } // end processing of p_alias
+        # Process p_alias
+        if p_alias is not null and validate_provider_region(p_alias, region) {
+          resources_from_region[address] = r
+        }
+      } // end processing of p_alias
+    } // end check p not null
   } // end for resources
 
   return resources_from_region

--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -157,12 +157,10 @@ validate_assumed_roles_with_map = func(roles_map, workspace_name) {
 }
 
 ### filter_resources_by_region ###
-# Filter resources to those from a specific provider alias in a specific region
-# using the tfconfig/v2 import.
+# Filter resources to those in a specific region using the tfconfig/v2 import.
 # The parameter, resources, should be a collection of AWS resources from tfconfig
-# The parameter, provider, should be a provider derived from tfconfig.providers.
 # The parameter, region, should be given as a string such as "us-east-1"
-filter_resources_by_region = func(resources, provider, region) {
+filter_resources_by_region = func(resources, region) {
 
   resources_from_region = {}
 

--- a/governance/third-generation/aws/aws-functions/docs/filter_resources_by_region.md
+++ b/governance/third-generation/aws/aws-functions/docs/filter_resources_by_region.md
@@ -1,5 +1,9 @@
 # filter_resources_by_region
-This function filters a collection of AWS resources to those created in a specific region. The resources should come from the tfconfig/v2 import
+This function filters a collection of AWS resources to those created in a specific region. The resources should come from the tfconfig/v2 import.
+
+This function inspects the provider aliases associated with the resources. It attempts to identify the region of the provider aliases in several ways including constant values assigned to their `region` argument and resolution of references to variables. It even tries to match provider aliases in proxy configuration blocks (which do not specify regions) of child modules to similarly-named provider aliases in the root module.
+
+However, if the alias passed in the module call does not match the alias in the root module, Sentinel has no way of linking the two provider aliases. So, while this function does its best to restrict resources to the allowed regions, it cannot guarantee 100% success.
 
 ## Sentinel Module
 This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.

--- a/governance/third-generation/aws/aws-functions/docs/filter_resources_by_region.md
+++ b/governance/third-generation/aws/aws-functions/docs/filter_resources_by_region.md
@@ -1,5 +1,5 @@
 # filter_resources_by_region
-This function filters a collection of AWS resources to those created by a specific alias of the AWS provider and a specific region. The resources should come from the tfconfig/v2 import
+This function filters a collection of AWS resources to those created in a specific region. The resources should come from the tfconfig/v2 import
 
 ## Sentinel Module
 This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
@@ -9,7 +9,6 @@ This function is contained in the [aws-functions.sentinel](../aws-functions.sent
 
 ## Arguments
 * **resources**: a collection of AWS resources derived from the tfconfig.resources.
-* **provider**: a specific alias of the AWS provider derived from tfconfig.providers.
 * **region**: a specific AWS region, provided as a string
 
 ## Common Functions Used
@@ -24,10 +23,8 @@ This function does not print anything.
 ## Examples
 Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
 ```
-for all_aws_providers as p {
-  for allowed_regions as region {
-      filtered_resources = aws.filter_resources_by_region(all_aws_resources, p, region)
-  }
+for allowed_regions as region {
+  filtered_resources = aws.filter_resources_by_region(all_aws_resources, region)
 }
 ```
 

--- a/governance/third-generation/aws/validate-resources-from-desired-regions.sentinel
+++ b/governance/third-generation/aws/validate-resources-from-desired-regions.sentinel
@@ -1,5 +1,15 @@
 # This policy uses the Sentinel tfconfig/v2 and tfplan/v2 imports to require that
 # all AWS resources are in specified regions
+# It does this by inspecting the provider aliases associated with the resources.
+# It attempts to identify the region of the provider aliases in several ways
+# including constant values assigned to their `region` argument and resolution
+# of references to variables. It even tries to match provider aliases in proxy
+# configuration blocks (which do not specify regions) of child modules to
+# similarly-named provider aliases in the root module.
+# However, if the alias passed in the module call does not match the alias
+# in the root module, Sentinel has no way of linking the two provider aliases.
+# So, while this policy does its best to restrict resources to the allowed
+# regions, it cannot guarantee 100% success.
 
 # Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
 # with alias "config"

--- a/governance/third-generation/aws/validate-resources-from-desired-regions.sentinel
+++ b/governance/third-generation/aws/validate-resources-from-desired-regions.sentinel
@@ -14,18 +14,13 @@ allowed_regions = ["us-east-1", "us-west-1"]
 # Get all AWS resources
 all_aws_resources = config.find_resources_by_provider("aws")
 
-// Get all providers
-all_aws_providers = config.find_providers_by_type("aws")
-
 # Find all AWS resources for allowed regions
 aws_resources_from_allowed_regions = {}
-for all_aws_providers as p {
-  for allowed_regions as region {
-      filtered_resources = aws.filter_resources_by_region(all_aws_resources, p, region)
-      # Add the filtered resources to aws_resources_from_allowed_regions
-      for filtered_resources as address, r {
-        aws_resources_from_allowed_regions[address] = r
-      }
+for allowed_regions as region {
+  filtered_resources = aws.filter_resources_by_region(all_aws_resources, region)
+  # Add the filtered resources to aws_resources_from_allowed_regions
+  for filtered_resources as address, r {
+    aws_resources_from_allowed_regions[address] = r
   }
 }
 


### PR DESCRIPTION
This simplifies the validate-resources-from-desired-regions policy and the filter_resources_by_region() function it calls to remove use of provider loop in the first and passing of provider to the second.