### PR TITLE
Include read and no op actions

### DIFF
--- a/governance/third-generation/aws/require-vpc-and-kms-for-lambda-functions.sentinel
+++ b/governance/third-generation/aws/require-vpc-and-kms-for-lambda-functions.sentinel
@@ -14,7 +14,7 @@ allLambdaFunctions = plan.find_resources("aws_lambda_function")
 
 # Lambda functions that have not set a KMS key
 LambdasWithoutKMSKey = plan.filter_attribute_is_value(allLambdaFunctions,
-                        "kms_key_arn", null, true)
+                        "kms_key_arn", "null", true)
 
 # Lambda functions that have not set VPC subnets and security groups
 LambdasWithoutVPCs = plan.filter_attribute_is_value(allLambdaFunctions,

--- a/governance/third-generation/azure/restrict-publishers-of-current-vms.sentinel
+++ b/governance/third-generation/azure/restrict-publishers-of-current-vms.sentinel
@@ -1,4 +1,4 @@
-# This policy uses the Sentinel tfplan/v2 import to require that
+# This policy uses the Sentinel tfstate/v2 import to require that
 # all existing Azure VMs have publishers from a specified list
 
 # Import common-functions/tfstate-functions/tfstate-functions.sentinel

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources.md
@@ -1,5 +1,5 @@
 # find_datasources
-This function finds all data source instances of a specific type that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+This function finds all data source instances of a specific type that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included.
 
 When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
 

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
@@ -1,5 +1,5 @@
 # find_datasources_by_provider
-This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included.
 
 When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
 

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources.md
@@ -1,5 +1,5 @@
 # find_resources
-This function finds all resource instances of a specific type in the current plan that are being created or modified using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+This function finds all resource instances of a specific type in the current plan that are being created, modified or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included.
 
 ## Sentinel Module
 This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
@@ -1,5 +1,5 @@
 # find_resources_by_provider
-This function finds all resource instances for a specific provider in the current plan that are being created or modified using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+This function finds all resource instances for a specific provider in the current plan that are being created, modified, or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included.
 
 If you are using Terraform 0.12, use the short form of the provider name such as "aws". If you are using Terraform 0.13, use the fully-qualified provider source such as "registry.terraform.io/hashicorp/aws".
 

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -26,7 +26,8 @@ find_resources = func(type) {
   resources = filter tfplan.resource_changes as address, rc {
   	rc.type is type and
   	rc.mode is "managed" and
-  	(rc.change.actions contains "create" or rc.change.actions contains "update")
+  	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+     rc.change.actions contains "read" or rc.change.actions contains "no-op")
   }
 
   return resources
@@ -40,7 +41,8 @@ find_resources_by_provider = func(provider) {
   resources = filter tfplan.resource_changes as address, rc {
     rc.provider_name is provider and
   	rc.mode is "managed" and
-  	(rc.change.actions contains "create" or rc.change.actions contains "update")
+  	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+     rc.change.actions contains "read" or rc.change.actions contains "no-op")
   }
 
   return resources
@@ -56,7 +58,8 @@ find_datasources = func(type) {
   	rc.mode is "data" and
   	(rc.change.actions contains "create" or
     rc.change.actions contains "update" or
-    rc.change.actions contains "read")
+    rc.change.actions contains "read" or
+    rc.change.actions contains "no-op")
   }
 
   return datasources
@@ -72,7 +75,8 @@ find_datasources_by_provider = func(provider) {
   	rc.mode is "data" and
   	(rc.change.actions contains "create" or
     rc.change.actions contains "update" or
-    rc.change.actions contains "read")
+    rc.change.actions contains "read" or
+    rc.change.actions contains "no-op")
   }
 
   return datasources

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -20,7 +20,7 @@ import "types"
 
 ### find_resources ###
 # Find all resources of a specific type using the tfplan/v2 import.
-# Only include resources that are being created or updated.
+# Include resources that are not being permamently deleted.
 # Technically, this returns a map of resource changes.
 find_resources = func(type) {
   resources = filter tfplan.resource_changes as address, rc {
@@ -35,7 +35,7 @@ find_resources = func(type) {
 
 ### find_resources_by_provider ###
 # Find all resources for a specific provider using the tfplan/v2 import.
-# Only include resources that are being created or updated.
+# Include resources that are not being permamently deleted.
 # Technically, this returns a map of resource changes.
 find_resources_by_provider = func(provider) {
   resources = filter tfplan.resource_changes as address, rc {
@@ -50,7 +50,7 @@ find_resources_by_provider = func(provider) {
 
 ### find_datasources ###
 # Find all data sources of a specific type using the tfplan/v2 import.
-# Only include data sources that are being created, updated, or read.
+# Include data sources that are not being permamently deleted.
 # Technically, this returns a map of resource changes.
 find_datasources = func(type) {
   datasources = filter tfplan.resource_changes as address, rc {
@@ -67,7 +67,7 @@ find_datasources = func(type) {
 
 ### find_datasources_by_provider ###
 # Find all data sources for a specific provider using the tfplan/v2 import.
-# Only include data sources that are being created, updated, or read.
+# Include data sources that are not being permamently deleted.
 # Technically, this returns a map of resource changes.
 find_datasources_by_provider = func(provider) {
   datasources = filter tfplan.resource_changes as address, rc {


### PR DESCRIPTION
I decided that the tfplan-functions module find functions should actually find all resources that are not being permanently deleted.  So, I changed the find functions to use the following actions condition:

```
rc.change.actions contains "create" or rc.change.actions contains "update" or
rc.change.actions contains "read" or rc.change.actions contains "no-op"
```

Previously, it had been:
```
rc.change.actions contains "create" or rc.change.actions contains "update"
```

I also updated docs for the related functions which are find_datasources_by_provider, find_datasources, find_resources_by_provider and find_resources.