### PR TITLE
print outputs

### DIFF
--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -1,5 +1,5 @@
 # TFE Automation Script
-Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted. If an apply is done, the script waits for it to finish and then downloads the apply log and the before and after state files. If an apply cannot be done, it downloads the plan log instead.
+Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted. If an apply is done, the script waits for it to finish and then downloads and prints the apply log and the state file. It also prints the outputs separately even though they are also in the state file. If an apply cannot be done, it downloads the plan log instead.
 
 Note that this script is only meant as an example that shows how to use the various Terraform Cloud APIs.  It is not suitable for production usage since it does not support modifying workspace variables after they have already been created in a workspace.
 
@@ -42,7 +42,7 @@ The script does the following steps:
     - Other values of $run_status cause the loop to repeat after a brief sleep.
 1. If $save_plan was set to "true" in the above loop, the script outputs and saves the plan log.
 1. If any apply was done, the script goes into a second loop to wait for the apply to finish, error, or be canceled.
-1. If and when the apply finishes, the script downloads the apply log and the new state file from before and after the apply.
+1. If and when the apply finishes, the script downloads the apply log, determines the state version ID, retrieves the outputs from the state version with that ID, and then downloads and prints the new state file.
 
 In addition to the loadAndRunWorkspace.sh script, this example includes the following files:
 

--- a/operations/automation-script/loadAndRunWorkspace.sh
+++ b/operations/automation-script/loadAndRunWorkspace.sh
@@ -483,10 +483,18 @@ if [[ "$applied" == "true" ]]; then
   echo ""
   echo "State ID:" ${state_id}
 
-  # Call API to get information about the state version including its URL
+  # Call API to get information about the state version including its URL and outputs
   state_file_url_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" "https://${address}/api/v2/state-versions/${state_id}?include=outputs")
 
   # Retrieve and echo outputs from state
+  # Note that we retrieved outputs in the last API call by
+  # adding `?include=outputs`
+  # Instead of doing that, we could have retrieved the state version output
+  # IDs from the relationships of the above API call and could have then
+  # called the State Version Output API to retrieve details for each output.
+  # That would have involved URLs like
+  # "https://${address}/api/v2/state-version-outputs/${output_id}"
+  # See `https://www.terraform.io/docs/cloud/api/state-version-outputs.html#show-a-state-version-output`
   num_outputs=$(echo $state_file_url_result | python -c "import sys, json; print(len(json.load(sys.stdin)['included']))")
   echo ""
   echo "Outputs from State:"

--- a/operations/automation-script/loadAndRunWorkspace.sh
+++ b/operations/automation-script/loadAndRunWorkspace.sh
@@ -6,7 +6,7 @@
 # checked against the workspace, and if $override=true and there were
 # no hard-mandatory violations of Sentinel policies, does an apply.
 # If an apply is done, the script waits for it to finish and then
-# downloads the apply log and the before and after state files.
+# downloads the apply log and the state file.
 
 # Make sure TFE_TOKEN and TFE_ORG environment variables are set
 # to owners team token and organization name for the respective
@@ -188,36 +188,44 @@ EOF
 sed "s/placeholder/${workspace}/" < workspace.template.json > workspace.json
 
 # Check to see if the workspace already exists
+echo ""
 echo "Checking to see if workspace exists"
 check_workspace_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/workspaces/${workspace}")
 
 # Parse workspace_id from check_workspace_result
 workspace_id=$(echo $check_workspace_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['id'])")
+echo ""
 echo "Workspace ID: " $workspace_id
 
 # Create workspace if it does not already exist
 if [ -z "$workspace_id" ]; then
+  echo ""
   echo "Workspace did not already exist; will create it."
   workspace_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --request POST --data @workspace.json "https://${address}/api/v2/organizations/${organization}/workspaces")
 
   # Parse workspace_id from workspace_result
   workspace_id=$(echo $workspace_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['id'])")
+  echo ""
   echo "Workspace ID: " $workspace_id
 else
+  echo ""
   echo "Workspace already existed."
 fi
 
 # Create configuration version
+echo ""
 echo "Creating configuration version."
 configuration_version_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @configversion.json "https://${address}/api/v2/workspaces/${workspace_id}/configuration-versions")
 
 # Parse configuration_version_id and upload_url
 config_version_id=$(echo $configuration_version_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['id'])")
 upload_url=$(echo $configuration_version_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['attributes']['upload-url'])")
+echo ""
 echo "Config Version ID: " $config_version_id
 echo "Upload URL: " $upload_url
 
 # Upload configuration
+echo ""
 echo "Uploading configuration version using ${config_dir}.tar.gz"
 #curl -s --request PUT -F 'data=@myconfig.tar.gz' "$upload_url"
 curl -s --header "Content-Type: application/octet-stream" --request PUT --data-binary @${config_dir}.tar.gz "$upload_url"
@@ -225,10 +233,12 @@ curl -s --header "Content-Type: application/octet-stream" --request PUT --data-b
 # Check if a variables.csv file is in the configuration directory
 # If so, use it. Otherwise, use the one in the current directory.
 if [ -f "${config_dir}/variables.csv" ]; then
+  echo ""
   echo "Found variables.csv in ${config_dir}."
   echo "Will load variables from it."
   variables_file=${config_dir}/variables.csv
 else
+  echo ""
   echo "Did not find variables.csv in configuration."
   echo "Will load variables from ./variables.csv"
   variables_file=variables.csv
@@ -243,6 +253,7 @@ escape_string()
 sedDelim=$(printf '\001')
 
 # Add variables to workspace
+echo ""
 while IFS=',' read -r key value category hcl sensitive
 do
   fixedkey=$(escape_string "$key")
@@ -255,6 +266,7 @@ done < ${variables_file}
 # List Sentinel Policies
 sentinel_list_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/policies")
 sentinel_policy_count=$(echo $sentinel_list_result | python -c "import sys, json; print(json.load(sys.stdin)['meta']['pagination']['total-count'])")
+echo ""
 echo "Number of Sentinel policies: " $sentinel_policy_count
 
 # Do a run
@@ -263,6 +275,7 @@ run_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Conte
 
 # Parse run_result
 run_id=$(echo $run_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['id'])")
+echo ""
 echo "Run ID: " $run_id
 
 # Check run result in loop
@@ -270,6 +283,7 @@ continue=1
 while [ $continue -ne 0 ]; do
   # Sleep
   sleep $sleep_duration
+  echo ""
   echo "Checking run status"
 
   # Check the status of run
@@ -295,6 +309,7 @@ while [ $continue -ne 0 ]; do
   # exist or are applicable to the workspace
   if [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "no" ]]; then
     continue=0
+    echo ""
     echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
     echo "Check the run in Terraform Enterprise UI and apply there if desired."
     save_plan="true"
@@ -302,11 +317,13 @@ while [ $continue -ne 0 ]; do
   # exist or are applicable to the workspace
   elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "no" ]]; then
     continue=0
+    echo ""
     echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
     echo "Check the run in Terraform Enterprise UI and apply there if desired."
     save_plan="true"
   elif [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "yes" ]]; then
     continue=0
+    echo ""
     echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
     echo "Since override was set to \"yes\", we are applying."
     # Do the apply
@@ -315,6 +332,7 @@ while [ $continue -ne 0 ]; do
     applied="true"
   elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "yes" ]]; then
     continue=0
+    echo ""
     echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
     echo "Since override was set to \"yes\", we are applying."
     # Do the apply
@@ -325,6 +343,7 @@ while [ $continue -ne 0 ]; do
   elif [[ "$run_status" == "policy_checked" ]]; then
     continue=0
     # Do the apply
+    echo ""
     echo "Policies passed. Doing Apply"
     apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
     applied="true"
@@ -332,17 +351,22 @@ while [ $continue -ne 0 ]; do
   # but since $override is "yes", we will override and then apply
   elif [[ "$run_status" == "policy_override" ]] && [[ "$override" == "yes" ]]; then
     continue=0
+    echo ""
     echo "Some policies failed, but overriding"
     # Get the policy check ID
+    echo ""
     echo "Getting policy check ID"
     policy_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" https://${address}/api/v2/runs/${run_id}/policy-checks)
     # Parse out the policy check ID
     policy_check_id=$(echo $policy_result | python -c "import sys, json; print(json.load(sys.stdin)['data'][0]['id'])")
+    echo ""
     echo "Policy Check ID: " $policy_check_id
     # Override policy
+    echo ""
     echo "Overriding policy check"
     override_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --request POST https://${address}/api/v2/policy-checks/${policy_check_id}/actions/override)
     # Do the apply
+    echo ""
     echo "Doing Apply"
     apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
     applied="true"
@@ -350,26 +374,32 @@ while [ $continue -ne 0 ]; do
   # but since $override is "no", we will not override
   # and will not apply
   elif [[ "$run_status" == "policy_override" ]] && [[ "$override" == "no" ]]; then
+    echo ""
     echo "Some policies failed, but will not override. Check run in Terraform Enterprise UI."
     save_plan="true"
     continue=0
   # errored means that plan had an error or that a hard-mandatory
   # policy failed
   elif [[ "$run_status" == "errored" ]]; then
+    echo ""
     echo "Plan errored or hard-mandatory policy failed"
     save_plan="true"
     continue=0
   elif [[ "$run_status" == "planned_and_finished" ]]; then
+    echo ""
     echo "Plan indicates no changes to apply."
     save_plan="true"
     continue=0
   elif [[ "run_status" == "canceled" ]]; then
+    echo ""
     echo "The run was canceled."
     continue=0
   elif [[ "run_status" == "force_canceled" ]]; then
+    echo ""
     echo "The run was canceled forcefully."
     continue=0
   elif [[ "run_status" == "discarded" ]]; then
+    echo ""
     echo "The run was discarded."
     continue=0
   else
@@ -380,18 +410,21 @@ done
 
 # Get the plan log if $save_plan is true
 if [[ "$save_plan" == "true" ]]; then
+  echo ""
   echo "Getting the result of the Terraform Plan."
   plan_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" https://${address}/api/v2/runs/${run_id}?include=plan)
   plan_log_url=$(echo $plan_result | python -c "import sys, json; print(json.load(sys.stdin)['included'][0]['attributes']['log-read-url'])")
+  echo ""
   echo "Plan Log:"
   # Retrieve Plan Log from the URL
   # and output to shell and file
   curl -s $plan_log_url | tee ${run_id}.log
 fi
 
-# Get the apply log and state files (before and after) if an apply was done
+# Get the apply log and state file if an apply was done
 if [[ "$applied" == "true" ]]; then
 
+  echo ""
   echo "An apply was done."
   echo "Will download apply log and state file."
 
@@ -400,6 +433,7 @@ if [[ "$applied" == "true" ]]; then
 
   # Get apply ID
   apply_id=$(echo $check_result | python -c "import sys, json; print(json.load(sys.stdin)['included'][0]['id'])")
+  echo ""
   echo "Apply ID:" $apply_id
 
   # Check apply status periodically in loop
@@ -407,6 +441,7 @@ if [[ "$applied" == "true" ]]; then
   while [ $continue -ne 0 ]; do
 
     sleep $sleep_duration
+    echo ""
     echo "Checking apply status"
 
     # Check the apply status
@@ -434,29 +469,43 @@ if [[ "$applied" == "true" ]]; then
 
   # Get apply log URL
   apply_log_url=$(echo $check_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['attributes']['log-read-url'])")
+  echo ""
   echo "Apply Log URL:"
   echo "${apply_log_url}"
 
   # Retrieve Apply Log from the URL
   # and output to shell and file
+  echo ""
   curl -s $apply_log_url | tee ${apply_id}.log
 
   # Get state version ID from after the apply
-  state_id_after=$(echo $check_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['relationships']['state-versions']['data'][0]['id'])")
-  echo "State ID:" ${state_id_after}
+  state_id=$(echo $check_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['relationships']['state-versions']['data'][0]['id'])")
+  echo ""
+  echo "State ID:" ${state_id}
 
   # Call API to get information about the state version including its URL
-  state_file_after_url_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" https://${address}/api/v2/state-versions/${state_id_after})
+  state_file_url_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" "https://${address}/api/v2/state-versions/${state_id}?include=outputs")
+
+  # Retrieve and echo outputs from state
+  num_outputs=$(echo $state_file_url_result | python -c "import sys, json; print(len(json.load(sys.stdin)['included']))")
+  echo ""
+  echo "Outputs from State:"
+  for ((output=0;output<$num_outputs;output++))
+  do
+    echo $state_file_url_result | python -c "import sys, json; print(json.dumps(json.load(sys.stdin)['included'][$output]['attributes'], sort_keys=True))"
+  done
 
   # Get state file URL from the result
-  state_file_after_url=$(echo $state_file_after_url_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['attributes']['hosted-state-download-url'])")
+  state_file_url=$(echo $state_file_url_result | python -c "import sys, json; print(json.load(sys.stdin)['data']['attributes']['hosted-state-download-url'])")
+  echo ""
   echo "URL for state file after apply:"
-  echo ${state_file_after_url}
+  echo ${state_file_url}
 
   # Retrieve state file from the URL
   # and output to shell and file
+  echo ""
   echo "State file after the apply:"
-  curl -s $state_file_after_url | tee ${apply_id}-after.tfstate
+  curl -s $state_file_url | tee ${apply_id}-after.tfstate
 
 fi
 


### PR DESCRIPTION
print outputs from run in the loadAndRunWorkspace.sh operations script. This uses the `?include=outputs` argument on the API call against the state version ID which then gives full information about the outputs.  As indicated in the comment starting at line 489, we could have instead retrieved state version output IDs from the relationships of the state version API call and could have then called the State Version Output API to retrieve details for each output. See https://www.terraform.io/docs/cloud/api/state-version-outputs.html#show-a-state-version-output