### PR TITLE
reference tfconfig-functions module

### DIFF
--- a/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
@@ -1,3 +1,7 @@
+module "tfconfig-functions" {
+    source = "../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
 policy "check-external-http-api" {
     source = "./check-external-http-api.sentinel"
     enforcement_level = "advisory"


### PR DESCRIPTION
I need to refere the tfconfig-function module in the sentinel.hcl file in the cloud-agnostic/http-examples directory.