### PR TITLE
add restrict-resources-by-module-source.sentinel

### DIFF
--- a/governance/third-generation/aws/aws-functions/aws-functions.sentinel
+++ b/governance/third-generation/aws/aws-functions/aws-functions.sentinel
@@ -279,7 +279,7 @@ validate_provider_in_allowed_regions = func(p, regions) {
             module_segments = strings.split(p.module_address, ".")
             num_segments = length(module_segments)
             parent_module = strings.join(module_segments[0:num_segments-2], ".")
-            current_module_name = module_segments[num_segments -1]
+            current_module_name = module_segments[num_segments-1]
 
             # Find module call that called current module
             if parent_module is "" {

--- a/governance/third-generation/aws/restrict-s3-bucket-policies.sentinel
+++ b/governance/third-generation/aws/restrict-s3-bucket-policies.sentinel
@@ -69,7 +69,7 @@ for allIAMPolicyDocuments as address, pd {
                             statements, "actions", restricted_s3_actions, false)
   if length(statementsWithS3actions["resources"]) is 0 {
     # No statements included restricted S3 actions, so policy document is ok.
-    break
+    continue
   }
 
   # Test each restricted S3 action separately to make sure some statement

--- a/governance/third-generation/cloud-agnostic/restrict-resources-by-module-source.sentinel
+++ b/governance/third-generation/cloud-agnostic/restrict-resources-by-module-source.sentinel
@@ -1,0 +1,58 @@
+# This policy restricts resources of specific types to only be created in
+# modules with sources in a given list.
+# If you want to allow creation of the resources in the root module, include
+# "root" in the `allowed_module_sources` list. But you generally would not
+# want to allow "root" since that sacrifices most control over creation of
+# the resource types in `restricted_resources`.
+
+##### Imports #####
+
+# Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
+# with alias "config"
+import "tfconfig-functions" as config
+
+##### Parameters #####
+param restricted_resources default [
+  "aws_s3_bucket",
+  "aws_s3_bucket_object",
+  "azurerm_storage_account",
+  "azurerm_storage_container",
+  "azurerm_storage_blob",
+
+]
+
+param allowed_module_sources default [
+  "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+  "localterraform.com/Cloud-Operations/s3-bucket/aws",
+  "app.terraform.io/Cloud-Operations/caf/azurerm",
+  "localterraform.com/Cloud-Operations/caf/azurerm",
+  "app.terraform.io/Cloud-Operations/cloud-storage/google",
+  "localterraform.com/Cloud-Operations/cloud-storage/google",
+]
+
+# Initialize validated
+validated = true
+
+# Iterate over restricted resource types
+for restricted_resources as _, type {
+  # Find all resources of the given type
+  all_resources = config.find_resources_by_type(type)
+
+  # Iterate over the resources to find module source
+  for all_resources as address, r {
+    module_address = r.module_address
+    # Get module source
+    module_source = config.get_module_source(module_address)
+    # Check module_source
+    if module_source not in allowed_module_sources {
+      print("resource", address, "has module source", module_source,
+            "that is not in the allowed list:", allowed_module_sources)
+      validated = false
+    } // end if module_source in allowed_module_sources
+  } // end for all_resources
+} // end restricted_resources
+
+# Main rule
+main = rule {
+  validated
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail.sentinel
@@ -1,0 +1,1021 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_s3_bucket.example": {
+		"address": "aws_s3_bucket.example",
+		"config": {
+			"bucket": {
+				"constant_value": "rogerberlindexample",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.aws_s3_bucket.example": {
+		"address": "module.local-s3-bucket.aws_s3_bucket.example",
+		"config": {
+			"bucket": {
+				"constant_value": "roger-local-module",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket",
+		"name":                "example",
+		"provider_config_key": "module.local-s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this",
+		"config": {
+			"block_public_acls": {
+				"references": [
+					"var.block_public_acls",
+				],
+			},
+			"block_public_policy": {
+				"references": [
+					"var.block_public_policy",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"var.attach_policy",
+					"aws_s3_bucket_policy.this[0]",
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"ignore_public_acls": {
+				"references": [
+					"var.ignore_public_acls",
+				],
+			},
+			"restrict_public_buckets": {
+				"references": [
+					"var.restrict_public_buckets",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_public_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_public_access_block",
+	},
+	"module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this",
+		"config":  {},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_elb_service_account",
+	},
+	"module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
+		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:PutObject",
+						],
+					},
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"references": [
+									"data.aws_elb_service_account.this",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.this[0]",
+						],
+					},
+					"sid": {
+						"constant_value": "",
+					},
+				},
+			],
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "elb_log_delivery",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+	"module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket.aws_s3_bucket_public_access_block.this": {
+		"address": "module.s3-bucket.aws_s3_bucket_public_access_block.this",
+		"config": {
+			"block_public_acls": {
+				"references": [
+					"var.block_public_acls",
+				],
+			},
+			"block_public_policy": {
+				"references": [
+					"var.block_public_policy",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"var.attach_policy",
+					"aws_s3_bucket_policy.this[0]",
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"ignore_public_acls": {
+				"references": [
+					"var.ignore_public_acls",
+				],
+			},
+			"restrict_public_buckets": {
+				"references": [
+					"var.restrict_public_buckets",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_public_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_public_access_block",
+	},
+	"module.s3-bucket.data.aws_elb_service_account.this": {
+		"address": "module.s3-bucket.data.aws_elb_service_account.this",
+		"config":  {},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_elb_service_account",
+	},
+	"module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
+		"address": "module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:PutObject",
+						],
+					},
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"references": [
+									"data.aws_elb_service_account.this",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.this[0]",
+						],
+					},
+					"sid": {
+						"constant_value": "",
+					},
+				},
+			],
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket",
+		"name":                "elb_log_delivery",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.local-s3-bucket.module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.local-s3-bucket.module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.local-s3-bucket.module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.local-s3-bucket.module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.local-s3-bucket.module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.local-s3-bucket.module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.local-s3-bucket.module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"local-s3-bucket": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "local-s3-bucket",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+	"module.local-s3-bucket:s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module-nested",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.local-s3-bucket",
+		"name":               "s3-bucket",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+	"s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass.sentinel
@@ -1,0 +1,987 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this",
+		"config": {
+			"block_public_acls": {
+				"references": [
+					"var.block_public_acls",
+				],
+			},
+			"block_public_policy": {
+				"references": [
+					"var.block_public_policy",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"var.attach_policy",
+					"aws_s3_bucket_policy.this[0]",
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"ignore_public_acls": {
+				"references": [
+					"var.ignore_public_acls",
+				],
+			},
+			"restrict_public_buckets": {
+				"references": [
+					"var.restrict_public_buckets",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_public_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_public_access_block",
+	},
+	"module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this",
+		"config":  {},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_elb_service_account",
+	},
+	"module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
+		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:PutObject",
+						],
+					},
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"references": [
+									"data.aws_elb_service_account.this",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.this[0]",
+						],
+					},
+					"sid": {
+						"constant_value": "",
+					},
+				},
+			],
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "elb_log_delivery",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+	"module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket.aws_s3_bucket_public_access_block.this": {
+		"address": "module.s3-bucket.aws_s3_bucket_public_access_block.this",
+		"config": {
+			"block_public_acls": {
+				"references": [
+					"var.block_public_acls",
+				],
+			},
+			"block_public_policy": {
+				"references": [
+					"var.block_public_policy",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"var.attach_policy",
+					"aws_s3_bucket_policy.this[0]",
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"ignore_public_acls": {
+				"references": [
+					"var.ignore_public_acls",
+				],
+			},
+			"restrict_public_buckets": {
+				"references": [
+					"var.restrict_public_buckets",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_public_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_public_access_block",
+	},
+	"module.s3-bucket.data.aws_elb_service_account.this": {
+		"address": "module.s3-bucket.data.aws_elb_service_account.this",
+		"config":  {},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_elb_service_account",
+	},
+	"module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
+		"address": "module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"s3:PutObject",
+						],
+					},
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"references": [
+									"data.aws_elb_service_account.this",
+								],
+							},
+							"type": {
+								"constant_value": "AWS",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"aws_s3_bucket.this[0]",
+						],
+					},
+					"sid": {
+						"constant_value": "",
+					},
+				},
+			],
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket",
+		"name":                "elb_log_delivery",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.local-s3-bucket.module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.local-s3-bucket.module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.local-s3-bucket.module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.local-s3-bucket.module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.local-s3-bucket.module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.local-s3-bucket.module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.local-s3-bucket.module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"local-s3-bucket": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "local-s3-bucket",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+	"module.local-s3-bucket:s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module-nested",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.local-s3-bucket",
+		"name":               "s3-bucket",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+	"s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/find_descendant_modules.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/find_descendant_modules.md
@@ -10,7 +10,7 @@ This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-f
 `find_descendant_modules = func(module_address)`
 
 ## Arguments
-* **module_address**: the address of the module containing descendant modules to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+* **module_address**: the address of the module containing descendant modules to find, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
 
 You can determine all module addresses in your current configuration by calling `find_descendant_modules("")`.
 
@@ -35,4 +35,4 @@ module_addresses += find_descendant_modules(new_module_address)
 ```
 It does not use `config.` before calling itself since that is not necessary when calling a function from inside the module that contains it.
 
-It is also called by the [use-lastest-module-versions.sentinel](../../../cloud-agnostic/http-examples/use-lastest-module-versions.sentinel) policy.
+It is used by the [use-latest-module-versions.sentinel](../../../cloud-agnostic/http-examples/use-latest-module-versions.sentinel) policy.

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/get_module_source.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/get_module_source.md
@@ -1,0 +1,30 @@
+# get_module_source
+This function finds the source of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module. It then finds the `module_call` in the parent module that calls the original module and then gets `module_source` from that module call.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`get_module_source = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns a a string containing the source of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+module_source = config.get_module_source(module_address)
+```
+
+It is used by the [restrict-resources-by-module-source.sentinel](../../../cloud-agnostic/restrict-resources-by-module-source.sentinel) policy.

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -499,3 +499,39 @@ filter_attribute_matches_regex = func(items, attr, expr, prtmsg) {
   } // end for items
   return {"items":violators,"messages":messages}
 }
+
+### get_module_source ###
+# Get the module source from a module address
+# Note that the module_address in many collections in the tfplan/v2, tfconfig/v2,
+# and tfstate/v2 imports gives the labels used in the module blocks.
+# For instance, a module_address like "module.A.module.B" means that the current
+# item is in a module with label "B" that is a module with label "A". But that
+# does not give you the source the module labeled "B".
+# But if you want to limit creation of resources to specific modules based on
+# their source, you need the module source.  This function computes it.
+get_module_source = func(module_address) {
+  # Check for root module
+  if module_address is "" {
+    return "root"
+  } else {
+    # Find parent module
+    module_segments = strings.split(module_address, ".")
+    num_segments = length(module_segments)
+    parent_module = strings.join(module_segments[0:num_segments-2], ".")
+    current_module_name = module_segments[num_segments-1]
+
+    # Find module call that called current module
+    if parent_module is "" {
+      # parent module is root module
+      mc = tfconfig.module_calls[current_module_name]
+    } else {
+      # parent module is not root module
+      mc = tfconfig.module_calls[parent_module + ":" + current_module_name]
+    }
+
+    # Set source from the module call
+    module_source = mc.source
+
+    return module_source
+  }
+}


### PR DESCRIPTION
This adds a new restrict-resources-by-modules-source.sentinel poilcy that restricts resources of specific types to only be created in modules with sources in a given list. It used the tfconfig/v2 import and a new function, get_module_source(), that I added to the tfconfig-functions.sentinel module. There is a new MD file to describe that new function.

It also fixes an error in the recently added restrict-s3-bucket-policies.sentinel policy, replacing an occurrence of `break` with `continue`.

It also changes some comments in the MD file for tfconfig-functions.find_descendant_modules() to refer to module labels instead of names and fixes a broken link in that file.

And it makes a mior typographical change in aws-functions.sentinel to change `num_segments -1` to `num_segments-1`.