### PR TITLE
Fix the Ending Curly Brace in to_string

### DIFF
--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -234,9 +234,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(key) + ": " + to_string(obj[key]) + ", "
         } else {
-          output += to_string(key) + ": " + to_string(obj[key]) + "}"
+          output += to_string(key) + ": " + to_string(obj[key])
         }
       }
+      output += "}"
       return output
     else:
       return ""


### PR DESCRIPTION
Currently, when an object has no elements, `to_string` outputs `{` instead of the expected `{}`. This change fixes that, thereby aligning the behavior more with how lists are handled (`[]`).