### PR TITLE
add Terraform code for two Sentinel policies

### DIFF
--- a/infrastructure-as-code/s3-buckets-and-policies/README.md
+++ b/infrastructure-as-code/s3-buckets-and-policies/README.md
@@ -1,0 +1,32 @@
+# AWS S3 Buckets, Bucket Policies, and IAM Policy Documents
+
+The Terraform code in this directory was used to generate some S3 buckets,
+S3 bucket policies, and an IAM policy document in order to run a plan and
+generate Sentinel mocks for use with the [restrict-s3-bucket-policies.sentinel](../governance/third-generation/restrict-s3-bucket-policies.sentinel)
+Sentinel policy.
+
+That policy requires all S3 buckets created with the `aws_s3_bucket` resource and
+all S3 bucket policies created with the `aws_s3_bucket_policy` resource to set
+their `policy` argument to an instance of the `aws_iam_policy_document` data
+source if they set it at all. The policy also restricts policy documents within
+`aws_iam_policy_document` data sources that certain S3 actions like "s3:ListBucket",
+"s3:GetObject", and "s3:PutObject" to include statements with conditions that
+mandate access over HTTPS and from specific VPC endpoints.
+
+Mandating the use of the `aws_iam_policy_document` data source in IAM policies set
+in S3 buckets and other AWS resources is useful when using Sentinel since each
+element of the policy documents created with that data source are given in their
+own distinct attributes. This allows Sentinel to see many elements of the policy
+document even if some of them are marked as computed because they refer to
+attributes of other resources that won't be known until the apply is run. In
+contrast, when you embed a policy directly inside the `policy` attribute of an S3
+bucket or S3 bucket policy resource, if any element of the policy refers to an
+attribute of some other resource that will not be known until the apply is run,
+then the entire policy ends up being marked as computed ("known after apply") and
+it is then completely opaque to Sentinel.
+
+The Terraform code in main.tf intentionally creates some buckets and bucket
+policies that will fail the restrict-s3-bucket-policies.sentinel policy. When I
+created the test cases for that policy, I copied the generated Sentinel mocks
+multiple times and then edited them to leave in only the instances of S3 buckets,
+S3 bucket policies, and IAM policy documents needed by each test case.

--- a/infrastructure-as-code/s3-buckets-and-policies/main.tf
+++ b/infrastructure-as-code/s3-buckets-and-policies/main.tf
@@ -1,0 +1,227 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "bucket_name" {
+   description = "Name of the bucket to create"
+   default = "roger-bucket-0"
+}
+
+variable "bucket_acl" {
+   description = "ACL for S3 bucket: private, public-read, public-read-write, etc"
+   default = "private"
+}
+
+variable "ip_addresses" {
+  description = "list of prohibited IP address"
+  default = ["1.1.1.1"]
+}
+
+variable "s3_vpce_id" {
+  description = "S3 VPC endpoint"
+  default = ""
+}
+
+variable "shared_s3_vpce_id" {
+  description = "Shared S3 VPC endpoint"
+  default = ""
+}
+
+resource "aws_kms_key" "my_key" {
+  description             = "This key is used to encrypt bucket objects"
+  deletion_window_in_days = 10
+}
+
+resource "aws_s3_bucket" "bucket_0" {
+  bucket = var.bucket_name
+  acl    = var.bucket_acl
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"PublicRead",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject","s3:GetObjectVersion"],
+      "Resource":["arn:aws:s3:::*"]
+    }
+  ]
+}
+POLICY
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.my_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+}
+
+resource "aws_s3_bucket" "bucket_1" {
+  bucket = "roger-bucket-1"
+  acl    = var.bucket_acl
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.my_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+}
+
+resource "aws_s3_bucket" "bucket_2" {
+  bucket = "roger-bucket-2"
+  acl    = var.bucket_acl
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.my_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy_1" {
+  bucket = aws_s3_bucket.bucket_1.id
+  policy = data.aws_iam_policy_document.example.json
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy_2" {
+  bucket = aws_s3_bucket.bucket_2.id
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"PublicRead",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject","s3:GetObjectVersion"],
+      "Resource":["arn:aws:s3:::*"]
+    }
+  ]
+}
+POLICY
+}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    sid = "Deny HTTP for bucket level operations"
+    effect = "Deny"
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.bucket_1.id}",
+    ]
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false",
+      ]
+    }
+  }
+
+  statement {
+    sid = "Deny HTTP for object operations"
+    effect = "Deny"
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.bucket_1.id}",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false",
+      ]
+    }
+  }
+
+  statement {
+    sid = "Deny bucket access not through vpce"
+    effect = "Deny"
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.bucket_1.id}",
+    ]
+    condition {
+      test     = "NotIpAddress"
+      variable = "aws:SourceIp"
+      values = var.ip_addresses
+    }
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:SourceVpce"
+      values = [
+        "vpce-111111",
+        var.s3_vpce_id,
+        var.shared_s3_vpce_id
+      ]
+    }
+  }
+
+  statement {
+    sid = "Deny object access not through vpce"
+    effect = "Deny"
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.bucket_1.id}",
+    ]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:SourceVpce"
+      values = [
+        "vpce-111111111111111111",
+        var.s3_vpce_id,
+        var.shared_s3_vpce_id
+      ]
+    }
+  }
+}
+

--- a/infrastructure-as-code/sagemaker-notebook/README.md
+++ b/infrastructure-as-code/sagemaker-notebook/README.md
@@ -1,0 +1,9 @@
+# Sagemaker Notebooks
+
+The Terraform code in this directory was used to generate a Sagemaker notebook
+instance and various supporting AWS resources in order to run a plan and generate
+Sentinel mocks for use with the [restrict-sagemaker-notebooks.sentinel](../governance/third-generation/restrict-sagemaker-notebooks.sentinel)
+Sentinel policy.
+
+That policy requires all Sagemaker Notebook instances created with the
+`aws_sagemaker_notebook_instance` resource to set their `root_access` and `direct_internet_access` arguments to `false`.

--- a/infrastructure-as-code/sagemaker-notebook/main.tf
+++ b/infrastructure-as-code/sagemaker-notebook/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_vpc" "sagemaker" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "sagemaker" {
+  vpc_id     = aws_vpc.sagemaker.id
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.sagemaker.id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.sagemaker.cidr_block]
+  }
+}
+
+data "aws_iam_policy_document" "instance-assume-role-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "sagemaker" {
+  name               = "instance_role"
+  path               = "/system/"
+  assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy.json
+}
+
+resource "aws_sagemaker_notebook_instance" "ni" {
+  name          = "roger-notebook-instance"
+  role_arn      = aws_iam_role.sagemaker.arn
+  instance_type = "ml.t2.medium"
+  
+  root_access = "Enabled"
+  direct_internet_access = "Enabled"
+
+  subnet_id = aws_subnet.sagemaker.id
+  security_groups = [aws_security_group.allow_tls.id]
+}


### PR DESCRIPTION
This adds Terraform code that I used to generate Sentinel mocks for two Sentinel policies. See the README.md files for details.