### PR TITLE
don't fail require-all-resources-from-pmr.sentinel if destroy

### DIFF
--- a/governance/third-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
+++ b/governance/third-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
@@ -4,6 +4,10 @@
 
 # Import the tfconfig/v2 import, but use the alias "tfconfig"
 import "tfconfig/v2" as tfconfig
+
+# Import the tfrun import
+import "tfrun"
+
 # Standard strings import
 import "strings"
 
@@ -20,7 +24,7 @@ violatingMCs = filter tfconfig.module_calls as index, mc {
 }
 
 # Print violation messages for invalid modules
-if length(violatingMCs) > 0 {
+if length(violatingMCs) > 0 and not tfrun.is_destroy {
   print("All modules called from the root module must come from the",
         "private module registry", address + "/" + organization)
   for violatingMCs as address, mc {
@@ -35,14 +39,16 @@ rootModuleResources = filter tfconfig.resources as address, r {
 }
 
 # Print violation messages for root module resources and data sources
-if length(rootModuleResources) > 0 {
+if length(rootModuleResources) > 0 and not tfrun.is_destroy {
   print("Resources and data sources are not allowed in the root module.")
   print("Your root module has", length(rootModuleResources), "resources and",
         "data sources.")
 }
 
 # Main rule
-validated = length(violatingMCs) is 0 and length(rootModuleResources) is 0
+validated = tfrun.is_destroy or
+            (length(violatingMCs) is 0 and
+            length(rootModuleResources) is 0)
 main = rule {
  validated is true
 }

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass-destroy.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass-destroy.sentinel
@@ -1,0 +1,134 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias":               "",
+		"config":              {},
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"module.nested.aws_instance.ubuntu": {
+		"address": "module.nested.aws_instance.ubuntu",
+		"config": {
+			"ami": {
+				"references": [
+					"var.ami_id",
+				],
+			},
+			"associate_public_ip_address": {
+				"references": [
+					"var.associate_public_ip_address",
+				],
+			},
+			"availability_zone": {
+				"references": [
+					"var.aws_region",
+				],
+			},
+			"instance_type": {
+				"references": [
+					"var.instance_type",
+				],
+			},
+			"tags": {
+				"references": [
+					"var.name",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "module.nested",
+		"name":                "ubuntu",
+		"provider_config_key": "module.nested:aws",
+		"provisioners":        [],
+		"type":                "aws_instance",
+	},
+}
+
+provisioners = {}
+
+variables = {
+	"module.nested:ami_id": {
+		"default":        "ami-2e1ef954",
+		"description":    "ID of the AMI to provision. Default is Ubuntu 14.04 Base Image",
+		"module_address": "module.nested",
+		"name":           "ami_id",
+	},
+	"module.nested:associate_public_ip_address": {
+		"default":        true,
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "associate_public_ip_address",
+	},
+	"module.nested:aws_region": {
+		"default":        "us-east-1",
+		"description":    "AWS region",
+		"module_address": "module.nested",
+		"name":           "aws_region",
+	},
+	"module.nested:instance_type": {
+		"default":        "t2.micro",
+		"description":    "type of EC2 instance to provision.",
+		"module_address": "module.nested",
+		"name":           "instance_type",
+	},
+	"module.nested:name": {
+		"default":        "roger-demo-nested",
+		"description":    "name to pass to Name tag",
+		"module_address": "module.nested",
+		"name":           "name",
+	},
+	"owners": {
+		"default": [
+			"099720109477",
+			"099720109476",
+		],
+		"description":    "list of owners of AMI",
+		"module_address": "",
+		"name":           "owners",
+	},
+}
+
+outputs = {
+	"module.nested:public_dns": {
+		"depends_on":     [],
+		"description":    "",
+		"module_address": "module.nested",
+		"name":           "public_dns",
+		"sensitive":      false,
+		"value": {
+			"references": [
+				"aws_instance.ubuntu",
+			],
+		},
+	},
+}
+
+module_calls = {
+	"nested": {
+		"config":             {},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested",
+		"source":             "app.terraform.io/Cloud-Operations/compute/aws",
+		"version_constraint": "",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-fail.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-fail.sentinel
@@ -1,0 +1,25 @@
+id = "run-tnXKfMSc4LHMX14h"
+created_at = "2021-04-13T18:49:56.141Z"
+message = "accept 400"
+commit_sha = undefined
+speculative = false
+is_destroy = false
+target_addrs = null
+
+variables = {}
+
+organization = {
+	"name": "Cloud-Operations",
+}
+
+workspace = {
+	"auto_apply":        false,
+	"created_at":        "2019-05-11T19:13:07.766Z",
+	"description":       null,
+	"id":                "ws-fo8TJnedDLEWfP3K",
+	"name":              "aws-ec2-instance",
+	"vcs_repo":          null,
+	"working_directory": "",
+}
+
+cost_estimate = {}

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-pass-destroy.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-pass-destroy.sentinel
@@ -1,0 +1,25 @@
+id = "run-tnXKfMSc4LHMX14h"
+created_at = "2021-04-13T18:49:56.141Z"
+message = "accept 400"
+commit_sha = undefined
+speculative = false
+is_destroy = true
+target_addrs = null
+
+variables = {}
+
+organization = {
+	"name": "Cloud-Operations",
+}
+
+workspace = {
+	"auto_apply":        false,
+	"created_at":        "2019-05-11T19:13:07.766Z",
+	"description":       null,
+	"id":                "ws-fo8TJnedDLEWfP3K",
+	"name":              "aws-ec2-instance",
+	"vcs_repo":          null,
+	"working_directory": "",
+}
+
+cost_estimate = {}

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfrun-pass.sentinel
@@ -1,0 +1,25 @@
+id = "run-tnXKfMSc4LHMX14h"
+created_at = "2021-04-13T18:49:56.141Z"
+message = "accept 400"
+commit_sha = undefined
+speculative = false
+is_destroy = false
+target_addrs = null
+
+variables = {}
+
+organization = {
+	"name": "Cloud-Operations",
+}
+
+workspace = {
+	"auto_apply":        false,
+	"created_at":        "2019-05-11T19:13:07.766Z",
+	"description":       null,
+	"id":                "ws-fo8TJnedDLEWfP3K",
+	"name":              "aws-ec2-instance",
+	"vcs_repo":          null,
+	"working_directory": "",
+}
+
+cost_estimate = {}

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass-destroy.hcl
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass-destroy.hcl
@@ -8,18 +8,19 @@ param "organization" {
 
 mock "tfconfig/v2" {
   module {
-    source = "mock-tfconfig-fail.sentinel"
+    source = "mock-tfconfig-pass-destroy.sentinel"
   }
 }
 
 mock "tfrun" {
   module {
-    source = "mock-tfrun-fail.sentinel"
+    source = "mock-tfrun-pass-destroy.sentinel"
   }
 }
 
+
 test {
   rules = {
-    main = false
+    main = true
   }
 }

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass.hcl
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass.hcl
@@ -12,6 +12,13 @@ mock "tfconfig/v2" {
   }
 }
 
+mock "tfrun" {
+  module {
+    source = "mock-tfrun-pass.sentinel"
+  }
+}
+
+
 test {
   rules = {
     main = true


### PR DESCRIPTION
I realized that this policy would fail if a destroy was being done. But in that case, we don't want to fail.
It now checks tfrun.is_destroy in addition to what it was already checking.