### PR TITLE
Two new policies restricting SSH and RDP for 0.0.0.0/0 for AWS SGs

### DIFF
--- a/governance/third-generation/aws/restrict-ingress-sg-rule-rdp.sentinel
+++ b/governance/third-generation/aws/restrict-ingress-sg-rule-rdp.sentinel
@@ -1,0 +1,121 @@
+# This policy uses the Sentinel tfplan/v2 import to validate that no security group
+# rules have the have SSH open to CIDR "0.0.0.0/0" for ingress rules.  It covers both the
+# aws_security_group and the aws_security_group_rule resources which can both
+# define rules.
+
+# Same targeting as terraform-foundational-policies-library/cis/
+# aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules
+# but provides greater detail of violations
+
+# Import the tfplan/v2 import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Import for looping through the Security Group Rules
+import "types"
+
+# Variables and print() can be edited to tailor this policy as needed
+forbidden_cidrs = ["0.0.0.0/0"]
+forbidden_port = 3389
+forbidden_to_port = 3389
+forbidden_from_port = 3389
+
+# Get all Security Group Ingress Rules
+aws_security_group_rules = filter tfplan.resource_changes as address, rc {
+  rc.type is "aws_security_group_rule" and
+  rc.mode is "managed" and rc.change.after.type is "ingress" and
+  (rc.change.actions contains "create" or rc.change.actions contains "update" or
+   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+}
+
+# Validate Security Group Rules
+violatingSGRulesCount = 0
+for aws_security_group_rules as address, sgr {
+
+	# Validate that each SG rule does not have disallowed value
+	# Since cidr_blocks is optional and could be computed,
+	# We check that it is present and really a list
+	# before checking whether it contains "0.0.0.0/0"
+	if sgr.change.after.cidr_blocks else null is not null and
+		types.type_of(sgr.change.after.cidr_blocks) is "list" and
+		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
+		sgr.change.after.from_port else null is not null and
+		sgr.change.after.from_port <= forbidden_from_port and 
+		sgr.change.after.to_port else null is not null and
+		sgr.change.after.to_port >= forbidden_to_port{
+		violatingSGRulesCount += 1
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		"(RDP) open to", forbidden_cidrs, "that is not allowed")
+		print("  Ingress Rule", "has from_port with value", sgr.change.after.from_port, 
+		"that is less than or equal to", forbidden_from_port)
+		print("  and Ingress Rule has to_port with value", sgr.change.after.to_port, 
+		"that is greater than or equal to", forbidden_to_port)
+	} else if sgr.change.after.cidr_blocks else null is not null and
+		types.type_of(sgr.change.after.cidr_blocks) is "list" and
+		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
+		sgr.change.after.to_port else null is not null and
+		sgr.change.after.to_port is forbidden_port{
+		violatingSGRulesCount += 1
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+			"(RDP) open to", forbidden_cidrs, "that is not allowed")
+		print("  Ingress Rule", "has to_port with value", sgr.change.after.to_port)
+  }
+} // end of SG Rules
+
+# Get all Security Groups
+allSGs = plan.find_resources("aws_security_group")
+
+# Validate Security Groups
+violatingSGsCount = 0
+for allSGs as address, sg {
+
+	# Find the ingress rules of the current SG
+	ingressRules = plan.find_blocks(sg, "ingress")
+	
+	# Filter to violating CIDR blocks
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingCidr = plan.filter_attribute_contains_items_from_list(ingressRules,
+					"cidr_blocks", forbidden_cidrs, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingToPort = plan.filter_attribute_is_value(ingressRules,
+						"to_port", forbidden_to_port, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingFromPortLess = plan.filter_attribute_less_than_equal_to_value(ingressRules,
+							"from_port", forbidden_from_port, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingToPortGreater = plan.filter_attribute_greater_than_equal_to_value(ingressRules,
+								"to_port", forbidden_to_port, false)
+	
+	# Print violation messages
+	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and 
+		length(violatingToPortGreater["messages"]) > 0{
+	violatingSGsCount += 1
+	print("SG Ingress Violation:", address, "has port", forbidden_port, 
+			"(RDP) open to", forbidden_cidrs, "that is not allowed")
+###Uncomment below if you want to show the CIDRs as a separate message as well
+#	plan.print_violations(violatingCidr["messages"], "  Ingress Rule")
+	plan.print_violations(violatingFromPortLess["messages"], "  Ingress Rule")
+	plan.print_violations(violatingToPortGreater["messages"], "  and Ingress Rule")
+	} else if length(violatingCidr["messages"]) > 0 and length(violatingToPort["messages"]) > 0{
+	violatingSGsCount += 1
+    print("SG Ingress Violation:", address, "has port", forbidden_port, 
+			"(RDP) open to", forbidden_cidrs, "that is not allowed")
+###Uncomment below if you want to show the CIDRs as a separate message as well
+#   plan.print_violations(violatingCidr["messages"], "  Ingress Rule")
+	plan.print_violations(violatingToPort["messages"], "  Ingress Rule")
+  }
+} // end for SGs
+
+validated = violatingSGsCount is 0 and violatingSGRulesCount is 0
+main = rule {
+  validated is true
+}

--- a/governance/third-generation/aws/restrict-ingress-sg-rule-ssh.sentinel
+++ b/governance/third-generation/aws/restrict-ingress-sg-rule-ssh.sentinel
@@ -1,0 +1,121 @@
+# This policy uses the Sentinel tfplan/v2 import to validate that no security group
+# rules have the have SSH open to CIDR "0.0.0.0/0" for ingress rules.  It covers both the
+# aws_security_group and the aws_security_group_rule resources which can both
+# define rules.
+
+# Same targeting as terraform-foundational-policies-library/cis/
+# aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules
+# but provides greater detail of violations
+
+# Import the tfplan/v2 import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Import for looping through the Security Group Rules
+import "types"
+
+# Variables and print() can be edited to tailor this policy as needed
+forbidden_cidrs = ["0.0.0.0/0"]
+forbidden_port = 22
+forbidden_to_port = 22
+forbidden_from_port = 22
+
+# Get all Security Group Ingress Rules
+aws_security_group_rules = filter tfplan.resource_changes as address, rc {
+  rc.type is "aws_security_group_rule" and
+  rc.mode is "managed" and rc.change.after.type is "ingress" and
+  (rc.change.actions contains "create" or rc.change.actions contains "update" or
+   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+}
+
+# Validate Security Group Rules
+violatingSGRulesCount = 0
+for aws_security_group_rules as address, sgr {
+
+	# Validate that each SG rule does not have disallowed value
+	# Since cidr_blocks is optional and could be computed,
+	# We check that it is present and really a list
+	# before checking whether it contains "0.0.0.0/0"
+	if sgr.change.after.cidr_blocks else null is not null and
+		types.type_of(sgr.change.after.cidr_blocks) is "list" and
+		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
+		sgr.change.after.from_port else null is not null and
+		sgr.change.after.from_port <= forbidden_from_port and 
+		sgr.change.after.to_port else null is not null and
+		sgr.change.after.to_port >= forbidden_to_port{
+		violatingSGRulesCount += 1
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		"(SSH) open to", forbidden_cidrs, "that is not allowed")
+		print("  Ingress Rule", "has from_port with value", sgr.change.after.from_port, 
+		"that is less than or equal to", forbidden_from_port)
+		print("  and Ingress Rule has to_port with value", sgr.change.after.to_port, 
+		"that is greater than or equal to", forbidden_to_port)
+	} else if sgr.change.after.cidr_blocks else null is not null and
+		types.type_of(sgr.change.after.cidr_blocks) is "list" and
+		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
+		sgr.change.after.to_port else null is not null and
+		sgr.change.after.to_port is forbidden_port{
+		violatingSGRulesCount += 1
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+			"(SSH) open to", forbidden_cidrs, "that is not allowed")
+		print("  Ingress Rule", "has to_port with value", sgr.change.after.to_port)
+  }
+} // end of SG Rules
+
+# Get all Security Groups
+allSGs = plan.find_resources("aws_security_group")
+
+# Validate Security Groups
+violatingSGsCount = 0
+for allSGs as address, sg {
+
+	# Find the ingress rules of the current SG
+	ingressRules = plan.find_blocks(sg, "ingress")
+	
+	# Filter to violating CIDR blocks
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingCidr = plan.filter_attribute_contains_items_from_list(ingressRules,
+					"cidr_blocks", forbidden_cidrs, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingToPort = plan.filter_attribute_is_value(ingressRules,
+						"to_port", forbidden_to_port, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingFromPortLess = plan.filter_attribute_less_than_equal_to_value(ingressRules,
+							"from_port", forbidden_from_port, false)
+	
+	# Filter to violating Service port
+	# Warnings will not be printed for violations since the last parameter is false
+	violatingToPortGreater = plan.filter_attribute_greater_than_equal_to_value(ingressRules,
+								"to_port", forbidden_to_port, false)
+	
+	# Print violation messages
+	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and 
+		length(violatingToPortGreater["messages"]) > 0{
+	violatingSGsCount += 1
+	print("SG Ingress Violation:", address, "has port", forbidden_port, 
+			"(SSH) open to", forbidden_cidrs, "that is not allowed")
+###Uncomment below if you want to show the CIDRs as a separate message as well
+#	plan.print_violations(violatingCidr["messages"], "  Ingress Rule")
+	plan.print_violations(violatingFromPortLess["messages"], "  Ingress Rule")
+	plan.print_violations(violatingToPortGreater["messages"], "  and Ingress Rule")
+	} else if length(violatingCidr["messages"]) > 0 and length(violatingToPort["messages"]) > 0{
+	violatingSGsCount += 1
+    print("SG Ingress Violation:", address, "has port", forbidden_port, 
+			"(SSH) open to", forbidden_cidrs, "that is not allowed")
+###Uncomment below if you want to show the CIDRs as a separate message as well
+#   plan.print_violations(violatingCidr["messages"], "  Ingress Rule")
+	plan.print_violations(violatingToPort["messages"], "  Ingress Rule")
+  }
+} // end for SGs
+
+validated = violatingSGsCount is 0 and violatingSGRulesCount is 0
+main = rule {
+  validated is true
+}

--- a/governance/third-generation/aws/sentinel.hcl
+++ b/governance/third-generation/aws/sentinel.hcl
@@ -68,3 +68,12 @@ policy "restrict-launch-configuration-instance-type" {
   source = "./restrict-launch-configuration-instance-type.sentinel"
   enforcement_level = "advisory"
 }
+policy "restrict-ingress-sg-rule-ssh" {
+  source = "./restrict-ingress-sg-rule-ssh.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-ingress-sg-rule-rdp" {
+  source = "./restrict-ingress-sg-rule-rdp.sentinel"
+  enforcement_level = "advisory"
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/fail.hcl
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/fail.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/mock-tfplan-fail.sentinel
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/mock-tfplan-fail.sentinel
@@ -1,0 +1,313 @@
+resource_changes = {
+	"aws_security_group.bar": {
+		"address": "aws_security_group.bar",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "bar",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "bar",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "-1",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          3389,
+					},
+				],
+				"name":                   "bar",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bar",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.baz": {
+		"address": "aws_security_group.baz",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "baz",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "baz",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          9443,
+					},
+				],
+				"name":                   "baz",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "baz",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.foo": {
+		"address": "aws_security_group.foo",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "foo",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "foo",
+						"from_port":        3389,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          3389,
+					},
+				],
+				"name":                   "foo",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "foo",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.seuss": {
+		"address": "aws_security_group.seuss",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":            "seuss",
+				"name":                   "seuss",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":      true,
+				"egress":   true,
+				"id":       true,
+				"ingress":  true,
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "seuss",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group_rule.eggs": {
+		"address": "aws_security_group_rule.eggs",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "eggs",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "-1",
+				"self":             false,
+				"to_port":          0,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "eggs",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.green": {
+		"address": "aws_security_group_rule.green",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "green",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          3389,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "green",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.ham": {
+		"address": "aws_security_group_rule.ham",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "ham",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          9443,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/mock-tfplan-pass.sentinel
@@ -1,0 +1,313 @@
+resource_changes = {
+	"aws_security_group.bar": {
+		"address": "aws_security_group.bar",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "bar",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"10.0.0.0/8",
+						],
+						"description":      "bar",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "-1",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          3389,
+					},
+				],
+				"name":                   "bar",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bar",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.baz": {
+		"address": "aws_security_group.baz",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "baz",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"10.0.0.0/0",
+						],
+						"description":      "baz",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          9443,
+					},
+				],
+				"name":                   "baz",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "baz",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.foo": {
+		"address": "aws_security_group.foo",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "foo",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "foo",
+						"from_port":        22,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          22,
+					},
+				],
+				"name":                   "foo",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "foo",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.seuss": {
+		"address": "aws_security_group.seuss",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":            "seuss",
+				"name":                   "seuss",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":      true,
+				"egress":   true,
+				"id":       true,
+				"ingress":  true,
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "seuss",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group_rule.eggs": {
+		"address": "aws_security_group_rule.eggs",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "eggs",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "-1",
+				"self":             false,
+				"to_port":          0,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "eggs",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.green": {
+		"address": "aws_security_group_rule.green",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"10.0.0.0/8",
+				],
+				"description":      "green",
+				"from_port":        3389,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          3389,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "green",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.ham": {
+		"address": "aws_security_group_rule.ham",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "ham",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          1024,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/pass.hcl
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-rdp/pass.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main =  true
+  }
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/fail.hcl
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/fail.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/mock-tfplan-fail.sentinel
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/mock-tfplan-fail.sentinel
@@ -1,0 +1,313 @@
+resource_changes = {
+	"aws_security_group.bar": {
+		"address": "aws_security_group.bar",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "bar",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "bar",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "-1",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          22,
+					},
+				],
+				"name":                   "bar",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bar",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.baz": {
+		"address": "aws_security_group.baz",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "baz",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "baz",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          1024,
+					},
+				],
+				"name":                   "baz",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "baz",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.foo": {
+		"address": "aws_security_group.foo",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "foo",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      "foo",
+						"from_port":        22,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          22,
+					},
+				],
+				"name":                   "foo",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "foo",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.seuss": {
+		"address": "aws_security_group.seuss",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":            "seuss",
+				"name":                   "seuss",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":      true,
+				"egress":   true,
+				"id":       true,
+				"ingress":  true,
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "seuss",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group_rule.eggs": {
+		"address": "aws_security_group_rule.eggs",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "eggs",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "-1",
+				"self":             false,
+				"to_port":          0,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "eggs",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.green": {
+		"address": "aws_security_group_rule.green",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "green",
+				"from_port":        22,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          22,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "green",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.ham": {
+		"address": "aws_security_group_rule.ham",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "ham",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          1024,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/mock-tfplan-pass.sentinel
@@ -1,0 +1,313 @@
+resource_changes = {
+	"aws_security_group.bar": {
+		"address": "aws_security_group.bar",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "bar",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"10.0.0.0/8",
+						],
+						"description":      "bar",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "-1",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          22,
+					},
+				],
+				"name":                   "bar",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bar",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.baz": {
+		"address": "aws_security_group.baz",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "baz",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"10.0.0.0/8",
+						],
+						"description":      "baz",
+						"from_port":        0,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          1024,
+					},
+				],
+				"name":                   "baz",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "baz",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.foo": {
+		"address": "aws_security_group.foo",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "foo",
+				"ingress": [
+					{
+						"cidr_blocks": [
+							"10.0.0.0/8",
+						],
+						"description":      "foo",
+						"from_port":        22,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             false,
+						"to_port":          22,
+					},
+				],
+				"name":                   "foo",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "foo",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.seuss": {
+		"address": "aws_security_group.seuss",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":            "seuss",
+				"name":                   "seuss",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":      true,
+				"egress":   true,
+				"id":       true,
+				"ingress":  true,
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "seuss",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group_rule.eggs": {
+		"address": "aws_security_group_rule.eggs",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "eggs",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "-1",
+				"self":             false,
+				"to_port":          0,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "eggs",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.green": {
+		"address": "aws_security_group_rule.green",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"0.0.0.0/0",
+				],
+				"description":      "green",
+				"from_port":        443,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          443,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "green",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.ham": {
+		"address": "aws_security_group_rule.ham",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": [
+					"10.0.0.0/8",
+				],
+				"description":      "ham",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             false,
+				"to_port":          1024,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+}

--- a/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/pass.hcl
+++ b/governance/third-generation/aws/test/restrict-ingress-sg-rule-ssh/pass.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main =  true
+  }
+}

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -548,7 +548,8 @@ filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined."
+                " that is null or undefined. " + "It is supposed to be less " +
+                "than or equal to " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -581,7 +582,8 @@ filter_attribute_greater_than_equal_to_value = func(resources, attr, value, prtm
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined."
+                " that is null or undefined. " + "It is supposed to be less " +
+                "than " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -614,7 +616,8 @@ filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined."
+                " that is null or undefined. " + "It is supposed to be greater " +
+                "than or equal to " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -647,7 +650,8 @@ filter_attribute_less_than_equal_to_value = func(resources, attr, value, prtmsg)
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined. "
+                " that is null or undefined. " + "It is supposed to be greater " +
+                "than " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -548,8 +548,7 @@ filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined. " + "It is supposed to be less " +
-                "than or equal to " + to_string(value)
+                " that is null or undefined."
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -559,6 +558,39 @@ filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that is greater than " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_greater_than_equal_to_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_equal_to_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined."
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) >= value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is greater than or equal to " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -582,8 +614,7 @@ filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
     if float(v) else null is null {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) +
-                " that is null or undefined. " + "It is supposed to be greater " +
-                "than or equal to " + to_string(value)
+                " that is null or undefined."
       violators[address] = rc
 			messages[address] = message
       if prtmsg {
@@ -593,6 +624,39 @@ filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
       # Add the resource and a warning message to the violators list
       message = to_string(address) + " has " + to_string(attr) + " with value " +
                 to_string(v) + " that is less than " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_less_than_equal_to_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_equal_to_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined. "
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) <= value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is less than or equal to " + to_string(value)
       violators[address] = rc
 			messages[address] = message
       if prtmsg {


### PR DESCRIPTION
Created new 3rd Gen policies for restricting SSH and RDP. They have similar targeting as terraform-foundational-policies-library/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules and terraform-foundational-policies-library/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules but adds "read" and "no-op" to resource changes, loops through both the aws_security_group and the aws_security_group_rule resources, and provides greater detail of violations.

Two new policy sets were added:
restrict-ingress-sg-rule-rdp
restrict-ingress-sg-rule-ssh

Changes were made to:
tfplan-function - adding "filter_attribute_less_than_equal_to_value" and "filter_attribute_greater_than_equal_to_value".