### PR TITLE
fix to_string for config and state

### DIFF
--- a/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/governance/third-generation/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -276,9 +276,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(key) + ": " + to_string(obj[key]) + ", "
         } else {
-          output += to_string(key) + ": " + to_string(obj[key]) + "}"
+          output += to_string(key) + ": " + to_string(obj[key])
         }
       }
+      output += "}"
       return output
     else:
       return ""

--- a/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -180,9 +180,10 @@ to_string = func(obj) {
         if index < lastIndex {
           output += to_string(key) + ": " + to_string(obj[key]) + ", "
         } else {
-          output += to_string(key) + ": " + to_string(obj[key]) + "}"
+          output += to_string(key) + ": " + to_string(obj[key])
         }
       }
+      output += "}"
       return output
     else:
       return ""


### PR DESCRIPTION
I had previously fixed to_string() in tfplan-functions to output {} for an empty map, but had forgotten about the same function in tfconfig-functions and tfstate-functions.