### PR TITLE
update restrict-resources-by-module-source policy

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -92,7 +92,9 @@ The `tfconfig-functions` module has several types of functions:
     * `items`: a map consisting of items that violate a condition.
     * `messages`: a map of violation messages associated with the items.
   * The same `to_string` and `print_violations` functions that are in the tfplan-functions module.
-  * A `get_module_source` function that computes the source of a module from its address. This is used in the [restrict-resources-by-module-source.sentinel](./cloud-agnostic/restrict-resources-by-module-source.sentinel) policy to restrict creation of resources based on the actual module sources.
+  * A `get_module_source` function that computes the source of a module from its address.
+  * A `get_ancestor_module_source` function that computes the source of the first ancestor module that is not a local module of a module from its address. This is used in the [restrict-resources-by-module-source.sentinel](./cloud-agnostic/restrict-resources-by-module-source.sentinel) policy to restrict creation of resources based on the actual module sources.
+  * A `get_parent_module_address` function that computes the address of the parent module of a module from its address.
 
 Documentation for each individual function can be found in this directory:
   * [tfconfig-functions](./common-functions/tfconfig-functions/docs)

--- a/governance/third-generation/cloud-agnostic/restrict-resources-by-module-source.sentinel
+++ b/governance/third-generation/cloud-agnostic/restrict-resources-by-module-source.sentinel
@@ -1,9 +1,13 @@
 # This policy restricts resources of specific types to only be created in
-# modules with sources in a given list.
+# modules with sources in a given list of modules from public and private module
+# registries or in their nested modules.
 # If you want to allow creation of the resources in the root module, include
 # "root" in the `allowed_module_sources` list. But you generally would not
 # want to allow "root" since that sacrifices most control over creation of
 # the resource types in `restricted_resources`.
+# Note that this policy allows creation of resources in module blocks that
+# point directly against a sub-directory of a module with a reference like
+# "app.terraform.io/Cloud-Operations/s3-bucket/aws//modules/notification".
 
 ##### Imports #####
 
@@ -11,10 +15,16 @@
 # with alias "config"
 import "tfconfig-functions" as config
 
+# Strings import
+import "strings"
+
 ##### Parameters #####
+
+# Resources that should be restricted
 param restricted_resources default [
   "aws_s3_bucket",
   "aws_s3_bucket_object",
+  "aws_s3_bucket_notification",
   "azurerm_storage_account",
   "azurerm_storage_container",
   "azurerm_storage_blob",
@@ -22,16 +32,32 @@ param restricted_resources default [
   "google_storage_bucket_object",
 ]
 
+# Allowed Public and Private Module Registry Modules
+# These can have 3 or 4 segments delimited by "/".
+# Assuming 4 segments for a Private Module Registry module:
+#   The first segment should be `app.terraform.io` for Terraform Cloud or the DNS
+#   of your TFE server, or `localterraform.com` to match the local TFE server.
+#   The second segement should be a TFC/E organization or `*` to allow any org.
+#   But `*` should only be used for TFE servers, not on Terraform Cloud.
+#   The third segment should be the name of the module.
+#   The fourth segment should be the provider of the module.
+# Assuming 3 segments for a public registry module:
+#   The first segement should be the namespace of the module.
+#   The second segment should be the name of the module.
+#   The third segment should be the provider of the module.
+# Do not add module sub-directories prefaced with "//" after the above segments.
 param allowed_module_sources default [
+  "terraform-aws-modules/s3-bucket/aws",
   "app.terraform.io/Cloud-Operations/s3-bucket/aws",
-  "localterraform.com/Cloud-Operations/s3-bucket/aws",
+  "localterraform.com/*/s3-bucket/aws",
+  "tfe.acme.com/*/s3-bucket/aws",
   "app.terraform.io/Cloud-Operations/caf/azurerm",
-  "localterraform.com/Cloud-Operations/caf/azurerm",
+  "localterraform.com/*/caf/azurerm",
   "app.terraform.io/Cloud-Operations/cloud-storage/google",
-  "localterraform.com/Cloud-Operations/cloud-storage/google",
+  "localterraform.com/*/cloud-storage/google",
 ]
 
-# Initialize validated
+# Initialize validated. We'll flip to false if we find a violation.
 validated = true
 
 # Iterate over restricted resource types
@@ -41,13 +67,73 @@ for restricted_resources as _, type {
 
   # Iterate over the resources to find module source
   for all_resources as address, r {
-    module_address = r.module_address
+
     # Get module source
-    module_source = config.get_module_source(module_address)
-    # Check module_source
-    if module_source not in allowed_module_sources {
-      print("resource", address, "has module source", module_source,
-            "that is not in the allowed list:", allowed_module_sources)
+    module_address = r.module_address
+    module_source = config.get_ancestor_module_source(module_address)
+    #module_source = config.get_module_source(module_address)
+
+    # Initialize found_match to false. We'll flip to true if we find a match.
+    found_match = false
+
+    # Iterate over allowed sources
+    for allowed_module_sources as ams {
+
+      # Parse the allowed module source
+      ams_segments= strings.split(ams, "/")
+      num_ams_segments = length(ams_segments)
+      if num_ams_segments is 4 {
+        ams_host = ams_segments[0]
+        ams_org = ams_segments[1]
+        ams_name = ams_segments[2]
+        ams_provider = ams_segments[3]
+      } else if num_ams_segments is 3 {
+        ams_host = ""
+        ams_org = ams_segments[0]
+        ams_name = ams_segments[1]
+        ams_provider = ams_segments[2]
+      } else {
+        print("Module sources listed in the list allowed_module_sources should",
+              "only have 3 or 4 segments delimited by `/`, representing modules",
+              "from the public Terraform Registry in the first case or a Private",
+              "Module Registry in a Terraform Cloud or Terraform Enterprise",
+              "organization in the second case.")
+        print("Ignoring module source", ams)
+        continue
+      }
+
+      # Derive regex from the allowed module source
+      h_segments = strings.split(ams_host, ".")
+      if num_ams_segments is 4 {
+        h_reg = "^" + strings.join(h_segments, "\\.") + "/"
+      } else {
+        h_reg = "^" + strings.join(h_segments, "\\.")
+      }
+      if ams_org is "*" {
+        o_reg = "[A-Za-z0-9_-]+" + "/"
+      } else {
+        o_reg = ams_org + "/"
+      }
+      n_reg = ams_name + "/"
+      p_reg = ams_provider
+      # This regex allows module sources like "app.terraform.io/*/s3-bucket/aws"
+      # as well as "app.terraform.io/*/s3-bucket/aws//extra/path" so that nested
+      # modules of allowed modules can also be used.
+      ams_reg = "(" + h_reg + o_reg + n_reg + p_reg + "$|" +
+                  h_reg + o_reg + n_reg + p_reg + "//(.*)$)"
+      #print("ams_reg:", ams_reg)
+
+      # Test module_source against the regex
+      if module_source matches ams_reg {
+        #print("module_source:", module_source)
+        #print("matched regex:", ams_reg)
+        found_match = true
+        break
+      } // end if module source match
+    } // end for allowed_module_sources
+    if not found_match {
+      print("resource", address, "has module source", module_source, "that is",
+      "not in the allowed list of modules:", allowed_module_sources)
       validated = false
     } // end if module_source in allowed_module_sources
   } // end for all_resources

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-direct-nested-module.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-direct-nested-module.hcl
@@ -4,7 +4,7 @@ module "tfconfig-functions" {
 
 mock "tfconfig/v2" {
   module {
-    source = "mock-tfconfig-fail.sentinel"
+    source = "mock-tfconfig-fail-direct-nested-module.sentinel"
   }
 }
 

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-nested-modules-2.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-nested-modules-2.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-nested-modules-2.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-nested-modules.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-nested-modules.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-nested-modules.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-non-nested-modules.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/fail-non-nested-modules.hcl
@@ -4,12 +4,12 @@ module "tfconfig-functions" {
 
 mock "tfconfig/v2" {
   module {
-    source = "mock-tfconfig-pass.sentinel"
+    source = "mock-tfconfig-fail-non-nested-modules.sentinel"
   }
 }
 
 test {
   rules = {
-    main = true
+    main = false
   }
 }

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-direct-nested-module.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-direct-nested-module.sentinel
@@ -1,0 +1,901 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.s3-bucket-notification.aws_lambda_permission.allow": {
+		"address": "module.s3-bucket-notification.aws_lambda_permission.allow",
+		"config": {
+			"action": {
+				"constant_value": "lambda:InvokeFunction",
+			},
+			"function_name": {
+				"references": [
+					"each.value",
+				],
+			},
+			"principal": {
+				"constant_value": "s3.amazonaws.com",
+			},
+			"qualifier": {
+				"references": [
+					"each.value",
+				],
+			},
+			"source_arn": {
+				"references": [
+					"local.bucket_arn",
+				],
+			},
+			"statement_id_prefix": {
+				"constant_value": "AllowLambdaS3BucketNotification-",
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.lambda_notifications",
+			],
+		},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_lambda_permission",
+	},
+	"module.s3-bucket-notification.aws_s3_bucket_notification.this": {
+		"address": "module.s3-bucket-notification.aws_s3_bucket_notification.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create",
+				"var.lambda_notifications",
+				"var.sqs_notifications",
+				"var.sns_notifications",
+			],
+		},
+		"depends_on": [
+			"aws_lambda_permission.allow",
+			"aws_sqs_queue_policy.allow",
+			"aws_sns_topic_policy.allow",
+		],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_notification",
+	},
+	"module.s3-bucket-notification.aws_sns_topic_policy.allow": {
+		"address": "module.s3-bucket-notification.aws_sns_topic_policy.allow",
+		"config": {
+			"arn": {
+				"references": [
+					"each.value",
+				],
+			},
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.sns",
+					"each.key",
+				],
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.sns_notifications",
+			],
+		},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_sns_topic_policy",
+	},
+	"module.s3-bucket-notification.aws_sqs_queue_policy.allow": {
+		"address": "module.s3-bucket-notification.aws_sqs_queue_policy.allow",
+		"config": {
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.sqs",
+					"each.key",
+				],
+			},
+			"queue_url": {
+				"references": [
+					"each.value",
+					"local.queue_ids",
+					"each.key",
+				],
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.sqs_notifications",
+			],
+		},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_sqs_queue_policy",
+	},
+	"module.s3-bucket-notification.data.aws_arn.queue": {
+		"address": "module.s3-bucket-notification.data.aws_arn.queue",
+		"config": {
+			"arn": {
+				"references": [
+					"each.value",
+				],
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.sqs_notifications",
+			],
+		},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "queue",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_arn",
+	},
+	"module.s3-bucket-notification.data.aws_iam_policy_document.sns": {
+		"address": "module.s3-bucket-notification.data.aws_iam_policy_document.sns",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"sns:Publish",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "ArnEquals",
+							},
+							"values": {
+								"references": [
+									"local.bucket_arn",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceArn",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"s3.amazonaws.com",
+								],
+							},
+							"type": {
+								"constant_value": "Service",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"each.value",
+						],
+					},
+					"sid": {
+						"constant_value": "AllowSNSS3BucketNotification",
+					},
+				},
+			],
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.sns_notifications",
+			],
+		},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "sns",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+	"module.s3-bucket-notification.data.aws_iam_policy_document.sqs": {
+		"address": "module.s3-bucket-notification.data.aws_iam_policy_document.sqs",
+		"config": {
+			"statement": [
+				{
+					"actions": {
+						"constant_value": [
+							"sqs:SendMessage",
+						],
+					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "ArnEquals",
+							},
+							"values": {
+								"references": [
+									"local.bucket_arn",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceArn",
+							},
+						},
+					],
+					"effect": {
+						"constant_value": "Allow",
+					},
+					"principals": [
+						{
+							"identifiers": {
+								"constant_value": [
+									"s3.amazonaws.com",
+								],
+							},
+							"type": {
+								"constant_value": "Service",
+							},
+						},
+					],
+					"resources": {
+						"references": [
+							"each.value",
+						],
+					},
+					"sid": {
+						"constant_value": "AllowSQSS3BucketNotification",
+					},
+				},
+			],
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.sqs_notifications",
+			],
+		},
+		"mode":                "data",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "sqs",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.local-s3-bucket.module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.local-s3-bucket.module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.local-s3-bucket.module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.local-s3-bucket.module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.local-s3-bucket.module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.local-s3-bucket.module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.local-s3-bucket.module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket-notification:bucket": {
+		"default":        "",
+		"description":    "Name of S3 bucket to use",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-notification:bucket_arn": {
+		"default":        null,
+		"description":    "ARN of S3 bucket to use in policies",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "bucket_arn",
+	},
+	"module.s3-bucket-notification:create": {
+		"default":        true,
+		"description":    "Whether to create this resource or not?",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "create",
+	},
+	"module.s3-bucket-notification:lambda_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to Lambda function",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "lambda_notifications",
+	},
+	"module.s3-bucket-notification:sns_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SNS topic",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "sns_notifications",
+	},
+	"module.s3-bucket-notification:sqs_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SQS queue",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "sqs_notifications",
+	},
+	"module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_notification_id": {
+		"depends_on":     [],
+		"description":    "ID of S3 bucket",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_notification_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_notification.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"s3-bucket-notification": {
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.example",
+				],
+			},
+			"bucket_arn": {
+				"references": [
+					"aws_s3_bucket.example",
+				],
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-notification",
+		"source":             "app.terraform.io/Operations/s3-bucket/aws//modules/notification",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-nested-modules-2.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-nested-modules-2.sentinel
@@ -1,0 +1,1388 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.cloudfront_log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.cloudfront_log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.log_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.log_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.random_pet.this": {
+		"address": "module.s3-bucket-complete.random_pet.this",
+		"config": {
+			"length": {
+				"constant_value": 2,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete:random",
+		"provisioners":        [],
+		"type":                "random_pet",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket-complete.module.log_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.log_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.log_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.log_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.log_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.log_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.log_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.log_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.log_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.log_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.log_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.log_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.log_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_arn",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_regional_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_hosted_zone_id",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_id",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_region",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_domain",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_endpoint",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"module.s3-bucket-complete:cloudfront_log_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": null,
+			},
+			"bucket": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+			"grant": {
+				"references": [
+					"data.aws_canonical_user_id.current",
+				],
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "cloudfront_log_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-complete:log_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": "log-delivery-write",
+			},
+			"attach_elb_log_delivery_policy": {
+				"constant_value": true,
+			},
+			"bucket": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "log_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-complete:s3_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": "private",
+			},
+			"attach_policy": {
+				"constant_value": true,
+			},
+			"block_public_acls": {
+				"constant_value": true,
+			},
+			"block_public_policy": {
+				"constant_value": true,
+			},
+			"bucket": {
+				"references": [
+					"local.bucket_name",
+				],
+			},
+			"cors_rule": {
+				"constant_value": [
+					{
+						"allowed_headers": [
+							"*",
+						],
+						"allowed_methods": [
+							"PUT",
+							"POST",
+						],
+						"allowed_origins": [
+							"https://modules.tf",
+							"https://terraform-aws-modules.modules.tf",
+						],
+						"expose_headers": [
+							"ETag",
+						],
+						"max_age_seconds": 3000,
+					},
+					{
+						"allowed_headers": [
+							"*",
+						],
+						"allowed_methods": [
+							"PUT",
+						],
+						"allowed_origins": [
+							"https://example.com",
+						],
+						"expose_headers": [
+							"ETag",
+						],
+						"max_age_seconds": 3000,
+					},
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+			"ignore_public_acls": {
+				"constant_value": true,
+			},
+			"lifecycle_rule": {
+				"constant_value": [
+					{
+						"enabled": true,
+						"expiration": {
+							"days": 90,
+						},
+						"id": "log",
+						"noncurrent_version_expiration": {
+							"days": 30,
+						},
+						"prefix": "log/",
+						"tags": {
+							"autoclean": "true",
+							"rule":      "log",
+						},
+						"transition": [
+							{
+								"days":          30,
+								"storage_class": "ONEZONE_IA",
+							},
+							{
+								"days":          60,
+								"storage_class": "GLACIER",
+							},
+						],
+					},
+					{
+						"abort_incomplete_multipart_upload_days": 7,
+						"enabled": true,
+						"id":      "log1",
+						"noncurrent_version_expiration": {
+							"days": 300,
+						},
+						"noncurrent_version_transition": [
+							{
+								"days":          30,
+								"storage_class": "STANDARD_IA",
+							},
+							{
+								"days":          60,
+								"storage_class": "ONEZONE_IA",
+							},
+							{
+								"days":          90,
+								"storage_class": "GLACIER",
+							},
+						],
+						"prefix": "log1/",
+					},
+				],
+			},
+			"logging": {
+				"references": [
+					"module.log_bucket.this_s3_bucket_id",
+				],
+			},
+			"object_lock_configuration": {
+				"constant_value": {
+					"object_lock_enabled": "Enabled",
+					"rule": {
+						"default_retention": {
+							"mode":  "COMPLIANCE",
+							"years": 5,
+						},
+					},
+				},
+			},
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.bucket_policy",
+				],
+			},
+			"restrict_public_buckets": {
+				"constant_value": true,
+			},
+			"server_side_encryption_configuration": {
+				"references": [
+					"aws_kms_key.objects",
+				],
+			},
+			"tags": {
+				"constant_value": {
+					"Owner": "Anton",
+				},
+			},
+			"versioning": {
+				"constant_value": {
+					"enabled": true,
+				},
+			},
+			"website": {
+				"constant_value": null,
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "s3_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"s3-bucket-complete": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-complete",
+		"source":             "app.terraform.io/CloudOperations/s3-bucket/aws//examples/complete",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-nested-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-nested-modules.sentinel
@@ -1,0 +1,2619 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.s3-bucket-notification.module.all_notifications.aws_s3_bucket_notification.this": {
+		"address": "module.s3-bucket-notification.module.all_notifications.aws_s3_bucket_notification.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create",
+				"var.lambda_notifications",
+				"var.sqs_notifications",
+				"var.sns_notifications",
+			],
+		},
+		"depends_on": [
+			"aws_lambda_permission.allow",
+			"aws_sqs_queue_policy.allow",
+			"aws_sns_topic_policy.allow",
+		],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification.module.all_notifications",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-notification.module.all_notifications:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_notification",
+	},
+	"module.s3-bucket-notification.module.lambda_function1.aws_s3_bucket_object.lambda_package": {
+		"address": "module.s3-bucket-notification.module.lambda_function1.aws_s3_bucket_object.lambda_package",
+		"config": {
+			"acl": {
+				"references": [
+					"var.s3_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.s3_bucket",
+				],
+			},
+			"etag": {
+				"references": [
+					"data.external.archive_prepare[0]",
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"key": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"server_side_encryption": {
+				"references": [
+					"var.s3_server_side_encryption",
+				],
+			},
+			"source": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"storage_class": {
+				"references": [
+					"var.s3_object_storage_class",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+					"var.s3_object_tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create",
+				"var.store_on_s3",
+				"var.create_package",
+			],
+		},
+		"depends_on": [
+			"null_resource.archive",
+		],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification.module.lambda_function1",
+		"name":                "lambda_package",
+		"provider_config_key": "module.s3-bucket-notification.module.lambda_function1:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_object",
+	},
+	"module.s3-bucket-notification.module.lambda_function2.aws_s3_bucket_object.lambda_package": {
+		"address": "module.s3-bucket-notification.module.lambda_function2.aws_s3_bucket_object.lambda_package",
+		"config": {
+			"acl": {
+				"references": [
+					"var.s3_acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.s3_bucket",
+				],
+			},
+			"etag": {
+				"references": [
+					"data.external.archive_prepare[0]",
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"key": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"server_side_encryption": {
+				"references": [
+					"var.s3_server_side_encryption",
+				],
+			},
+			"source": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"storage_class": {
+				"references": [
+					"var.s3_object_storage_class",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+					"var.s3_object_tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create",
+				"var.store_on_s3",
+				"var.create_package",
+			],
+		},
+		"depends_on": [
+			"null_resource.archive",
+		],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification.module.lambda_function2",
+		"name":                "lambda_package",
+		"provider_config_key": "module.s3-bucket-notification.module.lambda_function2:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_object",
+	},
+	"module.s3-bucket-notification.module.s3_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-notification.module.s3_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-notification.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-notification.module.s3_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-notification.module.s3_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-notification.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-notification.random_pet.this": {
+		"address": "module.s3-bucket-notification.random_pet.this",
+		"config": {
+			"length": {
+				"constant_value": 2,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-notification:random",
+		"provisioners":        [],
+		"type":                "random_pet",
+	},
+}
+
+provisioners = {
+	"module.s3-bucket-notification.module.lambda_function1.null_resource.archive:0": {
+		"config": {
+			"command": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"interpreter": {
+				"references": [
+					"local.python",
+					"path.module",
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"working_dir": {
+				"references": [
+					"path.cwd",
+				],
+			},
+		},
+		"index":            0,
+		"resource_address": "module.s3-bucket-notification.module.lambda_function1.null_resource.archive",
+		"type":             "local-exec",
+	},
+	"module.s3-bucket-notification.module.lambda_function2.null_resource.archive:0": {
+		"config": {
+			"command": {
+				"references": [
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"interpreter": {
+				"references": [
+					"local.python",
+					"path.module",
+					"data.external.archive_prepare[0]",
+				],
+			},
+			"working_dir": {
+				"references": [
+					"path.cwd",
+				],
+			},
+		},
+		"index":            0,
+		"resource_address": "module.s3-bucket-notification.module.lambda_function2.null_resource.archive",
+		"type":             "local-exec",
+	},
+	"module.s3-bucket-notification.null_resource.download_package:0": {
+		"config": {
+			"command": {
+				"references": [
+					"local.downloaded",
+					"local.package_url",
+				],
+			},
+		},
+		"index":            0,
+		"resource_address": "module.s3-bucket-notification.null_resource.download_package",
+		"type":             "local-exec",
+	},
+}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.s3-bucket-notification.module.all_notifications:bucket": {
+		"default":        "",
+		"description":    "Name of S3 bucket to use",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-notification.module.all_notifications:bucket_arn": {
+		"default":        null,
+		"description":    "ARN of S3 bucket to use in policies",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "bucket_arn",
+	},
+	"module.s3-bucket-notification.module.all_notifications:create": {
+		"default":        true,
+		"description":    "Whether to create this resource or not?",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "create",
+	},
+	"module.s3-bucket-notification.module.all_notifications:lambda_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to Lambda function",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "lambda_notifications",
+	},
+	"module.s3-bucket-notification.module.all_notifications:sns_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SNS topic",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "sns_notifications",
+	},
+	"module.s3-bucket-notification.module.all_notifications:sqs_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SQS queue",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "sqs_notifications",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:allowed_triggers": {
+		"default":        {},
+		"description":    "Map of allowed triggers to create Lambda permissions",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:artifacts_dir": {
+		"default":        "builds",
+		"description":    "Directory name where artifacts should be stored",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "artifacts_dir",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_async_event_policy": {
+		"default":        false,
+		"description":    "Controls whether async event policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_async_event_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_cloudwatch_logs_policy": {
+		"default":        true,
+		"description":    "Controls whether CloudWatch Logs policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_cloudwatch_logs_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_dead_letter_policy": {
+		"default":        false,
+		"description":    "Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_dead_letter_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_network_policy": {
+		"default":        false,
+		"description":    "Controls whether VPC/network policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_network_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_policies": {
+		"default":        false,
+		"description":    "Controls whether list of policies should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_policy": {
+		"default":        false,
+		"description":    "Controls whether policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_policy_json": {
+		"default":        false,
+		"description":    "Controls whether policy_json should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_policy_json",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_policy_jsons": {
+		"default":        false,
+		"description":    "Controls whether policy_jsons should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_policy_statements": {
+		"default":        false,
+		"description":    "Controls whether policy_statements should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_policy_statements",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:attach_tracing_policy": {
+		"default":        false,
+		"description":    "Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "attach_tracing_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:build_in_docker": {
+		"default":        false,
+		"description":    "Whether to build dependencies in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "build_in_docker",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:cloudwatch_logs_kms_key_id": {
+		"default":        null,
+		"description":    "The ARN of the KMS Key to use when encrypting log data.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "cloudwatch_logs_kms_key_id",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:cloudwatch_logs_retention_in_days": {
+		"default":        null,
+		"description":    "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "cloudwatch_logs_retention_in_days",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:cloudwatch_logs_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to the resource.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "cloudwatch_logs_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:compatible_runtimes": {
+		"default":        [],
+		"description":    "A list of Runtimes this layer is compatible with. Up to 5 runtimes can be specified.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "compatible_runtimes",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create": {
+		"default":        true,
+		"description":    "Controls whether resources should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_async_event_config": {
+		"default":        false,
+		"description":    "Controls whether async event configuration for Lambda Function/Alias should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_current_version_allowed_triggers": {
+		"default":        true,
+		"description":    "Whether to allow triggers on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_current_version_allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_current_version_async_event_config": {
+		"default":        true,
+		"description":    "Whether to allow async event configuration on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_current_version_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_function": {
+		"default":        true,
+		"description":    "Controls whether Lambda Function resource should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_function",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_layer": {
+		"default":        false,
+		"description":    "Controls whether Lambda Layer resource should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_layer",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_package": {
+		"default":        true,
+		"description":    "Controls whether Lambda package should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_role": {
+		"default":        true,
+		"description":    "Controls whether IAM role for Lambda Function should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_role",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_unqualified_alias_allowed_triggers": {
+		"default":        true,
+		"description":    "Whether to allow triggers on unqualified alias pointing to $LATEST version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_unqualified_alias_allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:create_unqualified_alias_async_event_config": {
+		"default":        true,
+		"description":    "Whether to allow async event configuration on unqualified alias pointing to $LATEST version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "create_unqualified_alias_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:dead_letter_target_arn": {
+		"default":        null,
+		"description":    "The ARN of an SNS topic or SQS queue to notify when an invocation fails.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "dead_letter_target_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:description": {
+		"default":        "",
+		"description":    "Description of your Lambda Function (or Layer)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "description",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:destination_on_failure": {
+		"default":        null,
+		"description":    "Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "destination_on_failure",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:destination_on_success": {
+		"default":        null,
+		"description":    "Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "destination_on_success",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:docker_build_root": {
+		"default":        "",
+		"description":    "Root dir where to build in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "docker_build_root",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:docker_file": {
+		"default":        "",
+		"description":    "Path to a Dockerfile when building in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "docker_file",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:docker_image": {
+		"default":        "",
+		"description":    "Docker image to use for the build",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "docker_image",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:docker_pip_cache": {
+		"default":        null,
+		"description":    "Whether to mount a shared pip cache folder into docker environment or not",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "docker_pip_cache",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:docker_with_ssh_agent": {
+		"default":        false,
+		"description":    "Whether to pass SSH_AUTH_SOCK into docker environment or not",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "docker_with_ssh_agent",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:environment_variables": {
+		"default":        {},
+		"description":    "A map that defines environment variables for the Lambda Function.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "environment_variables",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:event_source_mapping": {
+		"default":        {},
+		"description":    "Map of event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "event_source_mapping",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:file_system_arn": {
+		"default":        null,
+		"description":    "The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "file_system_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:file_system_local_mount_path": {
+		"default":        null,
+		"description":    "The path where the function can access the file system, starting with /mnt/.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "file_system_local_mount_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:function_name": {
+		"default":        "",
+		"description":    "A unique name for your Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "function_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:handler": {
+		"default":        "",
+		"description":    "Lambda Function entrypoint in your code",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "handler",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:hash_extra": {
+		"default":        "",
+		"description":    "The string to add into hashing function. Useful when building same source path for different functions.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "hash_extra",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:image_config_command": {
+		"default":        [],
+		"description":    "The CMD for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "image_config_command",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:image_config_entry_point": {
+		"default":        [],
+		"description":    "The ENTRYPOINT for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "image_config_entry_point",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:image_config_working_directory": {
+		"default":        null,
+		"description":    "The working directory for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "image_config_working_directory",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:image_uri": {
+		"default":        null,
+		"description":    "The ECR image URI containing the function's deployment package.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "image_uri",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:kms_key_arn": {
+		"default":        null,
+		"description":    "The ARN of KMS key to use by your Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "kms_key_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_at_edge": {
+		"default":        false,
+		"description":    "Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_at_edge",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_role": {
+		"default":        "",
+		"description":    " IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_role",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:layer_name": {
+		"default":        "",
+		"description":    "Name of Lambda Layer to create",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "layer_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:layers": {
+		"default":        null,
+		"description":    "List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "layers",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:license_info": {
+		"default":        "",
+		"description":    "License info for your Lambda Layer. Eg, MIT or full url of a license.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "license_info",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:local_existing_package": {
+		"default":        null,
+		"description":    "The absolute path to an existing zip-file to use",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "local_existing_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:maximum_event_age_in_seconds": {
+		"default":        null,
+		"description":    "Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "maximum_event_age_in_seconds",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:maximum_retry_attempts": {
+		"default":        null,
+		"description":    "Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "maximum_retry_attempts",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:memory_size": {
+		"default":        128,
+		"description":    "Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "memory_size",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:number_of_policies": {
+		"default":        0,
+		"description":    "Number of policies to attach to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "number_of_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:number_of_policy_jsons": {
+		"default":        0,
+		"description":    "Number of policies JSON to attach to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "number_of_policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:package_type": {
+		"default":        "Zip",
+		"description":    "The Lambda deployment package type. Valid options: Zip or Image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "package_type",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:policies": {
+		"default":        [],
+		"description":    "List of policy statements ARN to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:policy": {
+		"default":        null,
+		"description":    "An additional policy document ARN to attach to the Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:policy_json": {
+		"default":        null,
+		"description":    "An additional policy document as JSON to attach to the Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "policy_json",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:policy_jsons": {
+		"default":        [],
+		"description":    "List of additional policy documents as JSON to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:policy_statements": {
+		"default":        {},
+		"description":    "Map of dynamic policy statements to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "policy_statements",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:provisioned_concurrent_executions": {
+		"default":        -1,
+		"description":    "Amount of capacity to allocate. Set to 1 or greater to enable, or set to 0 to disable provisioned concurrency.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "provisioned_concurrent_executions",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:publish": {
+		"default":        false,
+		"description":    "Whether to publish creation/change as new Lambda Function Version.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "publish",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:reserved_concurrent_executions": {
+		"default":        -1,
+		"description":    "The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "reserved_concurrent_executions",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_description": {
+		"default":        null,
+		"description":    "Description of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_description",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_force_detach_policies": {
+		"default":        true,
+		"description":    "Specifies to force detaching any policies the IAM role has before destroying it.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_force_detach_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_name": {
+		"default":        null,
+		"description":    "Name of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_path": {
+		"default":        null,
+		"description":    "Path of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_permissions_boundary": {
+		"default":        null,
+		"description":    "The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_permissions_boundary",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:role_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to IAM role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "role_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:runtime": {
+		"default":        "",
+		"description":    "Lambda Function runtime",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "runtime",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_acl": {
+		"default":        "private",
+		"description":    "The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_acl",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_bucket": {
+		"default":        null,
+		"description":    "S3 bucket to store artifacts",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_bucket",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_existing_package": {
+		"default":        null,
+		"description":    "The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_existing_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_object_storage_class": {
+		"default":        "ONEZONE_IA",
+		"description":    "Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED_REDUNDANCY, ONEZONE_IA, INTELLIGENT_TIERING, or STANDARD_IA.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_object_storage_class",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_object_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to S3 bucket object.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_object_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_server_side_encryption": {
+		"default":        null,
+		"description":    "Specifies server-side encryption of the object in S3. Valid values are \"AES256\" and \"aws:kms\".",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_server_side_encryption",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:source_path": {
+		"default":        null,
+		"description":    "The absolute path to a local file or directory containing your Lambda source code",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "source_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:store_on_s3": {
+		"default":        false,
+		"description":    "Whether to store produced artifacts on S3 or locally.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "store_on_s3",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to resources.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:timeout": {
+		"default":        3,
+		"description":    "The amount of time your Lambda Function has to run in seconds.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "timeout",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:tracing_mode": {
+		"default":        null,
+		"description":    "Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "tracing_mode",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:trusted_entities": {
+		"default":        [],
+		"description":    "Lambda Function additional trusted entities for assuming roles (trust relationship)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "trusted_entities",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:use_existing_cloudwatch_log_group": {
+		"default":        false,
+		"description":    "Whether to use an existing CloudWatch log group or create new",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "use_existing_cloudwatch_log_group",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:vpc_security_group_ids": {
+		"default":        null,
+		"description":    "List of security group ids when Lambda Function should run in the VPC.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "vpc_security_group_ids",
+	},
+	"module.s3-bucket-notification.module.lambda_function1:vpc_subnet_ids": {
+		"default":        null,
+		"description":    "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "vpc_subnet_ids",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:allowed_triggers": {
+		"default":        {},
+		"description":    "Map of allowed triggers to create Lambda permissions",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:artifacts_dir": {
+		"default":        "builds",
+		"description":    "Directory name where artifacts should be stored",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "artifacts_dir",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_async_event_policy": {
+		"default":        false,
+		"description":    "Controls whether async event policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_async_event_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_cloudwatch_logs_policy": {
+		"default":        true,
+		"description":    "Controls whether CloudWatch Logs policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_cloudwatch_logs_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_dead_letter_policy": {
+		"default":        false,
+		"description":    "Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_dead_letter_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_network_policy": {
+		"default":        false,
+		"description":    "Controls whether VPC/network policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_network_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_policies": {
+		"default":        false,
+		"description":    "Controls whether list of policies should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_policy": {
+		"default":        false,
+		"description":    "Controls whether policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_policy_json": {
+		"default":        false,
+		"description":    "Controls whether policy_json should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_policy_json",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_policy_jsons": {
+		"default":        false,
+		"description":    "Controls whether policy_jsons should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_policy_statements": {
+		"default":        false,
+		"description":    "Controls whether policy_statements should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_policy_statements",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:attach_tracing_policy": {
+		"default":        false,
+		"description":    "Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "attach_tracing_policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:build_in_docker": {
+		"default":        false,
+		"description":    "Whether to build dependencies in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "build_in_docker",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:cloudwatch_logs_kms_key_id": {
+		"default":        null,
+		"description":    "The ARN of the KMS Key to use when encrypting log data.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "cloudwatch_logs_kms_key_id",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:cloudwatch_logs_retention_in_days": {
+		"default":        null,
+		"description":    "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "cloudwatch_logs_retention_in_days",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:cloudwatch_logs_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to the resource.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "cloudwatch_logs_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:compatible_runtimes": {
+		"default":        [],
+		"description":    "A list of Runtimes this layer is compatible with. Up to 5 runtimes can be specified.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "compatible_runtimes",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create": {
+		"default":        true,
+		"description":    "Controls whether resources should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_async_event_config": {
+		"default":        false,
+		"description":    "Controls whether async event configuration for Lambda Function/Alias should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_current_version_allowed_triggers": {
+		"default":        true,
+		"description":    "Whether to allow triggers on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_current_version_allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_current_version_async_event_config": {
+		"default":        true,
+		"description":    "Whether to allow async event configuration on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_current_version_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_function": {
+		"default":        true,
+		"description":    "Controls whether Lambda Function resource should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_function",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_layer": {
+		"default":        false,
+		"description":    "Controls whether Lambda Layer resource should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_layer",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_package": {
+		"default":        true,
+		"description":    "Controls whether Lambda package should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_role": {
+		"default":        true,
+		"description":    "Controls whether IAM role for Lambda Function should be created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_role",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_unqualified_alias_allowed_triggers": {
+		"default":        true,
+		"description":    "Whether to allow triggers on unqualified alias pointing to $LATEST version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_unqualified_alias_allowed_triggers",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:create_unqualified_alias_async_event_config": {
+		"default":        true,
+		"description":    "Whether to allow async event configuration on unqualified alias pointing to $LATEST version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "create_unqualified_alias_async_event_config",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:dead_letter_target_arn": {
+		"default":        null,
+		"description":    "The ARN of an SNS topic or SQS queue to notify when an invocation fails.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "dead_letter_target_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:description": {
+		"default":        "",
+		"description":    "Description of your Lambda Function (or Layer)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "description",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:destination_on_failure": {
+		"default":        null,
+		"description":    "Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "destination_on_failure",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:destination_on_success": {
+		"default":        null,
+		"description":    "Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "destination_on_success",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:docker_build_root": {
+		"default":        "",
+		"description":    "Root dir where to build in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "docker_build_root",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:docker_file": {
+		"default":        "",
+		"description":    "Path to a Dockerfile when building in Docker",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "docker_file",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:docker_image": {
+		"default":        "",
+		"description":    "Docker image to use for the build",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "docker_image",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:docker_pip_cache": {
+		"default":        null,
+		"description":    "Whether to mount a shared pip cache folder into docker environment or not",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "docker_pip_cache",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:docker_with_ssh_agent": {
+		"default":        false,
+		"description":    "Whether to pass SSH_AUTH_SOCK into docker environment or not",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "docker_with_ssh_agent",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:environment_variables": {
+		"default":        {},
+		"description":    "A map that defines environment variables for the Lambda Function.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "environment_variables",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:event_source_mapping": {
+		"default":        {},
+		"description":    "Map of event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "event_source_mapping",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:file_system_arn": {
+		"default":        null,
+		"description":    "The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "file_system_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:file_system_local_mount_path": {
+		"default":        null,
+		"description":    "The path where the function can access the file system, starting with /mnt/.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "file_system_local_mount_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:function_name": {
+		"default":        "",
+		"description":    "A unique name for your Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "function_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:handler": {
+		"default":        "",
+		"description":    "Lambda Function entrypoint in your code",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "handler",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:hash_extra": {
+		"default":        "",
+		"description":    "The string to add into hashing function. Useful when building same source path for different functions.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "hash_extra",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:image_config_command": {
+		"default":        [],
+		"description":    "The CMD for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "image_config_command",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:image_config_entry_point": {
+		"default":        [],
+		"description":    "The ENTRYPOINT for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "image_config_entry_point",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:image_config_working_directory": {
+		"default":        null,
+		"description":    "The working directory for the docker image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "image_config_working_directory",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:image_uri": {
+		"default":        null,
+		"description":    "The ECR image URI containing the function's deployment package.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "image_uri",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:kms_key_arn": {
+		"default":        null,
+		"description":    "The ARN of KMS key to use by your Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "kms_key_arn",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_at_edge": {
+		"default":        false,
+		"description":    "Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_at_edge",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_role": {
+		"default":        "",
+		"description":    " IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_role",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:layer_name": {
+		"default":        "",
+		"description":    "Name of Lambda Layer to create",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "layer_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:layers": {
+		"default":        null,
+		"description":    "List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "layers",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:license_info": {
+		"default":        "",
+		"description":    "License info for your Lambda Layer. Eg, MIT or full url of a license.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "license_info",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:local_existing_package": {
+		"default":        null,
+		"description":    "The absolute path to an existing zip-file to use",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "local_existing_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:maximum_event_age_in_seconds": {
+		"default":        null,
+		"description":    "Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "maximum_event_age_in_seconds",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:maximum_retry_attempts": {
+		"default":        null,
+		"description":    "Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "maximum_retry_attempts",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:memory_size": {
+		"default":        128,
+		"description":    "Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "memory_size",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:number_of_policies": {
+		"default":        0,
+		"description":    "Number of policies to attach to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "number_of_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:number_of_policy_jsons": {
+		"default":        0,
+		"description":    "Number of policies JSON to attach to IAM role for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "number_of_policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:package_type": {
+		"default":        "Zip",
+		"description":    "The Lambda deployment package type. Valid options: Zip or Image",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "package_type",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:policies": {
+		"default":        [],
+		"description":    "List of policy statements ARN to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:policy": {
+		"default":        null,
+		"description":    "An additional policy document ARN to attach to the Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "policy",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:policy_json": {
+		"default":        null,
+		"description":    "An additional policy document as JSON to attach to the Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "policy_json",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:policy_jsons": {
+		"default":        [],
+		"description":    "List of additional policy documents as JSON to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "policy_jsons",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:policy_statements": {
+		"default":        {},
+		"description":    "Map of dynamic policy statements to attach to Lambda Function role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "policy_statements",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:provisioned_concurrent_executions": {
+		"default":        -1,
+		"description":    "Amount of capacity to allocate. Set to 1 or greater to enable, or set to 0 to disable provisioned concurrency.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "provisioned_concurrent_executions",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:publish": {
+		"default":        false,
+		"description":    "Whether to publish creation/change as new Lambda Function Version.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "publish",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:reserved_concurrent_executions": {
+		"default":        -1,
+		"description":    "The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "reserved_concurrent_executions",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_description": {
+		"default":        null,
+		"description":    "Description of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_description",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_force_detach_policies": {
+		"default":        true,
+		"description":    "Specifies to force detaching any policies the IAM role has before destroying it.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_force_detach_policies",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_name": {
+		"default":        null,
+		"description":    "Name of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_name",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_path": {
+		"default":        null,
+		"description":    "Path of IAM role to use for Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_permissions_boundary": {
+		"default":        null,
+		"description":    "The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_permissions_boundary",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:role_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to IAM role",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "role_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:runtime": {
+		"default":        "",
+		"description":    "Lambda Function runtime",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "runtime",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_acl": {
+		"default":        "private",
+		"description":    "The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_acl",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_bucket": {
+		"default":        null,
+		"description":    "S3 bucket to store artifacts",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_bucket",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_existing_package": {
+		"default":        null,
+		"description":    "The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_existing_package",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_object_storage_class": {
+		"default":        "ONEZONE_IA",
+		"description":    "Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED_REDUNDANCY, ONEZONE_IA, INTELLIGENT_TIERING, or STANDARD_IA.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_object_storage_class",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_object_tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to S3 bucket object.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_object_tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_server_side_encryption": {
+		"default":        null,
+		"description":    "Specifies server-side encryption of the object in S3. Valid values are \"AES256\" and \"aws:kms\".",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_server_side_encryption",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:source_path": {
+		"default":        null,
+		"description":    "The absolute path to a local file or directory containing your Lambda source code",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "source_path",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:store_on_s3": {
+		"default":        false,
+		"description":    "Whether to store produced artifacts on S3 or locally.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "store_on_s3",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:tags": {
+		"default":        {},
+		"description":    "A map of tags to assign to resources.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "tags",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:timeout": {
+		"default":        3,
+		"description":    "The amount of time your Lambda Function has to run in seconds.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "timeout",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:tracing_mode": {
+		"default":        null,
+		"description":    "Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "tracing_mode",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:trusted_entities": {
+		"default":        [],
+		"description":    "Lambda Function additional trusted entities for assuming roles (trust relationship)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "trusted_entities",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:use_existing_cloudwatch_log_group": {
+		"default":        false,
+		"description":    "Whether to use an existing CloudWatch log group or create new",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "use_existing_cloudwatch_log_group",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:vpc_security_group_ids": {
+		"default":        null,
+		"description":    "List of security group ids when Lambda Function should run in the VPC.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "vpc_security_group_ids",
+	},
+	"module.s3-bucket-notification.module.lambda_function2:vpc_subnet_ids": {
+		"default":        null,
+		"description":    "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets.",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "vpc_subnet_ids",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-notification.module.s3_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.s3-bucket-notification.module.all_notifications:this_s3_bucket_notification_id": {
+		"depends_on":     [],
+		"description":    "ID of S3 bucket",
+		"module_address": "module.s3-bucket-notification.module.all_notifications",
+		"name":           "this_s3_bucket_notification_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_notification.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_cloudwatch_log_group_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Cloudwatch Log Group",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_cloudwatch_log_group_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.log_group_arn",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_cloudwatch_log_group_name": {
+		"depends_on":     [],
+		"description":    "The name of the Cloudwatch Log Group",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_cloudwatch_log_group_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.log_group_name",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_role_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the IAM role created for the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_role_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_iam_role.lambda",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:lambda_role_name": {
+		"depends_on":     [],
+		"description":    "The name of the IAM role created for the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "lambda_role_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_iam_role.lambda",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:local_filename": {
+		"depends_on":     [],
+		"description":    "The filename of zip archive deployed (if deployment was from local)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "local_filename",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.filename",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:s3_object": {
+		"depends_on":     [],
+		"description":    "The map with S3 object data of zip archive deployed (if deployment was from S3)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "s3_object",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.s3_bucket",
+				"local.s3_key",
+				"local.s3_object_version",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_event_source_mapping_function_arn": {
+		"depends_on":     [],
+		"description":    "The the ARN of the Lambda function the event source mapping is sending events to",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_event_source_mapping_function_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_event_source_mapping_state": {
+		"depends_on":     [],
+		"description":    "The state of the event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_event_source_mapping_state",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_event_source_mapping_state_transition_reason": {
+		"depends_on":     [],
+		"description":    "The reason the event source mapping is in its current state",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_event_source_mapping_state_transition_reason",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_event_source_mapping_uuid": {
+		"depends_on":     [],
+		"description":    "The UUID of the created event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_event_source_mapping_uuid",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_invoke_arn": {
+		"depends_on":     [],
+		"description":    "The Invoke ARN of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_invoke_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_kms_key_arn": {
+		"depends_on":     [],
+		"description":    "The ARN for the KMS encryption key of Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_kms_key_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_last_modified": {
+		"depends_on":     [],
+		"description":    "The date Lambda Function resource was last modified",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_last_modified",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_name": {
+		"depends_on":     [],
+		"description":    "The name of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_qualified_arn": {
+		"depends_on":     [],
+		"description":    "The ARN identifying your Lambda Function Version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_qualified_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_source_code_hash": {
+		"depends_on":     [],
+		"description":    "Base64-encoded representation of raw SHA-256 sum of the zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_source_code_hash",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_source_code_size": {
+		"depends_on":     [],
+		"description":    "The size in bytes of the function .zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_source_code_size",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_function_version": {
+		"depends_on":     [],
+		"description":    "Latest published version of Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_function_version",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_layer_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Layer with version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_layer_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_layer_created_date": {
+		"depends_on":     [],
+		"description":    "The date Lambda Layer resource was created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_layer_created_date",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_layer_layer_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Layer without version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_layer_layer_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_layer_source_code_size": {
+		"depends_on":     [],
+		"description":    "The size in bytes of the Lambda Layer .zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_layer_source_code_size",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function1:this_lambda_layer_version": {
+		"depends_on":     [],
+		"description":    "The Lambda Layer version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function1",
+		"name":           "this_lambda_layer_version",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_cloudwatch_log_group_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Cloudwatch Log Group",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_cloudwatch_log_group_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.log_group_arn",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_cloudwatch_log_group_name": {
+		"depends_on":     [],
+		"description":    "The name of the Cloudwatch Log Group",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_cloudwatch_log_group_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.log_group_name",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_role_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the IAM role created for the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_role_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_iam_role.lambda",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:lambda_role_name": {
+		"depends_on":     [],
+		"description":    "The name of the IAM role created for the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "lambda_role_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_iam_role.lambda",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:local_filename": {
+		"depends_on":     [],
+		"description":    "The filename of zip archive deployed (if deployment was from local)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "local_filename",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.filename",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:s3_object": {
+		"depends_on":     [],
+		"description":    "The map with S3 object data of zip archive deployed (if deployment was from S3)",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "s3_object",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"local.s3_bucket",
+				"local.s3_key",
+				"local.s3_object_version",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_event_source_mapping_function_arn": {
+		"depends_on":     [],
+		"description":    "The the ARN of the Lambda function the event source mapping is sending events to",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_event_source_mapping_function_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_event_source_mapping_state": {
+		"depends_on":     [],
+		"description":    "The state of the event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_event_source_mapping_state",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_event_source_mapping_state_transition_reason": {
+		"depends_on":     [],
+		"description":    "The reason the event source mapping is in its current state",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_event_source_mapping_state_transition_reason",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_event_source_mapping_uuid": {
+		"depends_on":     [],
+		"description":    "The UUID of the created event source mapping",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_event_source_mapping_uuid",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_event_source_mapping.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_invoke_arn": {
+		"depends_on":     [],
+		"description":    "The Invoke ARN of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_invoke_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_kms_key_arn": {
+		"depends_on":     [],
+		"description":    "The ARN for the KMS encryption key of Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_kms_key_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_last_modified": {
+		"depends_on":     [],
+		"description":    "The date Lambda Function resource was last modified",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_last_modified",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_name": {
+		"depends_on":     [],
+		"description":    "The name of the Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_qualified_arn": {
+		"depends_on":     [],
+		"description":    "The ARN identifying your Lambda Function Version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_qualified_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_source_code_hash": {
+		"depends_on":     [],
+		"description":    "Base64-encoded representation of raw SHA-256 sum of the zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_source_code_hash",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_source_code_size": {
+		"depends_on":     [],
+		"description":    "The size in bytes of the function .zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_source_code_size",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_function_version": {
+		"depends_on":     [],
+		"description":    "Latest published version of Lambda Function",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_function_version",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_function.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_layer_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Layer with version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_layer_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_layer_created_date": {
+		"depends_on":     [],
+		"description":    "The date Lambda Layer resource was created",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_layer_created_date",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_layer_layer_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the Lambda Layer without version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_layer_layer_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_layer_source_code_size": {
+		"depends_on":     [],
+		"description":    "The size in bytes of the Lambda Layer .zip file",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_layer_source_code_size",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.lambda_function2:this_lambda_layer_version": {
+		"depends_on":     [],
+		"description":    "The Lambda Layer version",
+		"module_address": "module.s3-bucket-notification.module.lambda_function2",
+		"name":           "this_lambda_layer_version",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_lambda_layer_version.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.s3_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-notification.module.s3_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.sns_topic1:this_sns_topic_arn": {
+		"depends_on":     [],
+		"description":    "ARN",
+		"module_address": "module.s3-bucket-notification.module.sns_topic1",
+		"name":           "this_sns_topic_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_sns_topic.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.sns_topic1:this_sns_topic_name": {
+		"depends_on":     [],
+		"description":    "Name",
+		"module_address": "module.s3-bucket-notification.module.sns_topic1",
+		"name":           "this_sns_topic_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_sns_topic.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.sns_topic2:this_sns_topic_arn": {
+		"depends_on":     [],
+		"description":    "ARN",
+		"module_address": "module.s3-bucket-notification.module.sns_topic2",
+		"name":           "this_sns_topic_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_sns_topic.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification.module.sns_topic2:this_sns_topic_name": {
+		"depends_on":     [],
+		"description":    "Name",
+		"module_address": "module.s3-bucket-notification.module.sns_topic2",
+		"name":           "this_sns_topic_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_sns_topic.this",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_arn",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_regional_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_hosted_zone_id",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_id",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_region",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_domain",
+			],
+		},
+	},
+	"module.s3-bucket-notification:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_endpoint",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"module.s3-bucket-notification:all_notifications": {
+		"config": {
+			"bucket": {
+				"references": [
+					"module.s3_bucket.this_s3_bucket_id",
+				],
+			},
+			"lambda_notifications": {
+				"references": [
+					"module.lambda_function1.this_lambda_function_arn",
+					"module.lambda_function1.this_lambda_function_name",
+					"module.lambda_function2.this_lambda_function_arn",
+					"module.lambda_function2.this_lambda_function_name",
+				],
+			},
+			"sns_notifications": {
+				"references": [
+					"module.sns_topic1.this_sns_topic_arn",
+					"module.sns_topic2.this_sns_topic_arn",
+				],
+			},
+			"sqs_notifications": {
+				"references": [
+					"aws_sqs_queue.this[0]",
+					"aws_sqs_queue.this[1]",
+				],
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "all_notifications",
+		"source":             "../../modules/notification",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-notification:lambda_function1": {
+		"config": {
+			"create_package": {
+				"constant_value": false,
+			},
+			"function_name": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"handler": {
+				"constant_value": "index.lambda_handler",
+			},
+			"local_existing_package": {
+				"references": [
+					"data.null_data_source.downloaded_package",
+				],
+			},
+			"runtime": {
+				"constant_value": "python3.8",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "lambda_function1",
+		"source":             "terraform-aws-modules/lambda/aws",
+		"version_constraint": "~> 1.0",
+	},
+	"module.s3-bucket-notification:lambda_function2": {
+		"config": {
+			"create_package": {
+				"constant_value": false,
+			},
+			"function_name": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"handler": {
+				"constant_value": "index.lambda_handler",
+			},
+			"local_existing_package": {
+				"references": [
+					"data.null_data_source.downloaded_package",
+				],
+			},
+			"runtime": {
+				"constant_value": "python3.8",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "lambda_function2",
+		"source":             "terraform-aws-modules/lambda/aws",
+		"version_constraint": "~> 1.0",
+	},
+	"module.s3-bucket-notification:s3_bucket": {
+		"config": {
+			"bucket": {
+				"references": [
+					"local.bucket_name",
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "s3_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-notification:sns_topic1": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "sns_topic1",
+		"source":             "terraform-aws-modules/cloudwatch/aws//examples/fixtures/aws_sns_topic",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-notification:sns_topic2": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-notification",
+		"name":               "sns_topic2",
+		"source":             "terraform-aws-modules/cloudwatch/aws//examples/fixtures/aws_sns_topic",
+		"version_constraint": "",
+	},
+	"s3-bucket-notification": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-notification",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws//examples/notification",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-non-nested-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-fail-non-nested-modules.sentinel
@@ -1,0 +1,888 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_s3_bucket.example": {
+		"address": "aws_s3_bucket.example",
+		"config": {
+			"bucket": {
+				"constant_value": "rogerberlindexample",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.aws_s3_bucket.example": {
+		"address": "module.local-s3-bucket.aws_s3_bucket.example",
+		"config": {
+			"bucket": {
+				"constant_value": "roger-local-module",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket",
+		"name":                "example",
+		"provider_config_key": "module.local-s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-pub-registry.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-pub-registry.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-pub-registry",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-pub-registry:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-pub-registry.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-pub-registry.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-pub-registry",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-pub-registry:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.local-s3-bucket.module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.local-s3-bucket.module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.local-s3-bucket.module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.local-s3-bucket.module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.local-s3-bucket.module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.local-s3-bucket.module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.local-s3-bucket.module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.local-s3-bucket.module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.local-s3-bucket.module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.local-s3-bucket.module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.local-s3-bucket.module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.local-s3-bucket.module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.local-s3-bucket.module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.local-s3-bucket.module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.local-s3-bucket.module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"local-s3-bucket": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "local-s3-bucket",
+		"source":             "./module",
+		"version_constraint": "",
+	},
+	"module.local-s3-bucket:s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module-nested",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.local-s3-bucket",
+		"name":               "s3-bucket",
+		"source":             "app.terraform.io/CloudOperations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+	"s3-bucket": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket",
+		"source":             "tfe.xyz.com/Cloud-Operations/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+	"s3-bucket-pub-registry": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-pub-registry",
+		"source":             "fake-terraform-aws-modules/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-direct-nested-module.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-direct-nested-module.sentinel
@@ -18,405 +18,288 @@ providers = {
 }
 
 resources = {
-	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this",
+	"module.s3-bucket-notification.aws_lambda_permission.allow": {
+		"address": "module.s3-bucket-notification.aws_lambda_permission.allow",
 		"config": {
-			"acceleration_status": {
+			"action": {
+				"constant_value": "lambda:InvokeFunction",
+			},
+			"function_name": {
 				"references": [
-					"var.acceleration_status",
+					"each.value",
 				],
 			},
-			"acl": {
+			"principal": {
+				"constant_value": "s3.amazonaws.com",
+			},
+			"qualifier": {
 				"references": [
-					"var.acl",
+					"each.value",
 				],
 			},
+			"source_arn": {
+				"references": [
+					"local.bucket_arn",
+				],
+			},
+			"statement_id_prefix": {
+				"constant_value": "AllowLambdaS3BucketNotification-",
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
+			"references": [
+				"var.lambda_notifications",
+			],
+		},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
+		"provisioners":        [],
+		"type":                "aws_lambda_permission",
+	},
+	"module.s3-bucket-notification.aws_s3_bucket_notification.this": {
+		"address": "module.s3-bucket-notification.aws_s3_bucket_notification.this",
+		"config": {
 			"bucket": {
 				"references": [
 					"var.bucket",
 				],
 			},
-			"bucket_prefix": {
-				"references": [
-					"var.bucket_prefix",
-				],
-			},
-			"force_destroy": {
-				"references": [
-					"var.force_destroy",
-				],
-			},
-			"request_payer": {
-				"references": [
-					"var.request_payer",
-				],
-			},
-			"tags": {
-				"references": [
-					"var.tags",
-				],
-			},
 		},
 		"count": {
 			"references": [
-				"var.create_bucket",
+				"var.create",
+				"var.lambda_notifications",
+				"var.sqs_notifications",
+				"var.sns_notifications",
 			],
 		},
-		"depends_on":          [],
+		"depends_on": [
+			"aws_lambda_permission.allow",
+			"aws_sqs_queue_policy.allow",
+			"aws_sns_topic_policy.allow",
+		],
 		"for_each":            {},
 		"mode":                "managed",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
+		"module_address":      "module.s3-bucket-notification",
 		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
-		"type":                "aws_s3_bucket",
+		"type":                "aws_s3_bucket_notification",
 	},
-	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_policy.this",
+	"module.s3-bucket-notification.aws_sns_topic_policy.allow": {
+		"address": "module.s3-bucket-notification.aws_sns_topic_policy.allow",
 		"config": {
-			"bucket": {
+			"arn": {
 				"references": [
-					"aws_s3_bucket.this[0]",
+					"each.value",
 				],
 			},
 			"policy": {
 				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"data.aws_iam_policy_document.elb_log_delivery[0]",
-					"var.policy",
+					"data.aws_iam_policy_document.sns",
+					"each.key",
 				],
 			},
 		},
-		"count": {
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
 			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-				"var.attach_policy",
+				"var.sns_notifications",
 			],
 		},
-		"depends_on":          [],
-		"for_each":            {},
 		"mode":                "managed",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
-		"type":                "aws_s3_bucket_policy",
+		"type":                "aws_sns_topic_policy",
 	},
-	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this",
+	"module.s3-bucket-notification.aws_sqs_queue_policy.allow": {
+		"address": "module.s3-bucket-notification.aws_sqs_queue_policy.allow",
 		"config": {
-			"block_public_acls": {
+			"policy": {
 				"references": [
-					"var.block_public_acls",
+					"data.aws_iam_policy_document.sqs",
+					"each.key",
 				],
 			},
-			"block_public_policy": {
+			"queue_url": {
 				"references": [
-					"var.block_public_policy",
-				],
-			},
-			"bucket": {
-				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"var.attach_policy",
-					"aws_s3_bucket_policy.this[0]",
-					"aws_s3_bucket.this[0]",
-				],
-			},
-			"ignore_public_acls": {
-				"references": [
-					"var.ignore_public_acls",
-				],
-			},
-			"restrict_public_buckets": {
-				"references": [
-					"var.restrict_public_buckets",
+					"each.value",
+					"local.queue_ids",
+					"each.key",
 				],
 			},
 		},
-		"count": {
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
 			"references": [
-				"var.create_bucket",
-				"var.attach_public_policy",
+				"var.sqs_notifications",
 			],
 		},
-		"depends_on":          [],
-		"for_each":            {},
 		"mode":                "managed",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "allow",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
-		"type":                "aws_s3_bucket_public_access_block",
+		"type":                "aws_sqs_queue_policy",
 	},
-	"module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this",
-		"config":  {},
-		"count": {
+	"module.s3-bucket-notification.data.aws_arn.queue": {
+		"address": "module.s3-bucket-notification.data.aws_arn.queue",
+		"config": {
+			"arn": {
+				"references": [
+					"each.value",
+				],
+			},
+		},
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
 			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
+				"var.sqs_notifications",
 			],
 		},
-		"depends_on":          [],
-		"for_each":            {},
 		"mode":                "data",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "queue",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
-		"type":                "aws_elb_service_account",
+		"type":                "aws_arn",
 	},
-	"module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
-		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+	"module.s3-bucket-notification.data.aws_iam_policy_document.sns": {
+		"address": "module.s3-bucket-notification.data.aws_iam_policy_document.sns",
 		"config": {
 			"statement": [
 				{
 					"actions": {
 						"constant_value": [
-							"s3:PutObject",
+							"sns:Publish",
 						],
 					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "ArnEquals",
+							},
+							"values": {
+								"references": [
+									"local.bucket_arn",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceArn",
+							},
+						},
+					],
 					"effect": {
 						"constant_value": "Allow",
 					},
 					"principals": [
 						{
 							"identifiers": {
-								"references": [
-									"data.aws_elb_service_account.this",
+								"constant_value": [
+									"s3.amazonaws.com",
 								],
 							},
 							"type": {
-								"constant_value": "AWS",
+								"constant_value": "Service",
 							},
 						},
 					],
 					"resources": {
 						"references": [
-							"aws_s3_bucket.this[0]",
+							"each.value",
 						],
 					},
 					"sid": {
-						"constant_value": "",
+						"constant_value": "AllowSNSS3BucketNotification",
 					},
 				},
 			],
 		},
-		"count": {
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
 			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
+				"var.sns_notifications",
 			],
 		},
-		"depends_on":          [],
-		"for_each":            {},
 		"mode":                "data",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "elb_log_delivery",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "sns",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
 		"type":                "aws_iam_policy_document",
 	},
-	"module.s3-bucket.aws_s3_bucket.this": {
-		"address": "module.s3-bucket.aws_s3_bucket.this",
-		"config": {
-			"acceleration_status": {
-				"references": [
-					"var.acceleration_status",
-				],
-			},
-			"acl": {
-				"references": [
-					"var.acl",
-				],
-			},
-			"bucket": {
-				"references": [
-					"var.bucket",
-				],
-			},
-			"bucket_prefix": {
-				"references": [
-					"var.bucket_prefix",
-				],
-			},
-			"force_destroy": {
-				"references": [
-					"var.force_destroy",
-				],
-			},
-			"request_payer": {
-				"references": [
-					"var.request_payer",
-				],
-			},
-			"tags": {
-				"references": [
-					"var.tags",
-				],
-			},
-		},
-		"count": {
-			"references": [
-				"var.create_bucket",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket",
-	},
-	"module.s3-bucket.aws_s3_bucket_policy.this": {
-		"address": "module.s3-bucket.aws_s3_bucket_policy.this",
-		"config": {
-			"bucket": {
-				"references": [
-					"aws_s3_bucket.this[0]",
-				],
-			},
-			"policy": {
-				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"data.aws_iam_policy_document.elb_log_delivery[0]",
-					"var.policy",
-				],
-			},
-		},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-				"var.attach_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket_policy",
-	},
-	"module.s3-bucket.aws_s3_bucket_public_access_block.this": {
-		"address": "module.s3-bucket.aws_s3_bucket_public_access_block.this",
-		"config": {
-			"block_public_acls": {
-				"references": [
-					"var.block_public_acls",
-				],
-			},
-			"block_public_policy": {
-				"references": [
-					"var.block_public_policy",
-				],
-			},
-			"bucket": {
-				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"var.attach_policy",
-					"aws_s3_bucket_policy.this[0]",
-					"aws_s3_bucket.this[0]",
-				],
-			},
-			"ignore_public_acls": {
-				"references": [
-					"var.ignore_public_acls",
-				],
-			},
-			"restrict_public_buckets": {
-				"references": [
-					"var.restrict_public_buckets",
-				],
-			},
-		},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_public_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket_public_access_block",
-	},
-	"module.s3-bucket.data.aws_elb_service_account.this": {
-		"address": "module.s3-bucket.data.aws_elb_service_account.this",
-		"config":  {},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "data",
-		"module_address":      "module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_elb_service_account",
-	},
-	"module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
-		"address": "module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+	"module.s3-bucket-notification.data.aws_iam_policy_document.sqs": {
+		"address": "module.s3-bucket-notification.data.aws_iam_policy_document.sqs",
 		"config": {
 			"statement": [
 				{
 					"actions": {
 						"constant_value": [
-							"s3:PutObject",
+							"sqs:SendMessage",
 						],
 					},
+					"condition": [
+						{
+							"test": {
+								"constant_value": "ArnEquals",
+							},
+							"values": {
+								"references": [
+									"local.bucket_arn",
+								],
+							},
+							"variable": {
+								"constant_value": "aws:SourceArn",
+							},
+						},
+					],
 					"effect": {
 						"constant_value": "Allow",
 					},
 					"principals": [
 						{
 							"identifiers": {
-								"references": [
-									"data.aws_elb_service_account.this",
+								"constant_value": [
+									"s3.amazonaws.com",
 								],
 							},
 							"type": {
-								"constant_value": "AWS",
+								"constant_value": "Service",
 							},
 						},
 					],
 					"resources": {
 						"references": [
-							"aws_s3_bucket.this[0]",
+							"each.value",
 						],
 					},
 					"sid": {
-						"constant_value": "",
+						"constant_value": "AllowSQSS3BucketNotification",
 					},
 				},
 			],
 		},
-		"count": {
+		"count":      {},
+		"depends_on": [],
+		"for_each": {
 			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
+				"var.sqs_notifications",
 			],
 		},
-		"depends_on":          [],
-		"for_each":            {},
 		"mode":                "data",
-		"module_address":      "module.s3-bucket",
-		"name":                "elb_log_delivery",
-		"provider_config_key": "module.s3-bucket:aws",
+		"module_address":      "module.s3-bucket-notification",
+		"name":                "sqs",
+		"provider_config_key": "module.s3-bucket-notification:aws",
 		"provisioners":        [],
 		"type":                "aws_iam_policy_document",
 	},
@@ -586,6 +469,42 @@ variables = {
 		"description":    "Map containing static web-site hosting or redirect configuration.",
 		"module_address": "module.local-s3-bucket.module.s3-bucket",
 		"name":           "website",
+	},
+	"module.s3-bucket-notification:bucket": {
+		"default":        "",
+		"description":    "Name of S3 bucket to use",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-notification:bucket_arn": {
+		"default":        null,
+		"description":    "ARN of S3 bucket to use in policies",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "bucket_arn",
+	},
+	"module.s3-bucket-notification:create": {
+		"default":        true,
+		"description":    "Whether to create this resource or not?",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "create",
+	},
+	"module.s3-bucket-notification:lambda_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to Lambda function",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "lambda_notifications",
+	},
+	"module.s3-bucket-notification:sns_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SNS topic",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "sns_notifications",
+	},
+	"module.s3-bucket-notification:sqs_notifications": {
+		"default":        {},
+		"description":    "Map of S3 bucket notifications to SQS queue",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "sqs_notifications",
 	},
 	"module.s3-bucket:acceleration_status": {
 		"default":        null,
@@ -837,6 +756,18 @@ outputs = {
 			],
 		},
 	},
+	"module.s3-bucket-notification:this_s3_bucket_notification_id": {
+		"depends_on":     [],
+		"description":    "ID of S3 bucket",
+		"module_address": "module.s3-bucket-notification",
+		"name":           "this_s3_bucket_notification_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_notification.this",
+			],
+		},
+	},
 	"module.s3-bucket:this_s3_bucket_arn": {
 		"depends_on":     [],
 		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
@@ -937,42 +868,25 @@ outputs = {
 }
 
 module_calls = {
-	"local-s3-bucket": {
-		"config":             {},
-		"count":              {},
-		"depends_on":         [],
-		"for_each":           {},
-		"module_address":     "",
-		"name":               "local-s3-bucket",
-		"source":             "./module",
-		"version_constraint": "",
-	},
-	"module.local-s3-bucket:s3-bucket": {
+	"s3-bucket-notification": {
 		"config": {
 			"bucket": {
-				"constant_value": "roger-from-pmr-module-nested",
+				"references": [
+					"aws_s3_bucket.example",
+				],
 			},
-		},
-		"count":              {},
-		"depends_on":         [],
-		"for_each":           {},
-		"module_address":     "module.local-s3-bucket",
-		"name":               "s3-bucket",
-		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
-		"version_constraint": "1.15.0",
-	},
-	"s3-bucket": {
-		"config": {
-			"bucket": {
-				"constant_value": "roger-from-pmr-module",
+			"bucket_arn": {
+				"references": [
+					"aws_s3_bucket.example",
+				],
 			},
 		},
 		"count":              {},
 		"depends_on":         [],
 		"for_each":           {},
 		"module_address":     "",
-		"name":               "s3-bucket",
-		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"name":               "s3-bucket-notification",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws//modules/notification",
 		"version_constraint": "1.15.0",
 	},
 }

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-nested-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-nested-modules.sentinel
@@ -1,0 +1,1388 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+		},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.cloudfront_log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.cloudfront_log_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.cloudfront_log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.log_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.log_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.log_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.log_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket.this",
+		"config": {
+			"acceleration_status": {
+				"references": [
+					"var.acceleration_status",
+				],
+			},
+			"acl": {
+				"references": [
+					"var.acl",
+				],
+			},
+			"bucket": {
+				"references": [
+					"var.bucket",
+				],
+			},
+			"bucket_prefix": {
+				"references": [
+					"var.bucket_prefix",
+				],
+			},
+			"force_destroy": {
+				"references": [
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-complete.module.s3_bucket.aws_s3_bucket_policy.this",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
+		},
+		"count": {
+			"references": [
+				"var.create_bucket",
+				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
+			],
+		},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete.module.s3_bucket",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete.module.s3_bucket:aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_policy",
+	},
+	"module.s3-bucket-complete.random_pet.this": {
+		"address": "module.s3-bucket-complete.random_pet.this",
+		"config": {
+			"length": {
+				"constant_value": 2,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-complete",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-complete:random",
+		"provisioners":        [],
+		"type":                "random_pet",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "",
+		"name":           "aws_region",
+	},
+	"bucket_name": {
+		"default":        "rogerberlindexample",
+		"description":    "Name of the bucket to create",
+		"module_address": "",
+		"name":           "bucket_name",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket-complete.module.log_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.log_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.log_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.log_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.log_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.log_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.log_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.log_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.log_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.log_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.log_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.log_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.log_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.log_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.log_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.log_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "website",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:acceleration_status": {
+		"default":        null,
+		"description":    "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "acceleration_status",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:acl": {
+		"default":        "private",
+		"description":    "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "acl",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_elb_log_delivery_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have ELB log delivery policy attached",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_elb_log_delivery_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_policy": {
+		"default":        false,
+		"description":    "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:attach_public_policy": {
+		"default":        true,
+		"description":    "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "attach_public_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:block_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "block_public_acls",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:block_public_policy": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should block public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "block_public_policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:bucket": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:bucket_prefix": {
+		"default":        null,
+		"description":    "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "bucket_prefix",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:cors_rule": {
+		"default":        [],
+		"description":    "List of maps containing rules for Cross-Origin Resource Sharing.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "cors_rule",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:create_bucket": {
+		"default":        true,
+		"description":    "Controls if S3 bucket should be created",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "create_bucket",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:force_destroy": {
+		"default":        false,
+		"description":    "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "force_destroy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:grant": {
+		"default":        [],
+		"description":    "An ACL policy grant. Conflicts with `acl`",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "grant",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:ignore_public_acls": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should ignore public ACLs for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "ignore_public_acls",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:lifecycle_rule": {
+		"default":        [],
+		"description":    "List of maps containing configuration of object lifecycle management.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "lifecycle_rule",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:logging": {
+		"default":        {},
+		"description":    "Map containing access bucket logging configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "logging",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:object_lock_configuration": {
+		"default":        {},
+		"description":    "Map containing S3 object locking configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "object_lock_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:policy": {
+		"default":        null,
+		"description":    "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "policy",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:replication_configuration": {
+		"default":        {},
+		"description":    "Map containing cross-region replication configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "replication_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:request_payer": {
+		"default":        null,
+		"description":    "(Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "request_payer",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:restrict_public_buckets": {
+		"default":        false,
+		"description":    "Whether Amazon S3 should restrict public bucket policies for this bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "restrict_public_buckets",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:server_side_encryption_configuration": {
+		"default":        {},
+		"description":    "Map containing server-side encryption configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "server_side_encryption_configuration",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:tags": {
+		"default":        {},
+		"description":    "(Optional) A mapping of tags to assign to the bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "tags",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:versioning": {
+		"default":        {},
+		"description":    "Map containing versioning configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "versioning",
+	},
+	"module.s3-bucket-complete.module.s3_bucket:website": {
+		"default":        {},
+		"description":    "Map containing static web-site hosting or redirect configuration.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "website",
+	},
+}
+
+outputs = {
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.cloudfront_log_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.cloudfront_log_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.log_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.log_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket_policy.this",
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete.module.s3_bucket:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete.module.s3_bucket",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_s3_bucket.this",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_arn": {
+		"depends_on":     [],
+		"description":    "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_arn",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_arn",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_bucket_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket domain name. Will be of format bucketname.s3.amazonaws.com.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_bucket_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_bucket_regional_domain_name": {
+		"depends_on":     [],
+		"description":    "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_bucket_regional_domain_name",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_bucket_regional_domain_name",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_hosted_zone_id": {
+		"depends_on":     [],
+		"description":    "The Route 53 Hosted Zone ID for this bucket's region.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_hosted_zone_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_hosted_zone_id",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_id": {
+		"depends_on":     [],
+		"description":    "The name of the bucket.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_id",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_id",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_region": {
+		"depends_on":     [],
+		"description":    "The AWS region this bucket resides in.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_region",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_region",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_website_domain": {
+		"depends_on":     [],
+		"description":    "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. ",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_website_domain",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_domain",
+			],
+		},
+	},
+	"module.s3-bucket-complete:this_s3_bucket_website_endpoint": {
+		"depends_on":     [],
+		"description":    "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.",
+		"module_address": "module.s3-bucket-complete",
+		"name":           "this_s3_bucket_website_endpoint",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"module.s3_bucket.this_s3_bucket_website_endpoint",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"module.s3-bucket-complete:cloudfront_log_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": null,
+			},
+			"bucket": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+			"grant": {
+				"references": [
+					"data.aws_canonical_user_id.current",
+				],
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "cloudfront_log_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-complete:log_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": "log-delivery-write",
+			},
+			"attach_elb_log_delivery_policy": {
+				"constant_value": true,
+			},
+			"bucket": {
+				"references": [
+					"random_pet.this",
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "log_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"module.s3-bucket-complete:s3_bucket": {
+		"config": {
+			"acl": {
+				"constant_value": "private",
+			},
+			"attach_policy": {
+				"constant_value": true,
+			},
+			"block_public_acls": {
+				"constant_value": true,
+			},
+			"block_public_policy": {
+				"constant_value": true,
+			},
+			"bucket": {
+				"references": [
+					"local.bucket_name",
+				],
+			},
+			"cors_rule": {
+				"constant_value": [
+					{
+						"allowed_headers": [
+							"*",
+						],
+						"allowed_methods": [
+							"PUT",
+							"POST",
+						],
+						"allowed_origins": [
+							"https://modules.tf",
+							"https://terraform-aws-modules.modules.tf",
+						],
+						"expose_headers": [
+							"ETag",
+						],
+						"max_age_seconds": 3000,
+					},
+					{
+						"allowed_headers": [
+							"*",
+						],
+						"allowed_methods": [
+							"PUT",
+						],
+						"allowed_origins": [
+							"https://example.com",
+						],
+						"expose_headers": [
+							"ETag",
+						],
+						"max_age_seconds": 3000,
+					},
+				],
+			},
+			"force_destroy": {
+				"constant_value": true,
+			},
+			"ignore_public_acls": {
+				"constant_value": true,
+			},
+			"lifecycle_rule": {
+				"constant_value": [
+					{
+						"enabled": true,
+						"expiration": {
+							"days": 90,
+						},
+						"id": "log",
+						"noncurrent_version_expiration": {
+							"days": 30,
+						},
+						"prefix": "log/",
+						"tags": {
+							"autoclean": "true",
+							"rule":      "log",
+						},
+						"transition": [
+							{
+								"days":          30,
+								"storage_class": "ONEZONE_IA",
+							},
+							{
+								"days":          60,
+								"storage_class": "GLACIER",
+							},
+						],
+					},
+					{
+						"abort_incomplete_multipart_upload_days": 7,
+						"enabled": true,
+						"id":      "log1",
+						"noncurrent_version_expiration": {
+							"days": 300,
+						},
+						"noncurrent_version_transition": [
+							{
+								"days":          30,
+								"storage_class": "STANDARD_IA",
+							},
+							{
+								"days":          60,
+								"storage_class": "ONEZONE_IA",
+							},
+							{
+								"days":          90,
+								"storage_class": "GLACIER",
+							},
+						],
+						"prefix": "log1/",
+					},
+				],
+			},
+			"logging": {
+				"references": [
+					"module.log_bucket.this_s3_bucket_id",
+				],
+			},
+			"object_lock_configuration": {
+				"constant_value": {
+					"object_lock_enabled": "Enabled",
+					"rule": {
+						"default_retention": {
+							"mode":  "COMPLIANCE",
+							"years": 5,
+						},
+					},
+				},
+			},
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.bucket_policy",
+				],
+			},
+			"restrict_public_buckets": {
+				"constant_value": true,
+			},
+			"server_side_encryption_configuration": {
+				"references": [
+					"aws_kms_key.objects",
+				],
+			},
+			"tags": {
+				"constant_value": {
+					"Owner": "Anton",
+				},
+			},
+			"versioning": {
+				"constant_value": {
+					"enabled": true,
+				},
+			},
+			"website": {
+				"constant_value": null,
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "module.s3-bucket-complete",
+		"name":               "s3_bucket",
+		"source":             "../../",
+		"version_constraint": "",
+	},
+	"s3-bucket-complete": {
+		"config":             {},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-complete",
+		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws//examples/complete",
+		"version_constraint": "1.15.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-non-nested-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/mock-tfconfig-pass-non-nested-modules.sentinel
@@ -18,40 +18,6 @@ providers = {
 }
 
 resources = {
-	"aws_s3_bucket.example": {
-		"address": "aws_s3_bucket.example",
-		"config": {
-			"bucket": {
-				"constant_value": "rogerberlindexample",
-			},
-		},
-		"count":               {},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "",
-		"name":                "example",
-		"provider_config_key": "aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket",
-	},
-	"module.local-s3-bucket.aws_s3_bucket.example": {
-		"address": "module.local-s3-bucket.aws_s3_bucket.example",
-		"config": {
-			"bucket": {
-				"constant_value": "roger-local-module",
-			},
-		},
-		"count":               {},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "module.local-s3-bucket",
-		"name":                "example",
-		"provider_config_key": "module.local-s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket",
-	},
 	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this": {
 		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket.this",
 		"config": {
@@ -136,122 +102,6 @@ resources = {
 		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
 		"provisioners":        [],
 		"type":                "aws_s3_bucket_policy",
-	},
-	"module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.aws_s3_bucket_public_access_block.this",
-		"config": {
-			"block_public_acls": {
-				"references": [
-					"var.block_public_acls",
-				],
-			},
-			"block_public_policy": {
-				"references": [
-					"var.block_public_policy",
-				],
-			},
-			"bucket": {
-				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"var.attach_policy",
-					"aws_s3_bucket_policy.this[0]",
-					"aws_s3_bucket.this[0]",
-				],
-			},
-			"ignore_public_acls": {
-				"references": [
-					"var.ignore_public_acls",
-				],
-			},
-			"restrict_public_buckets": {
-				"references": [
-					"var.restrict_public_buckets",
-				],
-			},
-		},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_public_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "managed",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_s3_bucket_public_access_block",
-	},
-	"module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this": {
-		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_elb_service_account.this",
-		"config":  {},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "data",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_elb_service_account",
-	},
-	"module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
-		"address": "module.local-s3-bucket.module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
-		"config": {
-			"statement": [
-				{
-					"actions": {
-						"constant_value": [
-							"s3:PutObject",
-						],
-					},
-					"effect": {
-						"constant_value": "Allow",
-					},
-					"principals": [
-						{
-							"identifiers": {
-								"references": [
-									"data.aws_elb_service_account.this",
-								],
-							},
-							"type": {
-								"constant_value": "AWS",
-							},
-						},
-					],
-					"resources": {
-						"references": [
-							"aws_s3_bucket.this[0]",
-						],
-					},
-					"sid": {
-						"constant_value": "",
-					},
-				},
-			],
-		},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "data",
-		"module_address":      "module.local-s3-bucket.module.s3-bucket",
-		"name":                "elb_log_delivery",
-		"provider_config_key": "module.local-s3-bucket.module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_iam_policy_document",
 	},
 	"module.s3-bucket.aws_s3_bucket.this": {
 		"address": "module.s3-bucket.aws_s3_bucket.this",
@@ -338,121 +188,90 @@ resources = {
 		"provisioners":        [],
 		"type":                "aws_s3_bucket_policy",
 	},
-	"module.s3-bucket.aws_s3_bucket_public_access_block.this": {
-		"address": "module.s3-bucket.aws_s3_bucket_public_access_block.this",
+	"module.s3-bucket-pub-registry.aws_s3_bucket.this": {
+		"address": "module.s3-bucket-pub-registry.aws_s3_bucket.this",
 		"config": {
-			"block_public_acls": {
+			"acceleration_status": {
 				"references": [
-					"var.block_public_acls",
+					"var.acceleration_status",
 				],
 			},
-			"block_public_policy": {
+			"acl": {
 				"references": [
-					"var.block_public_policy",
+					"var.acl",
 				],
 			},
 			"bucket": {
 				"references": [
-					"var.attach_elb_log_delivery_policy",
-					"var.attach_policy",
-					"aws_s3_bucket_policy.this[0]",
-					"aws_s3_bucket.this[0]",
+					"var.bucket",
 				],
 			},
-			"ignore_public_acls": {
+			"bucket_prefix": {
 				"references": [
-					"var.ignore_public_acls",
+					"var.bucket_prefix",
 				],
 			},
-			"restrict_public_buckets": {
+			"force_destroy": {
 				"references": [
-					"var.restrict_public_buckets",
+					"var.force_destroy",
+				],
+			},
+			"request_payer": {
+				"references": [
+					"var.request_payer",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.tags",
 				],
 			},
 		},
 		"count": {
 			"references": [
 				"var.create_bucket",
-				"var.attach_public_policy",
 			],
 		},
 		"depends_on":          [],
 		"for_each":            {},
 		"mode":                "managed",
-		"module_address":      "module.s3-bucket",
+		"module_address":      "module.s3-bucket-pub-registry",
 		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
+		"provider_config_key": "module.s3-bucket-pub-registry:aws",
 		"provisioners":        [],
-		"type":                "aws_s3_bucket_public_access_block",
+		"type":                "aws_s3_bucket",
 	},
-	"module.s3-bucket.data.aws_elb_service_account.this": {
-		"address": "module.s3-bucket.data.aws_elb_service_account.this",
-		"config":  {},
-		"count": {
-			"references": [
-				"var.create_bucket",
-				"var.attach_elb_log_delivery_policy",
-			],
-		},
-		"depends_on":          [],
-		"for_each":            {},
-		"mode":                "data",
-		"module_address":      "module.s3-bucket",
-		"name":                "this",
-		"provider_config_key": "module.s3-bucket:aws",
-		"provisioners":        [],
-		"type":                "aws_elb_service_account",
-	},
-	"module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery": {
-		"address": "module.s3-bucket.data.aws_iam_policy_document.elb_log_delivery",
+	"module.s3-bucket-pub-registry.aws_s3_bucket_policy.this": {
+		"address": "module.s3-bucket-pub-registry.aws_s3_bucket_policy.this",
 		"config": {
-			"statement": [
-				{
-					"actions": {
-						"constant_value": [
-							"s3:PutObject",
-						],
-					},
-					"effect": {
-						"constant_value": "Allow",
-					},
-					"principals": [
-						{
-							"identifiers": {
-								"references": [
-									"data.aws_elb_service_account.this",
-								],
-							},
-							"type": {
-								"constant_value": "AWS",
-							},
-						},
-					],
-					"resources": {
-						"references": [
-							"aws_s3_bucket.this[0]",
-						],
-					},
-					"sid": {
-						"constant_value": "",
-					},
-				},
-			],
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.this[0]",
+				],
+			},
+			"policy": {
+				"references": [
+					"var.attach_elb_log_delivery_policy",
+					"data.aws_iam_policy_document.elb_log_delivery[0]",
+					"var.policy",
+				],
+			},
 		},
 		"count": {
 			"references": [
 				"var.create_bucket",
 				"var.attach_elb_log_delivery_policy",
+				"var.attach_policy",
 			],
 		},
 		"depends_on":          [],
 		"for_each":            {},
-		"mode":                "data",
-		"module_address":      "module.s3-bucket",
-		"name":                "elb_log_delivery",
-		"provider_config_key": "module.s3-bucket:aws",
+		"mode":                "managed",
+		"module_address":      "module.s3-bucket-pub-registry",
+		"name":                "this",
+		"provider_config_key": "module.s3-bucket-pub-registry:aws",
 		"provisioners":        [],
-		"type":                "aws_iam_policy_document",
+		"type":                "aws_s3_bucket_policy",
 	},
 }
 
@@ -1006,7 +825,21 @@ module_calls = {
 		"for_each":           {},
 		"module_address":     "",
 		"name":               "s3-bucket",
-		"source":             "app.terraform.io/Cloud-Operations/s3-bucket/aws",
+		"source":             "tfe.acme.com/CloudOps/s3-bucket/aws",
+		"version_constraint": "1.15.0",
+	},
+	"s3-bucket-pub-registry": {
+		"config": {
+			"bucket": {
+				"constant_value": "roger-from-pmr-module",
+			},
+		},
+		"count":              {},
+		"depends_on":         [],
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "s3-bucket-pub-registry",
+		"source":             "terraform-aws-modules/s3-bucket/aws",
 		"version_constraint": "1.15.0",
 	},
 }

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-direct-nested-module.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-direct-nested-module.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-direct-nested-module.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-nested-modules.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-nested-modules.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-nested-modules.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-non-nested-modules.hcl
+++ b/governance/third-generation/cloud-agnostic/test/restrict-resources-by-module-source/pass-non-nested-modules.hcl
@@ -1,0 +1,15 @@
+module "tfconfig-functions" {
+  source = "../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-non-nested-modules.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/get_ancestor_module_source.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/get_ancestor_module_source.md
@@ -1,13 +1,15 @@
-# get_module_source
-This function finds the source of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+# get_ancestor_module_source
+This function finds the source of the first ancestor module that is not a local module of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import. (A local module is indicated by use of a source starting with "./" or "../".)
 
 It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module. It then finds the `module_call` in the parent module that calls the original module and then gets `source` from that module call.
+
+However, if the `source` starts with "./" or "../", the function then calls itself recursively against the address of the module's parent module. It keeps doing this until it finds a non-local module and then gives that module's source.
 
 ## Sentinel Module
 This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
 
 ## Declaration
-`get_module_source = func(module_address)`
+`get_ancestor_module_source = func(module_address)`
 
 ## Arguments
 * **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
@@ -16,7 +18,7 @@ This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-f
 None.
 
 ## What It Returns
-This function returns a string containing the source of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+This function returns a string containing the source of the ancestor module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
 
 ## What It Prints
 This function does not print anything.
@@ -25,5 +27,7 @@ This function does not print anything.
 Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
 ```
 module_address = r.module_address
-module_source = config.get_module_source(module_address)
+module_source = config.get_ancestor_module_source(module_address)
 ```
+
+It is used by the [restrict-resources-by-module-source.sentinel](../../../cloud-agnostic/restrict-resources-by-module-source.sentinel) policy.

--- a/governance/third-generation/common-functions/tfconfig-functions/docs/get_parent_module_address.md
+++ b/governance/third-generation/common-functions/tfconfig-functions/docs/get_parent_module_address.md
@@ -1,13 +1,13 @@
-# get_module_source
-This function finds the source of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+# get_parent_module_address
+This function finds the address of the parent module of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
 
-It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module. It then finds the `module_call` in the parent module that calls the original module and then gets `source` from that module call.
+It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module.
 
 ## Sentinel Module
 This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
 
 ## Declaration
-`get_module_source = func(module_address)`
+`get_parent_module_address = func(module_address)`
 
 ## Arguments
 * **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
@@ -16,7 +16,7 @@ This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-f
 None.
 
 ## What It Returns
-This function returns a string containing the source of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+This function returns a string containing the address of the parent module of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
 
 ## What It Prints
 This function does not print anything.
@@ -25,5 +25,5 @@ This function does not print anything.
 Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
 ```
 module_address = r.module_address
-module_source = config.get_module_source(module_address)
+parent_module_address = config.get_parent_module_address(module_address)
 ```

--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -535,3 +535,65 @@ get_module_source = func(module_address) {
     return module_source
   }
 }
+
+### get_ancestor_module_source ###
+# Get the module source of the first ancestor module from a module address that
+# is not a local module (one having source starting with "./" or "../").
+# Note that the module_address in many collections in the tfplan/v2, tfconfig/v2,
+# and tfstate/v2 imports gives the labels used in the module blocks.
+# For instance, a module_address like "module.A.module.B" means that the current
+# item is in a module with label "B" that is a module with label "A". But that
+# does not give you the source the module labeled "B".
+# But if you want to limit creation of resources to specific modules based on
+# their source, you need the module source.  This function computes it for
+# the first ancestor module that is not a local module.
+get_ancestor_module_source = func(module_address) {
+  # Check for root module
+  if module_address is "" {
+    return "root"
+  } else {
+    # Find parent module
+    module_segments = strings.split(module_address, ".")
+    num_segments = length(module_segments)
+    parent_module = strings.join(module_segments[0:num_segments-2], ".")
+    current_module_name = module_segments[num_segments-1]
+
+    # Find module call that called current module
+    if parent_module is "" {
+      # parent module is root module
+      mc = tfconfig.module_calls[current_module_name]
+    } else {
+      # parent module is not root module
+      mc = tfconfig.module_calls[parent_module + ":" + current_module_name]
+    }
+
+    # Set source from the module call
+    module_source = mc.source
+
+    # Check to see if current module source is a nested module
+    if strings.has_prefix(module_source, "./") or strings.has_prefix(module_source, "../") {
+      return get_ancestor_module_source(parent_module)
+    } else {
+      return module_source
+    }
+
+  }
+}
+
+### get_parent_module_address ###
+# Get the address of the parent module of a module from the module address
+# return "root" if the given module_address is "" (the root module).
+get_parent_module_address = func(module_address) {
+  # Check for root module
+  if module_address is "" {
+    return "root"
+  } else {
+    # Find parent module
+    module_segments = strings.split(module_address, ".")
+    num_segments = length(module_segments)
+    parent_module = strings.join(module_segments[0:num_segments-2], ".")
+    current_module_name = module_segments[num_segments-1]
+
+    return parent_module
+  }
+}


### PR DESCRIPTION
This PR has significant updates to the restrict-resources-by-module-source.sentinel policy and adds 2 new functions to the tfconfig-functions.sentinel module: get_ancestor_module_source() and get_parent_module_address(). The policy now calls the first of these instead of get_module_source(). This allows the policy to determine the source of the first non-local ancestor module (one that does not have source starting with "./" or "../") from the resource's actual module in case its source is local.

The policy now handles the following things that it previously did not:

1. Local modules within allowed modules.
2. Direct references to nested modules of allowed modules. (e.g., `app.terraform.io/Cloud-Operations/s3-bucket/aws//modules/notification`)
3. Modules in the public registry (which will have a source like `terraform-aws-modules/s3-bucket/aws` instead of a source like `app.terraform.io/Cloud-Operations/s3-bucket/aws`.
4. Use of the `*` wildcard for the organization for allowed Private Module Registry (PMR) sources. So, the list of allowed module sources can include a source like `localterraform.com/*/s3-bucket/aws`.

Additionally, instead of checking whether the computed module source is in the `allowed_module_sources` list, the policy now uses Sentinel's `matches` operator to compare the computed module source against a regex expression built from each of the sources in the list. By building the regex in the policy instead of asking users to provide regex expressions in the list, using the policy is made easier and the violation messages are easier to read since they give the actual module sources in that list instead of regex expressions.

Several new test cases have been added. These mostly were created from a PMR version of https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws/latest.

Two of the test cases used direct references to two of the example in that module.  The "complete" example has module sources like `../../`.  The "notficiation" example has module sources like `../../` but also `terraform-aws-modules/lambda/aws`   and `terraform-aws-modules/cloudwatch/aws//examples/fixtures/aws_sns_topic` which are not allowed.