### PR TITLE
fix order of filter conditions

### DIFF
--- a/governance/third-generation/aws/restrict-egress-sg-rule-cidr-blocks.sentinel
+++ b/governance/third-generation/aws/restrict-egress-sg-rule-cidr-blocks.sentinel
@@ -17,9 +17,10 @@ forbidden_cidrs = ["0.0.0.0/0"]
 # Get all Security Group Egress Rules
 SGEgressRules = filter tfplan.resource_changes as address, rc {
   rc.type is "aws_security_group_rule" and
-  rc.mode is "managed" and rc.change.after.type is "egress" and
+  rc.mode is "managed" and
   (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.type is "egress"
 }
 
 # Filter to Egress Security Group Rules with violations

--- a/governance/third-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
+++ b/governance/third-generation/aws/restrict-ingress-sg-rule-cidr-blocks.sentinel
@@ -17,9 +17,10 @@ forbidden_cidrs = ["0.0.0.0/0"]
 # Get all Security Group Ingress Rules
 SGIngressRules = filter tfplan.resource_changes as address, rc {
   rc.type is "aws_security_group_rule" and
-  rc.mode is "managed" and rc.change.after.type is "ingress" and
-  (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+  rc.mode is "managed" and
+  (rc.change.actions contains "create" or   rc.change.actions contains "update" or
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.type is "ingress" 
 }
 
 # Filter to Ingress Security Group Rules with violations

--- a/governance/third-generation/aws/restrict-ingress-sg-rule-rdp.sentinel
+++ b/governance/third-generation/aws/restrict-ingress-sg-rule-rdp.sentinel
@@ -26,9 +26,10 @@ forbidden_from_port = 3389
 # Get all Security Group Ingress Rules
 aws_security_group_rules = filter tfplan.resource_changes as address, rc {
   rc.type is "aws_security_group_rule" and
-  rc.mode is "managed" and rc.change.after.type is "ingress" and
+  rc.mode is "managed" and
   (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.type is "ingress" 
 }
 
 # Validate Security Group Rules
@@ -42,11 +43,11 @@ for aws_security_group_rules as address, sgr {
 	if sgr.change.after.cidr_blocks else null is not null and
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
-		sgr.change.after.from_port else null is null and 
-    	sgr.change.after.to_port else null is not null and 
+		sgr.change.after.from_port else null is null and
+    	sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port is forbidden_to_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(RDP) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has from_port that is null or undefined")
 		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port)
@@ -57,10 +58,10 @@ for aws_security_group_rules as address, sgr {
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
 		sgr.change.after.from_port else null is not null and
-    	sgr.change.after.from_port is forbidden_from_port and 
+    	sgr.change.after.from_port is forbidden_from_port and
 		sgr.change.after.to_port else null is null{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(RDP) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has from_port with value", sgr.change.after.from_port)
 		print("   and Ingress Rule has to_port that is null or undefined")
@@ -71,15 +72,15 @@ for aws_security_group_rules as address, sgr {
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
 		sgr.change.after.from_port else null is not null and
-    	sgr.change.after.from_port <= forbidden_from_port and 
+    	sgr.change.after.from_port <= forbidden_from_port and
 		sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port >= forbidden_to_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(RDP) open to", forbidden_cidrs, "that is not allowed")
-		print("  Ingress Rule has from_port with value", sgr.change.after.from_port, 
+		print("  Ingress Rule has from_port with value", sgr.change.after.from_port,
 		"that is less than or equal to", forbidden_from_port)
-		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port, 
+		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port,
 		"that is greater than or equal to", forbidden_to_port)
 		print("  The to_port and from_port both need to be set to an integer",
 			"range or of equal")
@@ -90,7 +91,7 @@ for aws_security_group_rules as address, sgr {
 		sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port is forbidden_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 			"(RDP) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has to_port with value", sgr.change.after.to_port)
 		print("  The to_port and from_port both need to be set to an integer",
@@ -108,27 +109,27 @@ for allSGs as address, sg {
 
 	# Find the ingress rules of the current SG
 	ingressRules = plan.find_blocks(sg, "ingress")
-	
+
 	# Filter to violating CIDR blocks
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingCidr = plan.filter_attribute_contains_items_from_list(ingressRules,
 					"cidr_blocks", forbidden_cidrs, false)
-	
+
 	# Filter to violating Service port
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingFromPortLess = plan.filter_attribute_less_than_equal_to_value(ingressRules,
 							"from_port", forbidden_from_port, false)
-	
+
 	# Filter to violating Service port
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingToPortGreater = plan.filter_attribute_greater_than_equal_to_value(ingressRules,
 								"to_port", forbidden_to_port, false)
-	
+
 	# Print violation messages
-	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and 
+	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and
 		length(violatingToPortGreater["messages"]) > 0{
 	violatingSGsCount += 1
-	print("SG Ingress Violation:", address, "has port", forbidden_port, 
+	print("SG Ingress Violation:", address, "has port", forbidden_port,
 			"(RDP) open to", forbidden_cidrs, "that is not allowed")
 ###Uncomment below if you want to show the CIDRs as a separate message as well
 #	plan.print_violations(violatingCidr["messages"], "  Ingress Rule")

--- a/governance/third-generation/aws/restrict-ingress-sg-rule-ssh.sentinel
+++ b/governance/third-generation/aws/restrict-ingress-sg-rule-ssh.sentinel
@@ -26,9 +26,10 @@ forbidden_from_port = 22
 # Get all Security Group Ingress Rules
 aws_security_group_rules = filter tfplan.resource_changes as address, rc {
   rc.type is "aws_security_group_rule" and
-  rc.mode is "managed" and rc.change.after.type is "ingress" and
+  rc.mode is "managed" and
   (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.type is "ingress"
 }
 
 # Validate Security Group Rules
@@ -42,11 +43,11 @@ for aws_security_group_rules as address, sgr {
 	if sgr.change.after.cidr_blocks else null is not null and
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
-		sgr.change.after.from_port else null is null and 
-    	sgr.change.after.to_port else null is not null and 
+		sgr.change.after.from_port else null is null and
+    	sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port is forbidden_to_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(SSH) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has from_port that is null or undefined")
 		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port)
@@ -57,10 +58,10 @@ for aws_security_group_rules as address, sgr {
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
 		sgr.change.after.from_port else null is not null and
-    	sgr.change.after.from_port is forbidden_from_port and 
+    	sgr.change.after.from_port is forbidden_from_port and
 		sgr.change.after.to_port else null is null{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(SSH) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has from_port with value", sgr.change.after.from_port)
 		print("   and Ingress Rule has to_port that is null or undefined")
@@ -71,15 +72,15 @@ for aws_security_group_rules as address, sgr {
 		types.type_of(sgr.change.after.cidr_blocks) is "list" and
 		sgr.change.after.cidr_blocks contains "0.0.0.0/0" and
 		sgr.change.after.from_port else null is not null and
-    	sgr.change.after.from_port <= forbidden_from_port and 
+    	sgr.change.after.from_port <= forbidden_from_port and
 		sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port >= forbidden_to_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 		"(SSH) open to", forbidden_cidrs, "that is not allowed")
-		print("  Ingress Rule has from_port with value", sgr.change.after.from_port, 
+		print("  Ingress Rule has from_port with value", sgr.change.after.from_port,
 		"that is less than or equal to", forbidden_from_port)
-		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port, 
+		print("   and Ingress Rule has to_port with value", sgr.change.after.to_port,
 		"that is greater than or equal to", forbidden_to_port)
 		print("  The to_port and from_port both need to be set to an integer",
 			"range or of equal")
@@ -90,7 +91,7 @@ for aws_security_group_rules as address, sgr {
 		sgr.change.after.to_port else null is not null and
 		sgr.change.after.to_port is forbidden_port{
 		violatingSGRulesCount += 1
-		print("SG Rule Ingress Violation:", address, "has port", forbidden_port, 
+		print("SG Rule Ingress Violation:", address, "has port", forbidden_port,
 			"(SSH) open to", forbidden_cidrs, "that is not allowed")
 		print("  Ingress Rule has to_port with value", sgr.change.after.to_port)
 		print("  The to_port and from_port both need to be set to an integer",
@@ -108,27 +109,27 @@ for allSGs as address, sg {
 
 	# Find the ingress rules of the current SG
 	ingressRules = plan.find_blocks(sg, "ingress")
-	
+
 	# Filter to violating CIDR blocks
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingCidr = plan.filter_attribute_contains_items_from_list(ingressRules,
 					"cidr_blocks", forbidden_cidrs, false)
-	
+
 	# Filter to violating Service port
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingFromPortLess = plan.filter_attribute_less_than_equal_to_value(ingressRules,
 							"from_port", forbidden_from_port, false)
-	
+
 	# Filter to violating Service port
 	# Warnings will not be printed for violations since the last parameter is false
 	violatingToPortGreater = plan.filter_attribute_greater_than_equal_to_value(ingressRules,
 								"to_port", forbidden_to_port, false)
-	
+
 	# Print violation messages
-	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and 
+	if length(violatingCidr["messages"]) > 0 and length(violatingFromPortLess["messages"]) > 0 and
 		length(violatingToPortGreater["messages"]) > 0{
 	violatingSGsCount += 1
-	print("SG Ingress Violation:", address, "has port", forbidden_port, 
+	print("SG Ingress Violation:", address, "has port", forbidden_port,
 			"(SSH) open to", forbidden_cidrs, "that is not allowed")
 ###Uncomment below if you want to show the CIDRs as a separate message as well
 #	plan.print_violations(violatingCidr["messages"], "  Ingress Rule")

--- a/governance/third-generation/azure/restrict-inbound-source-address-prefixes.sentinel
+++ b/governance/third-generation/azure/restrict-inbound-source-address-prefixes.sentinel
@@ -17,10 +17,11 @@ forbidden_cidrs = ["0.0.0.0/0", "0.0.0.0", "*", "Internet"]
 # Get all Network Security Group Inbound Allow Rules
 SGInboundAllowRules = filter tfplan.resource_changes as address, rc {
   rc.type is "azurerm_network_security_rule" and
-  rc.mode is "managed" and rc.change.after.direction is "Inbound" and
-  rc.change.after.access is "Allow" and
+  rc.mode is "managed" and
   (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.direction is "Inbound" and
+  rc.change.after.access is "Allow"
 }
 
 # Filter to Inbound Allow Security Group Rules with violations

--- a/governance/third-generation/azure/restrict-outbound-destination-address-prefixes.sentinel
+++ b/governance/third-generation/azure/restrict-outbound-destination-address-prefixes.sentinel
@@ -17,10 +17,11 @@ forbidden_cidrs = ["0.0.0.0/0", "0.0.0.0", "*", "Internet"]
 # Get all Network Security Group Outbound Allow Rules
 SGOutboundAllowRules = filter tfplan.resource_changes as address, rc {
   rc.type is "azurerm_network_security_rule" and
-  rc.mode is "managed" and rc.change.after.direction is "Outbound" and
-  rc.change.after.access is "Allow" and
+  rc.mode is "managed" and
   (rc.change.actions contains "create" or rc.change.actions contains "update" or
-   rc.change.actions contains "read" or rc.change.actions contains "no-op")
+   rc.change.actions contains "read" or rc.change.actions contains "no-op") and
+  rc.change.after.direction is "Outbound" and
+  rc.change.after.access is "Allow"
 }
 
 # Filter to Outbound Allow Security Group Rules with violations


### PR DESCRIPTION
This fixes order of conditions in filters used in 4 AWS and 2 Azure policies that restrict CIDRs.  Those policies included `rc.change.after.type is "ingress"` or `rc.change.after.type is "ingress", but it was possible for these to return undefined if a resource was being permanently destroyed since `rc.change.after` would then be empty. I moved those checks to after this:

```
(rc.change.actions contains "create" or rc.change.actions contains "update" or
   rc.change.actions contains "read" or rc.change.actions contains "no-op")
```

That then guarantees that the resource is not being deleted before rc.change.after.type is read.  (Recall that Sentinel has short-circuit logic, so if previous conditions are false, then later boolean expressions will not be read.)

Roger