### PR TITLE
update find_by_provider functions

### DIFF
--- a/governance/third-generation/aws/restrict-sagemaker-notebooks.sentinel
+++ b/governance/third-generation/aws/restrict-sagemaker-notebooks.sentinel
@@ -8,7 +8,6 @@ import "tfplan-functions" as plan
 
 # Get all Sagemaker notebooks
 allSagemakerNotebooks = plan.find_resources("aws_sagemaker_notebook_instance")
-#print("allSagemakerNotebooks:", allSagemakerNotebooks)
 
 # Filter to Sagemaker notebooks that have root_access set to "Enabled"
 # or missing.

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
@@ -3,7 +3,7 @@ This function finds all data source instances for a specific provider that are b
 
 When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
 
-If you are using Terraform 0.12, use the short form of the provider name such as "aws". If you are using Terraform 0.13, use the fully-qualified provider source such as "registry.terraform.io/hashicorp/aws".
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
 
 ## Sentinel Module
 This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) Sentinel module.

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
@@ -1,7 +1,7 @@
 # find_resources_by_provider
 This function finds all resource instances for a specific provider in the current plan that are being created, modified, or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included.
 
-If you are using Terraform 0.12, use the short form of the provider name such as "aws". If you are using Terraform 0.13, use the fully-qualified provider source such as "registry.terraform.io/hashicorp/aws".
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
 
 ## Sentinel Module
 This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -37,13 +37,46 @@ find_resources = func(type) {
 # Find all resources for a specific provider using the tfplan/v2 import.
 # Include resources that are not being permanently deleted.
 # Technically, this returns a map of resource changes.
+# Terraform 0.12 and earlier set `rc.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
 find_resources_by_provider = func(provider) {
-  resources = filter tfplan.resource_changes as address, rc {
-    rc.provider_name is provider and
-  	rc.mode is "managed" and
-  	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-     rc.change.actions contains "read" or rc.change.actions contains "no-op")
-  }
+  parsed_provider = strings.split(provider, "/")
+  segment_count = length(parsed_provider)
+  v = strings.split(tfplan.terraform_version, ".")
+  v_major = int(v[1])
+
+  # If v_major is 12, we know short form was passed to Sentinel
+  if v_major is 12 {
+    resources = filter tfplan.resource_changes as address, rc {
+      rc.provider_name is provider and
+    	rc.mode is "managed" and
+    	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+       rc.change.actions contains "read" or rc.change.actions contains "no-op")
+    }
+  } else {
+    # v_major must be higher than 12 since v2 imports being used
+    # So, we know long form like "registry.terraform.io/hashicorp/null" given
+    if segment_count is 1 {
+      # Function was passed short form, so we want to reduce each occurence of
+      # rc.provider_name to its short form.
+      resources = filter tfplan.resource_changes as address, rc {
+        strings.split(rc.provider_name, "/")[2] is provider and
+      	rc.mode is "managed" and
+      	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+      }
+    } else {
+      # Function was passed long form, so we use full rc.provider_name
+      resources = filter tfplan.resource_changes as address, rc {
+        rc.provider_name is provider and
+      	rc.mode is "managed" and
+      	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+      }
+    } // end segment_count
+  } // end v_major
 
   return resources
 }
@@ -69,15 +102,46 @@ find_datasources = func(type) {
 # Find all data sources for a specific provider using the tfplan/v2 import.
 # Include data sources that are not being permanently deleted.
 # Technically, this returns a map of resource changes.
+# Terraform 0.12 and earlier set `rc.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
 find_datasources_by_provider = func(provider) {
-  datasources = filter tfplan.resource_changes as address, rc {
-  	rc.provider_name is provider and
-  	rc.mode is "data" and
-  	(rc.change.actions contains "create" or
-    rc.change.actions contains "update" or
-    rc.change.actions contains "read" or
-    rc.change.actions contains "no-op")
-  }
+  parsed_provider = strings.split(provider, "/")
+  segment_count = length(parsed_provider)
+  v = strings.split(tfplan.terraform_version, ".")
+  v_major = int(v[1])
+
+  # If v_major is 12, we know short form was passed to Sentinel
+  if v_major is 12 {
+    datasources = filter tfplan.resource_changes as address, rc {
+      rc.provider_name is provider and
+    	rc.mode is "data" and
+    	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+       rc.change.actions contains "read" or rc.change.actions contains "no-op")
+    }
+  } else {
+    # v_major must be higher than 12 since v2 imports being used
+    # So, we know long form like "registry.terraform.io/hashicorp/null" given
+    if segment_count is 1 {
+      # Function was passed short form, so we want to reduce each occurence of
+      # rc.provider_name to its short form.
+      datasources = filter tfplan.resource_changes as address, rc {
+        strings.split(rc.provider_name, "/")[2] is provider and
+      	rc.mode is "data" and
+      	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+      }
+    } else {
+      # Function was passed long form, so we use full rc.provider_name
+      datasources = filter tfplan.resource_changes as address, rc {
+        rc.provider_name is provider and
+      	rc.mode is "data" and
+      	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+      }
+    } // end segment_count
+  } // end v_major
 
   return datasources
 }

--- a/governance/third-generation/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
@@ -1,7 +1,7 @@
 # find_datasources_by_provider
 This function finds all data source instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
 
-If you are using Terraform 0.12, use the short form of the provider name such as "aws". If you are using Terraform 0.13, use the fully-qualified provider source such as "registry.terraform.io/hashicorp/aws".
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
 
 ## Sentinel Module
 This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.

--- a/governance/third-generation/common-functions/tfstate-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfstate-functions/docs/find_resources_by_provider.md
@@ -1,7 +1,7 @@
 # find_resources_by_provider
 This function finds all resource instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
 
-If you are using Terraform 0.12, use the short form of the provider name such as "aws". If you are using Terraform 0.13, use the fully-qualified provider source such as "registry.terraform.io/hashicorp/aws".
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
 
 ## Sentinel Module
 This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.

--- a/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -31,11 +31,40 @@ find_resources = func(type) {
 
 ### find_resources_by_provider ###
 # Find all resources for a specific provider using the tfstate/v2 import.
+# Terraform 0.12 and earlier set `r.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
 find_resources_by_provider = func(provider) {
-  resources = filter tfstate.resources as address, r {
-  	r.provider_name is provider and
-  	r.mode is "managed"
-  }
+  parsed_provider = strings.split(provider, "/")
+  segment_count = length(parsed_provider)
+  v = strings.split(tfstate.terraform_version, ".")
+  v_major = int(v[1])
+
+  # If v_major is 12, we know short form was passed to Sentinel
+  if v_major is 12 {
+    resources = filter tfstate.resources as address, r {
+      r.provider_name is provider and
+    	r.mode is "managed"
+    }
+  } else {
+    # v_major must be higher than 12 since v2 imports being used
+    # So, we know long form like "registry.terraform.io/hashicorp/null" given
+    if segment_count is 1 {
+      # Function was passed short form, so we want to reduce each occurence of
+      # r.provider_name to its short form.
+      resources = filter tfstate.resources as address, r {
+        strings.split(r.provider_name, "/")[2] is provider and
+      	r.mode is "managed"
+      }
+    } else {
+      # Function was passed long form, so we use full r.provider_name
+      resources = filter tfstate.resources as address, r {
+        r.provider_name is provider and
+      	r.mode is "managed"
+      }
+    } // end segment_count
+  } // end v_major
 
   return resources
 }
@@ -53,11 +82,40 @@ find_datasources = func(type) {
 
 ### find_datasources_by_provider ###
 # Find all data sources for a specific provider using the tfstate/v2 import.
+# Terraform 0.12 and earlier set `r.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
 find_datasources_by_provider = func(provider) {
-  datasources = filter tfstate.resources as address, d {
-  	d.provider_name is provider and
-  	d.mode is "data"
-  }
+  parsed_provider = strings.split(provider, "/")
+  segment_count = length(parsed_provider)
+  v = strings.split(tfstate.terraform_version, ".")
+  v_major = int(v[1])
+
+  # If v_major is 12, we know short form was passed to Sentinel
+  if v_major is 12 {
+    datasources = filter tfstate.resources as address, r {
+      r.provider_name is provider and
+    	r.mode is "data"
+    }
+  } else {
+    # v_major must be higher than 12 since v2 imports being used
+    # So, we know long form like "registry.terraform.io/hashicorp/null" given
+    if segment_count is 1 {
+      # Function was passed short form, so we want to reduce each occurence of
+      # r.provider_name to its short form.
+      datasources = filter tfstate.resources as address, r {
+        strings.split(r.provider_name, "/")[2] is provider and
+      	r.mode is "data"
+      }
+    } else {
+      # Function was passed long form, so we use full r.provider_name
+      datasources = filter tfstate.resources as address, r {
+        r.provider_name is provider and
+      	r.mode is "data"
+      }
+    } // end segment_count
+  } // end v_major
 
   return datasources
 }


### PR DESCRIPTION
This updates the find_resources_by_provider() and find_datasources_by_provider() functions for both the tfplan-functions and the tfstate-functions modules to make them more flexible in dealing with the different way that Terraform 0.13 and higher versions treat provider_name of resources in the tfplan/v2 and tfstate/v2 imports compared to the way that Terraform 0.12 did.  The difference was that 0.13 and higher give the full name of a provider such as "registry.terraform.io/hashicorp/aws" while 0.12 just gave "aws".

Previously, I had adjusted for that by telling users to use the long form name if using 0.13 or higher and to use the short form name if using 0.12.

Now, users can use either form with 0.13 and higher depending on their preference.  They must still use the short form with Terraform 0.12.

The different ways of using the functions are documented in the MD files associated with the functions.