### PR TITLE
allow proxy config blocks for providers

### DIFF
--- a/governance/third-generation/cloud-agnostic/prevent-non-root-providers.sentinel
+++ b/governance/third-generation/cloud-agnostic/prevent-non-root-providers.sentinel
@@ -1,20 +1,38 @@
 # This policy uses the tfconfig/v2 import to prevent providers from being
-# created in non-root modules
+# created in non-root modules. Only provider proxy configuration blocks
+# that do not have any config are allowed.
 
 # Import tfconfig/v2 with alias "tfconfig"
 import "tfconfig/v2" as tfconfig
 
 # Indicate that providers are only allowed in the root module
-print("Providers are only allowed in the root module.")
+print("Providers that are not proxy configuration blocks " +
+      "are only allowed in the root module.")
 
 # Filter to providers not in root module
-# Warnings will not be printed for violations since the last parameter is false
-violatingProviders = filter tfconfig.providers as address, p {
-  p.module_address is not "" and
-  print("provider", address, "was defined in module", p.module_address)
+nonRootProviders = filter tfconfig.providers as address, p {
+  p.module_address is not ""
 }
+
+# Filter to non-root providers with config
+nonRootProvidersWithConfig = filter nonRootProviders as address, p {
+  length(p.config) is not 0 and
+  print("non-proxy provider", address, "was defined in module", p.module_address,
+        "and has a non-empty config with these keys:", keys(p.config))
+}
+
+# Filter to non-root providers with version
+nonRootProvidersWithVersion = filter nonRootProviders as address, p {
+  p.version_constraint is not "" and
+  print("non-proxy provider", address, "was defined in module", p.module_address,
+        "and has a version constraint")
+}
+
+# Determine if there were any violations
+violations = length(nonRootProvidersWithConfig) +
+             length(nonRootProvidersWithVersion)
 
 # Main rule
 main = rule {
- length(violatingProviders) is 0
+ violations is 0
 }

--- a/governance/third-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-fail.sentinel
@@ -35,7 +35,7 @@ providers = {
 		"module_address":      "module.nested",
 		"name":                "aws",
 		"provider_config_key": "module.nested:aws",
-		"version_constraint":  "",
+		"version_constraint":  "2.0.0",
 	},
 	"module.nested:http.east": {
 		"alias": "east",
@@ -43,7 +43,7 @@ providers = {
 		"module_address":      "module.nested",
 		"name":                "http",
 		"provider_config_key": "module.nested:http.east",
-		"version_constraint":  "",
+		"version_constraint":  "2.0.0",
 	},
 }
 

--- a/governance/third-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/prevent-non-root-providers/mock-tfconfig-pass.sentinel
@@ -15,6 +15,14 @@ providers = {
 		"provider_config_key": "aws",
 		"version_constraint":  "",
 	},
+	"module.nested:http.east": {
+		"alias": "east",
+		"config": {},
+		"module_address":      "module.nested",
+		"name":                "http",
+		"provider_config_key": "module.nested:http.east",
+		"version_constraint":  "",
+	},
 }
 
 resources = {


### PR DESCRIPTION
I improved the prevent-non-root-providers.sentinel policy to allow provider proxy configuration blocks that only have a name and alias to a provider in the calling module.  See https://www.terraform.io/docs/modules/providers.html#proxy-configuration-blocks