### PR TITLE
update sentinel.hcl files to add policies

### DIFF
--- a/governance/third-generation/aws/sentinel.hcl
+++ b/governance/third-generation/aws/sentinel.hcl
@@ -19,8 +19,23 @@ policy "enforce-mandatory-tags" {
   enforcement_level = "advisory"
 }
 
+policy "require-dns-support-for-vpcs" {
+  source = "./require-dns-support-for-vpcs.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "require-most-recent-AMI-version" {
+  source = "./require-most-recent-AMI-version.sentinel"
+  enforcement_level = "advisory"
+}
+
 policy "require-private-acl-and-kms-for-s3-buckets" {
   source = "./require-private-acl-and-kms-for-s3-buckets.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "require-vpc-and-kms-for-lambda-functions" {
+  source = "./require-vpc-and-kms-for-lambda-functions.sentinel"
   enforcement_level = "advisory"
 }
 
@@ -59,8 +74,33 @@ policy "restrict-ec2-instance-type" {
   enforcement_level = "advisory"
 }
 
+policy "restrict-egress-sg-rule-cidr-blocks" {
+  source = "./restrict-egress-sg-rule-cidr-blocks.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-eks-node-group-size" {
+  source = "./restrict-eks-node-group-size.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-iam-policy-actions" {
+  source = "./restrict-iam-policy-actions.sentinel"
+  enforcement_level = "advisory"
+}
+
 policy "restrict-ingress-sg-rule-cidr-blocks" {
   source = "./restrict-ingress-sg-rule-cidr-blocks.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-ingress-sg-rule-rdp" {
+  source = "./restrict-ingress-sg-rule-rdp.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-ingress-sg-rule-ssh" {
+  source = "./restrict-ingress-sg-rule-ssh.sentinel"
   enforcement_level = "advisory"
 }
 
@@ -68,12 +108,23 @@ policy "restrict-launch-configuration-instance-type" {
   source = "./restrict-launch-configuration-instance-type.sentinel"
   enforcement_level = "advisory"
 }
-policy "restrict-ingress-sg-rule-ssh" {
-  source = "./restrict-ingress-sg-rule-ssh.sentinel"
+
+policy "restrict-s3-bucket-policies" {
+  source = "./restrict-s3-bucket-policies.sentinel"
   enforcement_level = "advisory"
 }
 
-policy "restrict-ingress-sg-rule-rdp" {
-  source = "./restrict-ingress-sg-rule-rdp.sentinel"
+policy "restrict-sagemaker-notebooks" {
+  source = "./restrict-sagemaker-notebooks.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "restrict-subnet-of-ec2-instances" {
+  source = "./restrict-subnet-of-ec2-instancess.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "validate-providers-from-desired-regions" {
+  source = "./validate-providers-from-desired-regions.sentinel"
   enforcement_level = "advisory"
 }

--- a/governance/third-generation/azure/sentinel.hcl
+++ b/governance/third-generation/azure/sentinel.hcl
@@ -15,13 +15,38 @@ policy "enforce-mandatory-tags" {
     enforcement_level = "advisory"
 }
 
+policy "restrict-aks-clusters" {
+    source = "./restrict-aks-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "restrict-app-service-to-https" {
     source = "./restrict-app-service-to-https.sentinel"
     enforcement_level = "advisory"
 }
 
+policy "restrict-inbound-source-address-prefixes" {
+    source = "./restrict-inbound-source-address-prefixes.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-outbound-destination-address-prefixes" {
+    source = "./restrict-outbound-destination-address-prefixes.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "restrict-publishers-of-current-vms" {
     source = "./restrict-publishers-of-current-vms.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-vm-image-id" {
+    source = "./restrict-vm-image-id.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-vm-publisher" {
+    source = "./restrict-vm-publisher.sentinel"
     enforcement_level = "advisory"
 }
 

--- a/governance/third-generation/cloud-agnostic/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/sentinel.hcl
@@ -14,23 +14,23 @@ module "tfrun-functions" {
     source = "../common-functions/tfrun-functions/tfrun-functions.sentinel"
 }
 
-policy "prohibited-datasources" {
-    source = "./prohibited-datasources.sentinel"
+policy "allowed-datasources" {
+    source = "./allowed-datasources.sentinel"
     enforcement_level = "advisory"
 }
 
-policy "prohibited-providers" {
-    source = "./prohibited-providers.sentinel"
+policy "allowed-providers" {
+    source = "./allowed-providers.sentinel"
     enforcement_level = "advisory"
 }
 
-policy "prohibited-provisioners" {
-    source = "./prohibited-provisioners.sentinel"
+policy "allowed-provisioners" {
+    source = "./allowed-provisioners.sentinel"
     enforcement_level = "advisory"
 }
 
-policy "prohibited-resources" {
-    source = "./prohibited-resources.sentinel"
+policy "allowed-resources" {
+    source = "./allowed-resources.sentinel"
     enforcement_level = "advisory"
 }
 
@@ -64,32 +64,47 @@ policy "prevent-remote-exec-provisioners-on-null-resources" {
     enforcement_level = "advisory"
 }
 
+policy "prohibited-datasources" {
+    source = "./prohibited-datasources.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "prohibited-providers" {
+    source = "./prohibited-providers.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "prohibited-provisioners" {
+    source = "./prohibited-provisioners.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "prohibited-resources" {
+    source = "./prohibited-resources.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "require-all-modules-have-version-constraint" {
+    source = "./require-all-modules-have-version-constraint.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "require-all-providers-have-version-constraint" {
+    source = "./require-all-providers-have-version-constraint.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "require-all-resources-from-pmr" {
     source = "./require-all-resources-from-pmr.sentinel"
     enforcement_level = "advisory"
 }
 
+policy "restrict-databricks-clusters" {
+    source = "./restrict-databricks-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "validate-variables-have-descriptions" {
     source = "./validate-variables-have-descriptions.sentinel"
-    enforcement_level = "advisory"
-}
-
-policy "allowed-datasources" {
-    source = "./allowed-datasources.sentinel"
-    enforcement_level = "advisory"
-}
-
-policy "allowed-providers" {
-    source = "./allowed-providers.sentinel"
-    enforcement_level = "advisory"
-}
-
-policy "allowed-provisioners" {
-    source = "./allowed-provisioners.sentinel"
-    enforcement_level = "advisory"
-}
-
-policy "allowed-resources" {
-    source = "./allowed-resources.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/gcp/sentinel.hcl
+++ b/governance/third-generation/gcp/sentinel.hcl
@@ -15,7 +15,22 @@ policy "enforce-mandatory-labels" {
     enforcement_level = "advisory"
 }
 
+policy "restrict-egress-firewall-destination-ranges" {
+    source = "./restrict-egress-firewall-destination-ranges.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "restrict-gce-machine-type" {
     source = "./restrict-gce-machine-type.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-gke-clusters" {
+    source = "./restrict-gke-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-ingress-firewall-source-ranges" {
+    source = "./restrict-ingress-firewall-source-ranges.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/vmware/sentinel.hcl
+++ b/governance/third-generation/vmware/sentinel.hcl
@@ -10,6 +10,21 @@ module "tfconfig-functions" {
     source = "../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
 }
 
+policy "require-storage-drs" {
+    source = "./require-storage-drs.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "require_nfs41_and_kerberos" {
+    source = "./require_nfs41_and_kerberos.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "restrict-virtual-disk-size-and-type" {
+    source = "./restrict-virtual-disk-size-and-type.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "restrict-vm-cpu-and-memory" {
     source = "./restrict-vm-cpu-and-memory.sentinel"
     enforcement_level = "advisory"


### PR DESCRIPTION
I realized that I have neglected to add many recently added policies to their corresponding sentinel.hcl policy set definition files.  This PR adds them all and puts them in alphabetical order to make it easier to check for missing policies in them in the future.