### PR TITLE
add require-free-sec-center-subscription-pricing-for-vms.sentinel

### DIFF
--- a/governance/third-generation/azure/require-free-sec-center-subscription-pricing-for-vms.sentinel
+++ b/governance/third-generation/azure/require-free-sec-center-subscription-pricing-for-vms.sentinel
@@ -1,0 +1,31 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# any occurence of the azurerm_security_center_subscription_pricing
+# resource that lists VirtualMachines as the resource_type also lists
+# the tier as "Free"
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel with
+# alias "plan"
+import "tfplan-functions" as plan
+
+# Get all Azure Security Center Pricings
+allAzureSecCenterSubPricings = plan.find_resources("azurerm_security_center_subscription_pricing")
+
+# Filter to Azure Security Center Pricings for Virtual Machines
+# Warnings will not be printed for violations since the last parameter is false
+azureSecCenterSubPricingsForVMs = plan.filter_attribute_is_value(
+                             allAzureSecCenterSubPricings,
+                             "resource_type", "VirtualMachines", false)
+
+# Filter to Azure Security Center Pricings for Virtual Machines with pricing
+# tier set to Standard.
+# When applying a second filter, we restrict to the resources map returned from
+# the first filter.
+# Warnings will be printed for all violations since the last parameter is true
+violatingAzureSecCenterSubPricingsForVMs = plan.filter_attribute_is_value(
+                                           azureSecCenterSubPricingsForVMs["resources"],
+                                           "tier", "Standard", true)
+
+# Main rule
+main = rule {
+  length(violatingAzureSecCenterSubPricingsForVMs["messages"]) is 0
+}

--- a/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/fail.hcl
+++ b/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/fail.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-fail.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/mock-tfplan-fail.sentinel
+++ b/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/mock-tfplan-fail.sentinel
@@ -1,0 +1,80 @@
+terraform_version = "1.0.5"
+
+variables = {}
+
+resource_changes = {
+	"azurerm_security_center_subscription_pricing.keyvaults": {
+		"address": "azurerm_security_center_subscription_pricing.keyvaults",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "KeyVaults",
+				"tier":          "Standard",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "keyvaults",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+	"azurerm_security_center_subscription_pricing.storageaccounts": {
+		"address": "azurerm_security_center_subscription_pricing.storageaccounts",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "StorageAccounts",
+				"tier":          "Free",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "storageaccounts",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+	"azurerm_security_center_subscription_pricing.vms": {
+		"address": "azurerm_security_center_subscription_pricing.vms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "VirtualMachines",
+				"tier":          "Standard",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vms",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/mock-tfplan-pass.sentinel
+++ b/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/mock-tfplan-pass.sentinel
@@ -1,0 +1,80 @@
+terraform_version = "1.0.5"
+
+variables = {}
+
+resource_changes = {
+	"azurerm_security_center_subscription_pricing.keyvaults": {
+		"address": "azurerm_security_center_subscription_pricing.keyvaults",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "KeyVaults",
+				"tier":          "Standard",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "keyvaults",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+	"azurerm_security_center_subscription_pricing.storageaccounts": {
+		"address": "azurerm_security_center_subscription_pricing.storageaccounts",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "StorageAccounts",
+				"tier":          "Free",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "storageaccounts",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+	"azurerm_security_center_subscription_pricing.vms": {
+		"address": "azurerm_security_center_subscription_pricing.vms",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"resource_type": "VirtualMachines",
+				"tier":          "Free",
+				"timeouts":      null,
+			},
+			"after_unknown": {
+				"id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "vms",
+		"provider_name":  "registry.terraform.io/hashicorp/azurerm",
+		"type":           "azurerm_security_center_subscription_pricing",
+	},
+}
+
+output_changes = {}

--- a/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/pass.hcl
+++ b/governance/third-generation/azure/test/require-free-sec-center-subscription-pricing-for-vms/pass.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-pass.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}


### PR DESCRIPTION
Add policy that requires use of Free pricing tier on all Virtual Machines in Azure.