### PR TITLE
add restrict-s3-bucket-policies.sentinel policy

### DIFF
--- a/governance/third-generation/aws/restrict-s3-bucket-policies.sentinel
+++ b/governance/third-generation/aws/restrict-s3-bucket-policies.sentinel
@@ -1,0 +1,163 @@
+# This policy uses the Sentinel tfplan/v2 and tfconfig/v2 imports to require
+# that all S3 bucket policies are implemented with the aws_iam_policy_document
+# data source and that those policies require buckets to only be accessible
+# via HTTPS and from specific VPC endpoints.
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
+# with alias "config"
+import "tfconfig-functions" as config
+
+# Restricted S3 Actions
+restricted_s3_actions = ["s3:ListBucket", "s3:GetObject", "s3:PutObject"]
+
+# Allowed VPC Endpoints
+allowed_vpc_endpoints = ["vpce-111111", "vpce-222222", "vpce-333333"]
+
+# Get all S3 buckets in configuration
+allS3Buckets = config.find_resources_by_type("aws_s3_bucket")
+
+# Filter to S3 buckets with the policy argument set since it is not mandatory.
+# Don't print violation messages
+S3BucketsWithPolicy = config.filter_attribute_not_in_list(
+  allS3Buckets, "config.policy", ["null"], false)
+
+# Filter to S3 buckets that set policy but do not set it to an instance of
+# the aws_iam_policy_document data source.
+# Print violation messages which will now only be for those buckets that
+# set policy to something other than an instance of aws_iam_policy_document
+S3BucketsWithInvalidPolicy = config.filter_attribute_does_not_match_regex(
+                             S3BucketsWithPolicy["items"], "config.policy",
+                             "^data\\.aws_iam_policy_document\\.(.*)$", true)
+if length(S3BucketsWithInvalidPolicy["messages"]) > 0 {
+  print("All aws_s3_bucket resources must get their policy from an instance of",
+        "the data_iam_policy_document data source.")
+}
+
+# Get all S3 bucket policies in configuration
+allS3BucketPolicies = config.find_resources_by_type("aws_s3_bucket_policy")
+
+# Filter to S3 bucket policies that set policy but do not set it to an instance
+# of the aws_iam_policy_document data source.
+# Print violation messages for s3 bucket policies that set policy to something
+# other than an instance of aws_iam_policy_document
+# Note that we do not need to screen out instances of aws_s3_bucket_policy that
+# are missing the policy argument because it is mandatory.
+S3BucketPoliciesWithInvalidPolicy = config.filter_attribute_does_not_match_regex(
+                                allS3BucketPolicies, "config.policy",
+                                "^data\\.aws_iam_policy_document\\.(.*)$", true)
+if length(S3BucketPoliciesWithInvalidPolicy["messages"]) > 0 {
+  print("All aws_s3_bucket_policy resources must get their policy from",
+        "an instance of the data_iam_policy_document data source.")
+}
+
+# Find instances of aws_iam_policy_document
+allIAMPolicyDocuments = plan.find_datasources("aws_iam_policy_document")
+
+# Validate IAM Policy Documents
+policyDocumentsValidated = true
+for allIAMPolicyDocuments as address, pd {
+
+  # Find the statements of the current policy document
+  statements = plan.find_blocks(pd, "statement")
+
+  # Determine if any statements include restricted S3 actions
+  statementsWithS3actions = plan.filter_attribute_contains_items_from_list(
+                            statements, "actions", restricted_s3_actions, false)
+  if length(statementsWithS3actions["resources"]) is 0 {
+    # No statements included restricted S3 actions, so policy document is ok.
+    break
+  }
+
+  # Test each restricted S3 action separately to make sure some statement
+  # in the current policy document has the desired conditions.
+  for restricted_s3_actions as s3_action {
+    # Filter to statements of the current policy document that have an S3 action
+    statementsWithS3action = plan.filter_attribute_contains_items_from_list(
+          statements, "actions", [s3_action], false)
+
+    # Search for deny statement with aws:SecureTransport set to false
+    foundSecureTransportCondition = false
+    for statementsWithS3action["resources"] as _, statement {
+      if foundSecureTransportCondition {
+        break
+      }
+      if statement.effect else "" is "Deny" {
+        for statement.condition else [] as _, condition {
+          if condition.test is "Bool" and
+             condition.variable is "aws:SecureTransport" and
+             "false" in condition.values {
+            foundSecureTransportCondition = true
+            break
+          } // end if secureTransport condition test
+        } // end for condition
+      } // end if statement.effect is Deny
+    } // end for statementsWithS3actions
+
+    # If no statement had a valid condition for aws:SecureTransport,
+    # Then current policy document is invalid.
+    if not foundSecureTransportCondition {
+      print("IAM policy document", address, "has statements that apply to S3",
+            "buckets and/or objects, but does not have a Deny statement that",
+            "requires aws:SecureTransport to be false for action", s3_action)
+      policyDocumentsValidated = false
+    }
+
+    # Search for deny statement with valid aws:SourceVpce
+    foundVPCECondition = false
+    foundInvalidVPCE = false
+    for statementsWithS3action["resources"] as _, statement {
+      if foundVPCECondition {
+        break
+      }
+      if statement.effect else "" is "Deny" {
+        for statement.condition else [] as _, condition {
+          if condition.test is "StringNotEquals" and
+             condition.variable is "aws:SourceVpce" {
+            foundInvalidVPCE = false
+            for condition.values as value {
+              if value not in allowed_vpc_endpoints {
+                foundInvalidVPCE = true
+                break
+              } // end value check
+            } // end for condition.values
+            if not foundInvalidVPCE {
+              foundVPCECondition = true
+              break
+            } // end not foundInvalidVPCE
+          } // end if SourceVpce condition test
+        } // end for condition
+      } // end if statement.effect is Deny
+    } // end for statementsWithS3actions
+
+    # If no statement had a valid condition for aws:SourceVpce,
+    # Then current policy document is invalid.
+    if foundVPCECondition is false and  foundInvalidVPCE is false {
+      print("IAM policy document", address, "has statements that apply to S3",
+            "buckets and/or objects, but does not have a Deny statement that",
+            "restricts aws:SourceVpce to VPC endpoints in", allowed_vpc_endpoints,
+            "for action", s3_action)
+      policyDocumentsValidated = false
+    }
+    if foundVPCECondition is false and foundInvalidVPCE is true {
+      print("IAM policy document", address, "has statements that apply to S3",
+            "buckets and/or objects and does have a Deny statement that",
+            "restricts aws:SourceVpce to VPC endpoints, but it includes at",
+            "least one VPC endpoint that is not in", allowed_vpc_endpoints,
+            "for action", s3_action)
+      policyDocumentsValidated = false
+    }
+
+  } // end for restricted_s3_actions
+} // end for allIAMPolicyDocuments
+
+# Main rule
+validated = length(S3BucketsWithInvalidPolicy["messages"]) is 0 and
+            length(S3BucketPoliciesWithInvalidPolicy["messages"]) is 0 and
+            policyDocumentsValidated
+main = rule {
+  validated is true
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-bucket-policy.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-bucket-policy.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail-bucket-policy.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-bucket-policy.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-bucket.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-bucket.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail-bucket.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-bucket.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-invalid-vpces.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-invalid-vpces.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail-invalid-vpces.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-invalid-vpces.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-missing-vpce.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-missing-vpce.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail-missing-vpce.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-missing-vpce.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-secure-transport.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/fail-secure-transport.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail-secure-transport.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-secure-transport.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-bucket-policy.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-bucket-policy.sentinel
@@ -1,0 +1,195 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket_1": {
+		"address": "aws_s3_bucket.bucket_1",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"constant_value": "roger-bucket-1",
+			},
+			"server_side_encryption_configuration": [
+				{
+					"rule": [
+						{
+							"apply_server_side_encryption_by_default": [
+								{
+									"kms_master_key_id": {
+										"references": [
+											"aws_kms_key.my_key",
+										],
+									},
+									"sse_algorithm": {
+										"constant_value": "aws:kms",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket.bucket_2": {
+		"address": "aws_s3_bucket.bucket_2",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"constant_value": "roger-bucket-2",
+			},
+			"server_side_encryption_configuration": [
+				{
+					"rule": [
+						{
+							"apply_server_side_encryption_by_default": [
+								{
+									"kms_master_key_id": {
+										"references": [
+											"aws_kms_key.my_key",
+										],
+									},
+									"sse_algorithm": {
+										"constant_value": "aws:kms",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_2",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket_policy.bucket_policy_2": {
+		"address": "aws_s3_bucket_policy.bucket_policy_2",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.bucket_2",
+				],
+			},
+			"policy": {
+				"constant_value": "{\n  \"Version\":\"2012-10-17\",\n  \"Statement\":[\n    {\n      \"Sid\":\"PublicRead\",\n      \"Effect\":\"Allow\",\n      \"Principal\": \"*\",\n      \"Action\":[\"s3:GetObject\",\"s3:GetObjectVersion\"],\n      \"Resource\":[\"arn:aws:s3:::*\"]\n    }\n  ]\n}\n",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_policy_2",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-bucket-0",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-bucket.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-bucket.sentinel
@@ -1,0 +1,136 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket_0": {
+		"address": "aws_s3_bucket.bucket_0",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket_name",
+				],
+			},
+			"policy": {
+				"constant_value": "{\n  \"Version\":\"2012-10-17\",\n  \"Statement\":[\n    {\n      \"Sid\":\"PublicRead\",\n      \"Effect\":\"Allow\",\n      \"Principal\": \"*\",\n      \"Action\":[\"s3:GetObject\",\"s3:GetObjectVersion\"],\n      \"Resource\":[\"arn:aws:s3:::*\"]\n    }\n  ]\n}\n",
+			},
+			"server_side_encryption_configuration": [
+				{
+					"rule": [
+						{
+							"apply_server_side_encryption_by_default": [
+								{
+									"kms_master_key_id": {
+										"references": [
+											"aws_kms_key.my_key",
+										],
+									},
+									"sse_algorithm": {
+										"constant_value": "aws:kms",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_0",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-bucket-0",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-invalid-vpces.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-invalid-vpces.sentinel
@@ -1,0 +1,302 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for bucket level operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for object operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "NotIpAddress",
+							},
+							"values": {
+								"references": [
+									"var.ip_addresses",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceIp",
+							},
+						},
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny bucket access not through vpce",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny object access not through vpce",
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-bucket-0",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-missing-vpce.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-missing-vpce.sentinel
@@ -1,0 +1,241 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for bucket level operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for object operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "NotIpAddress",
+							},
+							"values": {
+								"references": [
+									"var.ip_addresses",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceIp",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny bucket access not through vpce",
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-bucket-0",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-secure-transport.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-fail-secure-transport.sentinel
@@ -1,0 +1,256 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for bucket level operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "NotIpAddress",
+							},
+							"values": {
+								"references": [
+									"var.ip_addresses",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceIp",
+							},
+						},
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny bucket access not through vpce",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket_1",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny object access not through vpce",
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-bucket-0",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfconfig-pass.sentinel
@@ -1,0 +1,370 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"config": {
+			"deletion_window_in_days": {
+				"constant_value": 10,
+			},
+			"description": {
+				"constant_value": "This key is used to encrypt bucket objects",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "my_key",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"acl": {
+				"references": [
+					"var.bucket_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket_name",
+				],
+			},
+			"server_side_encryption_configuration": [
+				{
+					"rule": [
+						{
+							"apply_server_side_encryption_by_default": [
+								{
+									"kms_master_key_id": {
+										"references": [
+											"aws_kms_key.my_key",
+										],
+									},
+									"sse_algorithm": {
+										"constant_value": "aws:kms",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket_policy.bucket_policy": {
+		"address": "aws_s3_bucket_policy.bucket_policy",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.bucket",
+				],
+			},
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.example",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for bucket level operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "Bool",
+							},
+							"values": {
+								"constant_value": [
+									"false",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SecureTransport",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "*",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny HTTP for object operations",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:ListBucket",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "NotIpAddress",
+							},
+							"values": {
+								"references": [
+									"var.ip_addresses",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceIp",
+							},
+						},
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny bucket access not through vpce",
+					},
+				},
+				{
+					"actions": {
+						"constant_value": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "StringNotEquals",
+							},
+							"values": {
+								"references": [
+									"var.s3_vpce_id",
+									"var.shared_s3_vpce_id",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceVpce",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Deny",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"*",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.bucket",
+						],
+					},
+					"sid": {
+						"constant_value": "Deny object access not through vpce",
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"bucket_acl": {
+		"default":        "private",
+		"description":    "ACL for S3 bucket: private, public-read, public-read-write, etc",
+		"module_address": "",
+		"name":           "bucket_acl",
+	},
+	"bucket_name": {
+		"default":        "roger-morgan-bucket",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"ip_addresses": {
+		"default": [
+			"1.1.1.1",
+		],
+		"description":    "list of prohibited IP address",
+		"module_address": "",
+		"name":           "ip_addresses",
+	},
+	"s3_vpce_id": {
+		"default":        "",
+		"description":    "S3 VPC endpoint",
+		"module_address": "",
+		"name":           "s3_vpce_id",
+	},
+	"shared_s3_vpce_id": {
+		"default":        "",
+		"description":    "Shared S3 VPC endpoint",
+		"module_address": "",
+		"name":           "shared_s3_vpce_id",
+	},
+}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-bucket-policy.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-bucket-policy.sentinel
@@ -1,0 +1,239 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-bucket-0",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket_1": {
+		"address": "aws_s3_bucket.bucket_1",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":                       "private",
+				"bucket":                    "roger-bucket-1",
+				"bucket_prefix":             null,
+				"cors_rule":                 [],
+				"force_destroy":             false,
+				"grant":                     [],
+				"lifecycle_rule":            [],
+				"logging":                   [],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"sse_algorithm": "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags":    null,
+				"website": [],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging":                     [],
+				"object_lock_configuration":   [],
+				"region":                      true,
+				"replication_configuration":   [],
+				"request_payer":               true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": true,
+									},
+								],
+							},
+						],
+					},
+				],
+				"versioning":       true,
+				"website":          [],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket_1",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket",
+	},
+	"aws_s3_bucket.bucket_2": {
+		"address": "aws_s3_bucket.bucket_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":                       "private",
+				"bucket":                    "roger-bucket-2",
+				"bucket_prefix":             null,
+				"cors_rule":                 [],
+				"force_destroy":             false,
+				"grant":                     [],
+				"lifecycle_rule":            [],
+				"logging":                   [],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"sse_algorithm": "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags":    null,
+				"website": [],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging":                     [],
+				"object_lock_configuration":   [],
+				"region":                      true,
+				"replication_configuration":   [],
+				"request_payer":               true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": true,
+									},
+								],
+							},
+						],
+					},
+				],
+				"versioning":       true,
+				"website":          [],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket_2",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket",
+	},
+	"aws_s3_bucket_policy.bucket_policy_2": {
+		"address": "aws_s3_bucket_policy.bucket_policy_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"policy": "{\n  \"Version\":\"2012-10-17\",\n  \"Statement\":[\n    {\n      \"Sid\":\"PublicRead\",\n      \"Effect\":\"Allow\",\n      \"Principal\": \"*\",\n      \"Action\":[\"s3:GetObject\",\"s3:GetObjectVersion\"],\n      \"Resource\":[\"arn:aws:s3:::*\"]\n    }\n  ]\n}\n",
+			},
+			"after_unknown": {
+				"bucket": true,
+				"id":     true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket_policy_2",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket_policy",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-bucket.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-bucket.sentinel
@@ -1,0 +1,139 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-bucket-0",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket_0": {
+		"address": "aws_s3_bucket.bucket_0",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":                       "private",
+				"bucket":                    "roger-bucket-0",
+				"bucket_prefix":             null,
+				"cors_rule":                 [],
+				"force_destroy":             false,
+				"grant":                     [],
+				"lifecycle_rule":            [],
+				"logging":                   [],
+				"object_lock_configuration": [],
+				"policy":                    "{\n  \"Version\":\"2012-10-17\",\n  \"Statement\":[\n    {\n      \"Sid\":\"PublicRead\",\n      \"Effect\":\"Allow\",\n      \"Principal\": \"*\",\n      \"Action\":[\"s3:GetObject\",\"s3:GetObjectVersion\"],\n      \"Resource\":[\"arn:aws:s3:::*\"]\n    }\n  ]\n}\n",
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"sse_algorithm": "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags":    null,
+				"website": [],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging":                     [],
+				"object_lock_configuration":   [],
+				"region":                      true,
+				"replication_configuration":   [],
+				"request_payer":               true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": true,
+									},
+								],
+							},
+						],
+					},
+				],
+				"versioning":       true,
+				"website":          [],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket_0",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-invalid-vpces.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-invalid-vpces.sentinel
@@ -1,0 +1,320 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-bucket-0",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"change": {
+			"actions": [
+				"read",
+			],
+			"after": {
+				"override_json":             null,
+				"override_policy_documents": null,
+				"policy_id":                 null,
+				"source_json":               null,
+				"source_policy_documents":   null,
+				"statement": [
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for bucket level operations",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for object operations",
+					},
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "NotIpAddress",
+								"values": [
+									"1.1.1.1",
+								],
+								"variable": "aws:SourceIp",
+							},
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-444444",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny bucket access not through vpce",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-444444",
+									"vpce-555555",
+									"vpce-666666",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny object access not through vpce",
+					},
+				],
+				"version": null,
+			},
+			"after_unknown": {
+				"id":   true,
+				"json": true,
+				"statement": [
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_iam_policy_document",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-missing-vpce.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-missing-vpce.sentinel
@@ -1,0 +1,282 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-bucket-0",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"change": {
+			"actions": [
+				"read",
+			],
+			"after": {
+				"override_json":             null,
+				"override_policy_documents": null,
+				"policy_id":                 null,
+				"source_json":               null,
+				"source_policy_documents":   null,
+				"statement": [
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for bucket level operations",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for object operations",
+					},
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "NotIpAddress",
+								"values": [
+									"1.1.1.1",
+								],
+								"variable": "aws:SourceIp",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny bucket access not through vpce",
+					},
+				],
+				"version": null,
+			},
+			"after_unknown": {
+				"id":   true,
+				"json": true,
+				"statement": [
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_iam_policy_document",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-secure-transport.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-fail-secure-transport.sentinel
@@ -1,0 +1,293 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-bucket-0",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"change": {
+			"actions": [
+				"read",
+			],
+			"after": {
+				"override_json":             null,
+				"override_policy_documents": null,
+				"policy_id":                 null,
+				"source_json":               null,
+				"source_policy_documents":   null,
+				"statement": [
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Allow",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for bucket level operations",
+					},
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "NotIpAddress",
+								"values": [
+									"1.1.1.1",
+								],
+								"variable": "aws:SourceIp",
+							},
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-111111",
+									"vpce-222222",
+									"vpce-333333",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny bucket access not through vpce",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-111111",
+									"vpce-222222",
+									"vpce-333333",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny object access not through vpce",
+					},
+				],
+				"version": null,
+			},
+			"after_unknown": {
+				"id":   true,
+				"json": true,
+				"statement": [
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_iam_policy_document",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/mock-tfplan-pass.sentinel
@@ -1,0 +1,421 @@
+terraform_version = "0.13.5"
+
+variables = {
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "private",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-morgan-bucket",
+	},
+	"ip_addresses": {
+		"name": "ip_addresses",
+		"value": [
+			"1.1.1.1",
+		],
+	},
+	"s3_vpce_id": {
+		"name":  "s3_vpce_id",
+		"value": "",
+	},
+	"shared_s3_vpce_id": {
+		"name":  "shared_s3_vpce_id",
+		"value": "",
+	},
+}
+
+resource_changes = {
+	"aws_kms_key.my_key": {
+		"address": "aws_kms_key.my_key",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"customer_master_key_spec": "SYMMETRIC_DEFAULT",
+				"deletion_window_in_days":  10,
+				"description":              "This key is used to encrypt bucket objects",
+				"enable_key_rotation":      false,
+				"is_enabled":               true,
+				"key_usage":                "ENCRYPT_DECRYPT",
+				"tags":                     null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"id":     true,
+				"key_id": true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "my_key",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_kms_key",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"acl":                       "private",
+				"bucket":                    "roger-morgan-bucket",
+				"bucket_prefix":             null,
+				"cors_rule":                 [],
+				"force_destroy":             false,
+				"grant":                     [],
+				"lifecycle_rule":            [],
+				"logging":                   [],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"sse_algorithm": "aws:kms",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags":    null,
+				"website": [],
+			},
+			"after_unknown": {
+				"acceleration_status": true,
+				"arn":                         true,
+				"bucket_domain_name":          true,
+				"bucket_regional_domain_name": true,
+				"cors_rule":                   [],
+				"grant":                       [],
+				"hosted_zone_id":              true,
+				"id":                          true,
+				"lifecycle_rule":              [],
+				"logging":                     [],
+				"object_lock_configuration":   [],
+				"region":                      true,
+				"replication_configuration":   [],
+				"request_payer":               true,
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": true,
+									},
+								],
+							},
+						],
+					},
+				],
+				"versioning":       true,
+				"website":          [],
+				"website_domain":   true,
+				"website_endpoint": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket",
+	},
+	"aws_s3_bucket_policy.bucket_policy": {
+		"address": "aws_s3_bucket_policy.bucket_policy",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {},
+			"after_unknown": {
+				"bucket": true,
+				"id":     true,
+				"policy": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket_policy",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_s3_bucket_policy",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"change": {
+			"actions": [
+				"read",
+			],
+			"after": {
+				"override_json":             null,
+				"override_policy_documents": null,
+				"policy_id":                 null,
+				"source_json":               null,
+				"source_policy_documents":   null,
+				"statement": [
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for bucket level operations",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "Bool",
+								"values": [
+									"false",
+								],
+								"variable": "aws:SecureTransport",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "*",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny HTTP for object operations",
+					},
+					{
+						"actions": [
+							"s3:ListBucket",
+						],
+						"condition": [
+							{
+								"test": "NotIpAddress",
+								"values": [
+									"1.1.1.1",
+								],
+								"variable": "aws:SourceIp",
+							},
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-111111",
+									"vpce-222222",
+									"vpce-333333",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny bucket access not through vpce",
+					},
+					{
+						"actions": [
+							"s3:GetObject",
+							"s3:PutObject",
+						],
+						"condition": [
+							{
+								"test": "StringNotEquals",
+								"values": [
+									"vpce-111111",
+									"vpce-222222",
+									"vpce-333333",
+								],
+								"variable": "aws:SourceVpce",
+							},
+						],
+						"effect":         "Deny",
+						"not_actions":    null,
+						"not_principals": [],
+						"not_resources":  null,
+						"principals": [
+							{
+								"identifiers": [
+									"*",
+								],
+								"type": "AWS",
+							},
+						],
+						"resources": [],
+						"sid":       "Deny object access not through vpce",
+					},
+				],
+				"version": null,
+			},
+			"after_unknown": {
+				"id":   true,
+				"json": true,
+				"statement": [
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+								],
+							},
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+					{
+						"actions": [
+							false,
+							false,
+						],
+						"condition": [
+							{
+								"values": [
+									false,
+									false,
+									false,
+								],
+							},
+						],
+						"not_principals": [],
+						"principals": [
+							{
+								"identifiers": [
+									false,
+								],
+							},
+						],
+						"resources": [
+							true,
+						],
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_iam_policy_document",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/aws/test/restrict-s3-bucket-policies/pass.hcl
+++ b/governance/third-generation/aws/test/restrict-s3-bucket-policies/pass.hcl
@@ -1,0 +1,25 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-pass.sentinel"
+  }
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main =  true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -299,7 +299,7 @@ evaluate_attribute = func(item, attribute) {
     return null
   }
   if attributes[0] is "config" {
-    config = item.config[attributes[1]]
+    config = item.config[attributes[1]] else {}
     if "constant_value" in config {
       # Found constant_value in config
       return config.constant_value
@@ -328,7 +328,8 @@ filter_attribute_not_in_list = func(items, attr, allowed, prtmsg) {
 
   # Iterate over items
   for items as index, item {
-    val = item[attr] else null
+    val = evaluate_attribute(item, attr) else null
+    #val = item[attr] else null
     # Check if the value is null
     if val is null {
       val = "null"
@@ -362,7 +363,8 @@ filter_attribute_in_list = func(items, attr, forbidden, prtmsg) {
 
   # Iterate over items
   for items as index, item {
-    val = item[attr] else null
+    val = evaluate_attribute(item, attr) else null
+    #val = item[attr] else null
     # Check if the value is null
     if val is null {
       val = "null"


### PR DESCRIPTION
This adds a Sentinel policy that restricts the policies applied to S3 buckets so that they must be defined in an aws_iam_policy_document data source and that that any policy document that applies to a list of S3 actions must include statements with conditions that prevent HTTP access and mandate acess from specific VPC endpoints.