### PR TITLE
add restrict-resources-by-module-source to sentinel.hcl

### DIFF
--- a/governance/third-generation/cloud-agnostic/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/sentinel.hcl
@@ -104,6 +104,11 @@ policy "restrict-databricks-clusters" {
     enforcement_level = "advisory"
 }
 
+policy "restrict-resources-by-module-source" {
+    source = "./restrict-resources-by-module-source.sentinel"
+    enforcement_level = "advisory"
+}
+
 policy "validate-variables-have-descriptions" {
     source = "./validate-variables-have-descriptions.sentinel"
     enforcement_level = "advisory"


### PR DESCRIPTION
I had forgotten to add the new policy to the cloud-agnosticsentinel.hcl file 