### PR TITLE
add jq version of loadAndRunWorkspace.sh

### DIFF
--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -76,7 +76,7 @@ Do the following before using these scripts:
 1. To see how the scripts can check Sentinel policies and even override soft-mandatory failures, add the included restrict-name-variable.sentinel policy to your TFE organization. See the [Managing Sentinel Policies](https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html) documentation for instructions.
 
 ## Using with a Terraform Enteprise Server using private CA
-If you use these scripts with a Terraform Enterprise server that uses a private CA instead of a public CA, you will need to ensure that the curl commands run by the script will trust the private CA.  There are several ways to do this.  The first is easiest for enabling the automation script to run, but it only affects curl. The second and third are useful for using the Terraform and TFE CLIs against your PTFE server. The third is a permanent solution.
+If you use these scripts with a Terraform Enterprise server that uses a private CA instead of a public CA, you will need to ensure that the curl commands run by the script will trust the private CA.  There are several ways to do this.  The first is easiest for enabling the automation script to run, but it only affects curl. The second and third approaches are useful when using the Terraform CLI to talk to your Terraform Enterprise server. The third is a permanent solution.
 1. `export  CURL_CA_BUNDLE=<path_to_ca_bundle>`
 1. Export the Golang SSL_CERT_FILE and/or SSL_CERT_DIR environment variables. For instance, you could set the first of these to the same CA bundle used in option 1.
 1. Copy your certificate bundle to /etc/pki/ca-trust/source/anchors and then run `update-ca-trust extract`.

--- a/operations/automation-script/README.md
+++ b/operations/automation-script/README.md
@@ -1,14 +1,20 @@
 # TFE Automation Script
-Script to automate interactions with Terraform Enterprise, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted. If an apply is done, the script waits for it to finish and then downloads and prints the apply log and the state file. It also prints the outputs separately even though they are also in the state file. If an apply cannot be done, it downloads the plan log instead.
+This directory contains scripts to automate interactions with Terraform Cloud, including the cloning of a repository containing Terraform configuration code, creation of a workspace, tarring and uploading of the Terraform code, setting of variables, triggering a run, checking Sentinel policies, and finally doing an apply if permitted. If an apply is done, the scripts wait for it to finish and then downloads and prints the apply log and the state file. They also print the outputs separately even though they are also in the state file. If an apply cannot be done, they download the plan log instead.
 
-Note that this script is only meant as an example that shows how to use the various Terraform Cloud APIs.  It is not suitable for production usage since it does not support modifying workspace variables after they have already been created in a workspace.
+Note that these scripts are only meant as examples that show how to use the various Terraform Cloud (TFC) APIs.  They are not suitable for production usage since they do not support modifying workspace variables after they have already been created in a workspace.
 
-There is also a script to delete the workspace.
+The primary script exists in two versions:
+1. _loadAndRunWorkspace-python.sh_ which uses `python` to parse the JSON results returned by the TFC APIs.
+2. _loadAndRunWorkspace-jq.sh_ which uses `jq` to parse the JSON results returned by the TFC APIs.
+
+**You should copy the one you prefer to use to _loadAndRunWorkspace.sh_.  We assume you have done that in the rest of this document.**
+
+There is also a _deleteWorkspace.sh_ script to delete the workspace.
 
 ## Introduction
-This script uses curl to interact with Terraform Enterprise via the Terraform Enterprise REST API. The same APIs could be used from Jenkins or other solutions to incorporate Terraform Enterprise into your CI/CD pipeline.
+These scripts use curl to interact with Terraform Cloud or Terraform Enterprise via the Terraform Cloud REST API. The same API calls could be used from Jenkins or other solutions to incorporate Terraform Cloud into your CI/CD pipeline.
 
-Three arguments can be provided on the command line when calling the script:
+Three arguments can be provided on the command line when calling the _loadAndRunWorkspace.sh_ script:
 1. The first, **git_url**, is an optional URL for a git repository from which the script should clone some Terraform code.
 1. The second, **workspace**, is the name of the workspace to use or create if it does not already exist. Note that TFE workspace names are not allowed to contain spaces. The script checks for this and will exit if workspace contains any spaces.
 1. The third, **override**, is used in two ways:
@@ -26,11 +32,11 @@ The script does the following steps:
 1. Creates a new configuration version.
 1. Uploads the tar file as a new configuration.
 1. Adds Terraform and environment variables from the file variables.csv that was included in the cloned repository if it exists or from the local copy in the same directory as the script. That local version adds one Terraform variable called "name" with value "Roger" and one Environment variable called "TF_CLI_ARGS" with value "-no-color" to the workspace. This supresses color codes from the apply log output. You can edit this file to add as many variables as you want and then add it to your repository.
-1. Determines the number of Sentinel policies so that it knows whether it needs to check them.
+1. Determines the number of Sentinel policy sets so that it can report how many there were.
 1. Starts a new run.
 1. Enters a loop to check the run results periodically.
-    - If $run_status is "planned" or "cost_estimated", $is_confirmable is "True", and $override is "no", the script stops. In this case, no Sentinel policies existed or none of them were applicable to this workspace. The script will stop.  The user should can apply the run in the Terraform Enterprise UI.
-    - If $run_status is "planned" or "cost_estimated", $is_confirmable is "True", and $override is "yes", the script will do an apply. As in the previous case, no Sentinel policies existed or none of them were applicable to this workspace.
+    - If $run_status is "planned" or "cost_estimated", $is_confirmable is "True" (for python) or "true" (for jq), and $override is "no", the script stops. In this case, no Sentinel policies existed or none of them were applicable to this workspace. The script will stop.  The user should can apply the run in the Terraform Cloud UI.
+    - If $run_status is "planned" or "cost_estimated", $is_confirmable is "True" (for python) or "true" (for jq), and $override is "yes", the script will do an apply. As in the previous case, no Sentinel policies existed or none of them were applicable to this workspace.
     - If $run_status is "policy_checked", it does an Apply. In this case, all Sentinel policies passed.
     - If $run_status is "policy_override" and $override is "yes", it overrides the failed policy checks and does an Apply. In this case, one or more Sentinel policies failed, but they were marked "advisory" or "soft-mandatory" and the script was configured to override the failure.
     - If $run_status is "policy_override" and $override is "no", it prints out a message indicating that some policies failed and are not being overridden.
@@ -44,43 +50,45 @@ The script does the following steps:
 1. If any apply was done, the script goes into a second loop to wait for the apply to finish, error, or be canceled.
 1. If and when the apply finishes, the script downloads the apply log, determines the state version ID, retrieves the outputs from the state version with that ID, and then downloads and prints the new state file.
 
-In addition to the loadAndRunWorkspace.sh script, this example includes the following files:
+In addition to the loadAndRunWorkspace-python.sh and loadAndRunWorkspace-jq.sh scripts, this example includes the following files:
 
 1. [config/main.tf](./config/main.tf) which is a file with some Terraform code that says "Hello" to the person whose name is given and generates a random number. This is used if no git URL is provided to the script.
 1. [variables.csv](./variables.csv) which contains the variables that are uploaded to the workspace if no file with the same name is found in the root directory of the cloned repository. The columns are key, value, category, hcl, and sensitive with the last two corresponding to the hcl and sensitive checkboxes of TFE variables. The `category` should be set to `terraform` for Terraform variables and to `env` for environment variables. The `hcl` and `sensitive` values can be set to `true` or `false`. This should be in the same directory as the script unless you include a file with the same name in your git repository.
 1. [deleteWorkspace.sh](./deleteWorkspace.sh): a script that can be used to delete the workspace.
 1. [restrict-name-variable.sentinel](./restrict-name-variable.sentinel): a Sentinel policy you can add to your TFE organization in order to see how the script can check Sentinel policies and even override soft-mandatory failures.
 
-The following files are embedded inside the script:
+The following files are embedded inside the scripts:
 
-1. **workspace.template.json** which is used to generate _workspace.json_ which is used when creating the workspace. If you wish to add or modify the settings that are included in the _@workspace.json_ payload, add them to _workspace.template.json_ inside the script and be sure to check the Terraform Enterprise API [syntax](https://www.terraform.io/docs/enterprise/api/workspaces.html#update-a-workspace). Update or modify `"terraform-version": "0.13.6"` within _workspace.template.json_  to set a specific workspace version of the Terraform OSS binary.
+1. **workspace.template.json** which is used to generate _workspace.json_ which is used when creating the workspace. If you wish to add or modify the settings that are included in the _@workspace.json_ payload, add them to _workspace.template.json_ inside the script and be sure to check the Terraform Cloud API [syntax](https://www.terraform.io/docs/enterprise/api/workspaces.html#update-a-workspace). Update or modify `"terraform-version": "1.0.5"` within _workspace.template.json_  to set a specific workspace version of the Terraform OSS binary.
 1. **configversion.json** which is used to generate a new configuration version.
 1. **variable.template.json** which is used to generate _variable.json_ which is used when creating a variable called "name" in the workspace.
 1. **run.template.json** which is used to generate _run.json_ which is used when triggering a run against the workspace.
 1. **apply.json** which is used when doing the apply against the workspace.
 
 ## Preparation
-Do the following before using this script:
+Do the following before using these scripts:
 
 1. `git clone https://github.com/hashicorp/terraform-guides.git`
 1. `cd operations/automation-script`
-1. Make sure [python](https://www.python.org/downloads/) is installed on your machine and in your path since the script uses python to parse JSON documents returned by the Terraform Enterprise REST API.
-1. If you want the script to use a variables.csv file stored in the git repository containing your Terraform code, edit the sample file with that name and add it to the root of your repository.
-1. To see how the script can check Sentinel policies and even override soft-mandatory failures, add the included restrict-name-variable.sentinel policy to your TFE organization. See the [Managing Sentinel Policies](https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html) documentation for instructions.
+1. Make sure [python](https://www.python.org/downloads/) is installed on your machine if you want to use loadAndRunWorkspace-python.sh.
+1. Make sure [jq](https://stedolan.github.io/jq/download/) is installed on your machine if you want to use loadAndRunWorkspace-jq.sh.
+1. If you want the scripts to use a variables.csv file stored in the git repository containing your Terraform code, edit the sample file with that name and add it to the root of your repository.
+1. To see how the scripts can check Sentinel policies and even override soft-mandatory failures, add the included restrict-name-variable.sentinel policy to your TFE organization. See the [Managing Sentinel Policies](https://www.terraform.io/docs/enterprise/sentinel/manage-policies.html) documentation for instructions.
 
-## Using with Private Terraform Enteprise Server using private CA
-If you use this script with a Private Terraform Enterprise (PTFE) server that uses a private CA instead of a public CA, you will need to ensure that the curl commands run by the script will trust the private CA.  There are several ways to do this.  The first is easiest for enabling the automation script to run, but it only affects curl. The second and third are useful for using the Terraform and TFE CLIs against your PTFE server. The third is a permanent solution.
+## Using with a Terraform Enteprise Server using private CA
+If you use these scripts with a Terraform Enterprise server that uses a private CA instead of a public CA, you will need to ensure that the curl commands run by the script will trust the private CA.  There are several ways to do this.  The first is easiest for enabling the automation script to run, but it only affects curl. The second and third are useful for using the Terraform and TFE CLIs against your PTFE server. The third is a permanent solution.
 1. `export  CURL_CA_BUNDLE=<path_to_ca_bundle>`
 1. Export the Golang SSL_CERT_FILE and/or SSL_CERT_DIR environment variables. For instance, you could set the first of these to the same CA bundle used in option 1.
 1. Copy your certificate bundle to /etc/pki/ca-trust/source/anchors and then run `update-ca-trust extract`.
 
 ## Instructions
-Follow these instructions to run the script with with the included main.tf and variables.csv files or with your own git repository:
+Follow these instructions to run the scripts with with the included main.tf and variables.csv files or with your own git repository:
 
-1. Generate a [team token](https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html#team-service-accounts) for the owners team in your organization in the Terraform Enterprise UI by selecting your organization settings, then Teams, then owners, and then clicking the Generate button and saving the token that is displayed.
+1. Generate a [team token](https://www.terraform.io/docs/enterprise/users-teams-organizations/service-accounts.html#team-service-accounts) for the owners team in your organization in the Terraform Cloud UI by selecting your organization settings, then Teams, then owners, and then clicking the Generate button and saving the token that is displayed.
 1. `export TFE_TOKEN=<owners_token>` where \<owners_token\> is the token generated in the previous step.
 1. `export TFE_ORG=<your_organization>` where \<your_organization\> is the name of your target TFE organization.
-1. `export TFE_ADDR=<your_address>` where \<your_address\> is the custom address of your target TFE server in the format server.domain.tld. If you do not set this environment variable it will default to the Terraform Enterprise Cloud/SaaS address of app.terraform.io.
+1. `export TFE_ADDR=<your_address>` where \<your_address\> is the custom address of your target TFE server in the format server.domain.tld. If you do not set this environment variable it will default to the Terraform Cloud Cloud/SaaS address of app.terraform.io.
+1. Copy the script you prefer to use (_loadAndRunWorkspace-python.sh_ or _loadAndRunWorkspace-jq.sh_) to _loadAndRunWorkspace.sh_.
 1. If you want, edit _loadAndRunWorkspace.sh_ to change the name of the workspace that will be created by editing the workspace variable. *Note* that you can also pass the workspace as the second argument to the script.
 1. If you want, you can change the sleep_duration variable which controls how often the script checks the status of the triggered run (in seconds). Setting a longer value would make sense if using Terraform code that takes longer to apply.
 1. If you are providing a URL to clone a git repository, you can add Terraform and environment variables needed by your Terraform code to [variables.csv](./variables.csv) and remove the "name" variable. You can also add the edited variables.csv file to your repository.
@@ -92,4 +100,4 @@ Follow these instructions to run the script with with the included main.tf and v
 As mentioned above, you can replace the main.tf file in the config directory with your own Terraform code or clone Terraform code from a git repository. In the fist case, all files in the config directory will be uploaded to your TFE server.  In the second case, the entire git repository will be cloned and uploaded except for the .git directory. Edit variables.csv to remove the name variable and add rows for any Terraform and Environment variables that are required by your Terraform code.  If your code has a terraform.tfvars file, please rename it to terraform.auto.tfvars or some other file with a name matching `*.auto.tfvars` since TFE overwrites any instance of terraform.tfvars with the variables set in the workspace. Note that variables added via a `*.auto.tfvars` file will not show up on the variables tab of the workspace in the TFE UI. Additionally, you cannot add environment variables in a tfvars file. In contrast, you can add both Terraform and environment variables to the variables.csv file and they will show up on the variables tab of the workspace.
 
 ## Cleaning Up
-You can run `./deleteWorkspace.sh` or `./deleteWorkspace.sh <workspace>` to delete the workspace. Be sure to set the same address, organization, and workspace variables that you set in the loadAndRunWorkspace.sh script or use the same \<workspace\> variable you used when you created the workspace with the `loadAndRunWorkspace.sh script`.
+You can run `./deleteWorkspace.sh` or `./deleteWorkspace.sh <workspace>` to delete the workspace. Be sure to set the same address, organization, and workspace variables that you set in the _loadAndRunWorkspace.sh_ script or use the same \<workspace\> variable you used when you created the workspace with the _loadAndRunWorkspace.sh_ script.

--- a/operations/automation-script/loadAndRunWorkspace-jq.sh
+++ b/operations/automation-script/loadAndRunWorkspace-jq.sh
@@ -1,0 +1,528 @@
+#!/bin/bash
+# Script that clones Terraform configuration from a git repository
+# creates a workspace if it does not already exist, uploads the
+# Terraform configuration to it, adds variables to the workspace,
+# triggers a run, checks the results of Sentinel policies (if any)
+# checked against the workspace, and if $override=true and there were
+# no hard-mandatory violations of Sentinel policies, does an apply.
+# If an apply is done, the script waits for it to finish and then
+# downloads the apply log and the state file.
+
+# Make sure TFE_TOKEN and TFE_ORG environment variables are set
+# to owners team token and organization name for the respective
+# TFE environment. TFE_ADDR should be set to the FQDN/URL of the private
+# TFE server or if unset it will default to TF Cloud/SaaS address.
+
+if [ ! -z "$TFE_TOKEN" ]; then
+  token=$TFE_TOKEN
+  echo "TFE_TOKEN environment variable was found."
+else
+  echo "TFE_TOKEN environment variable was not set."
+  echo "You must export/set the TFE_TOKEN environment variable."
+  echo "It should be a user or team token that has write or admin"
+  echo "permission on the workspace."
+  echo "Exiting."
+  exit
+fi
+
+# Evaluate $TFE_ORG environment variable
+# If not set, give error and exit
+if [ ! -z "$TFE_ORG" ]; then
+  organization=$TFE_ORG
+  echo "TFE_ORG environment variable was set to ${TFE_ORG}."
+  echo "Using organization, ${organization}."
+else
+  echo "You must export/set the TFE_ORG environment variable."
+  echo "Exiting."
+  exit
+fi
+
+# Evaluate $TFE_ADDR environment variable if it exists
+# Otherwise, use "app.terraform.io"
+# You should edit these before running the script.
+if [ ! -z "$TFE_ADDR" ]; then
+  address=$TFE_ADDR
+  echo "TFE_ADDR environment variable was set to ${TFE_ADDR}."
+  echo "Using address, ${address}"
+else
+  address="app.terraform.io"
+  echo "TFE_ADDR environment variable was not set."
+  echo "Using Terraform Cloud (TFE SaaS) address, app.terraform.io."
+  echo "If you want to use a private TFE server, export/set TFE_ADDR."
+fi
+
+# workspace name should not have spaces and should be set as second
+# argument from CLI
+
+workspace="workspace-from-api"
+
+# You can change sleep duration if desired
+sleep_duration=5
+
+# Get first argument.
+# If not "", Set to git clone URL
+# and clone the git repository
+# If "", then load code from config directory
+if [ ! -z $1 ]; then
+  git_url=$1
+  config_dir=$(echo $git_url | cut -d "/" -f 5 | cut -d "." -f 1)
+  if [ -d "${config_dir}" ]; then
+    echo "removing existing directory ${config_dir}"
+    rm -fr ${config_dir}
+  fi
+  echo "Cloning from git URL ${git_url} into directory ${config_dir}"
+  git clone -q ${git_url}
+else
+  echo "Will take code from config directory."
+  git_url=""
+  config_dir="config"
+fi
+
+# Set workspace if provided as the second argument
+if [ ! -z "$2" ]; then
+  workspace=$2
+  echo "Using workspace provided as argument: " $workspace
+else
+  echo "Using workspace set in the script: " $workspace
+fi
+
+# Make sure $workspace does not have spaces
+if [[ "${workspace}" != "${workspace% *}" ]] ; then
+    echo "The workspace name cannot contain spaces."
+    echo "Please pick a name without spaces and run again."
+    exit
+fi
+
+# Override soft-mandatory policy checks that fail.
+# Set to "yes" or "no" in second argument passed to script.
+# If not specified, then this is set to "no"
+# If not cloning a git repository, set first argument to ""
+if [ ! -z $3 ]; then
+  override=$3
+  echo "override set to ${override} on command line."
+else
+  override="no"
+  echo "override not set on command line. Will not override."
+fi
+
+# build compressed tar file from configuration directory
+echo "Tarring configuration directory."
+tar -czf ${config_dir}.tar.gz -C ${config_dir} --exclude .git .
+
+# Write out workspace.template.json
+cat > workspace.template.json <<EOF
+{
+  "data":
+  {
+    "attributes": {
+      "name":"placeholder",
+      "terraform-version": "1.0.5"
+    },
+    "type":"workspaces"
+  }
+}
+EOF
+
+# Write out configversion.json
+cat > configversion.json <<EOF
+{
+  "data": {
+    "type": "configuration-versions",
+    "attributes": {
+      "auto-queue-runs": false
+    }
+  }
+}
+EOF
+
+# Write out variable.template.json
+cat > variable.template.json <<EOF
+{
+  "data": {
+    "type":"vars",
+    "attributes": {
+      "key":"my-key",
+      "value":"my-value",
+      "category":"my-category",
+      "hcl":my-hcl,
+      "sensitive":my-sensitive
+    }
+  },
+  "filter": {
+    "organization": {
+      "username":"my-organization"
+    },
+    "workspace": {
+      "name":"my-workspace"
+    }
+  }
+}
+EOF
+
+# Write out run.template.json
+cat > run.template.json <<EOF
+{
+  "data": {
+    "attributes": {
+      "is-destroy":false
+    },
+    "type":"runs",
+    "relationships": {
+      "workspace": {
+        "data": {
+          "type": "workspaces",
+          "id": "workspace_id"
+        }
+      }
+    }
+  }
+}
+EOF
+
+# Write out apply.json
+cat > apply.json <<EOF
+{"comment": "apply via API"}
+EOF
+
+#Set name of workspace in workspace.json
+sed "s/placeholder/${workspace}/" < workspace.template.json > workspace.json
+
+# Check to see if the workspace already exists
+echo ""
+echo "Checking to see if workspace exists"
+check_workspace_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/workspaces/${workspace}")
+
+# Parse workspace_id from check_workspace_result
+workspace_id=$(echo $check_workspace_result | jq -r '.data.id')
+echo ""
+echo "Workspace ID: " $workspace_id
+
+# Create workspace if it does not already exist
+if [ "$workspace_id" = "null" ]; then
+  echo ""
+  echo "Workspace did not already exist; will create it."
+  workspace_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --request POST --data @workspace.json "https://${address}/api/v2/organizations/${organization}/workspaces")
+
+  # Parse workspace_id from workspace_result
+  workspace_id=$(echo $workspace_result | jq -r '.data.id')
+  echo ""
+  echo "Workspace ID: " $workspace_id
+else
+  echo ""
+  echo "Workspace already existed."
+fi
+
+# Create configuration version
+echo ""
+echo "Creating configuration version."
+configuration_version_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @configversion.json "https://${address}/api/v2/workspaces/${workspace_id}/configuration-versions")
+
+# Parse configuration_version_id and upload_url
+config_version_id=$(echo $configuration_version_result | jq -r '.data.id')
+upload_url=$(echo $configuration_version_result | jq -r '.data.attributes."upload-url"')
+echo ""
+echo "Config Version ID: " $config_version_id
+echo "Upload URL: " $upload_url
+
+# Upload configuration
+echo ""
+echo "Uploading configuration version using ${config_dir}.tar.gz"
+#curl -s --request PUT -F 'data=@myconfig.tar.gz' "$upload_url"
+curl -s --header "Content-Type: application/octet-stream" --request PUT --data-binary @${config_dir}.tar.gz "$upload_url"
+
+# Check if a variables.csv file is in the configuration directory
+# If so, use it. Otherwise, use the one in the current directory.
+if [ -f "${config_dir}/variables.csv" ]; then
+  echo ""
+  echo "Found variables.csv in ${config_dir}."
+  echo "Will load variables from it."
+  variables_file=${config_dir}/variables.csv
+else
+  echo ""
+  echo "Did not find variables.csv in configuration."
+  echo "Will load variables from ./variables.csv"
+  variables_file=variables.csv
+fi
+
+# Function to process special characters in sed
+escape_string()
+{
+  printf '%s' "$1" | sed -e 's/\([&\]\)/\\\1/g'
+}
+
+sedDelim=$(printf '\001')
+
+# Add variables to workspace
+echo ""
+while IFS=',' read -r key value category hcl sensitive
+do
+  fixedkey=$(escape_string "$key")
+  fixedvalue=$(escape_string "$value")
+  sed -e "s/my-organization/$organization/" -e "s/my-workspace/${workspace}/" -e "s${sedDelim}my-key${sedDelim}$fixedkey${sedDelim}" -e "s${sedDelim}my-value${sedDelim}$fixedvalue${sedDelim}" -e "s/my-category/$category/" -e "s/my-hcl/$hcl/" -e "s/my-sensitive/$sensitive/" < variable.template.json | sed -e 's|\\|\\\\|g' > variable.json
+  echo "Adding variable $key with value $value in category $category with hcl $hcl and sensitive $sensitive"
+  upload_variable_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @variable.json "https://${address}/api/v2/vars?filter%5Borganization%5D%5Bname%5D=${organization}&filter%5Bworkspace%5D%5Bname%5D=${workspace}")
+done < ${variables_file}
+
+# List Sentinel Policy Sets
+sentinel_list_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/policy-sets")
+sentinel_policy_set_count=$(echo $sentinel_list_result | tr '\r\n' ' ' | jq -r '.meta.pagination."total-count"')
+echo ""
+echo "Number of Sentinel policy sets: " $sentinel_policy_set_count
+
+# Do a run
+sed "s/workspace_id/$workspace_id/" < run.template.json  > run.json
+run_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @run.json https://${address}/api/v2/runs)
+
+# Parse run_result
+run_id=$(echo $run_result | jq -r '.data.id')
+echo ""
+echo "Run ID: " $run_id
+
+# Check run result in loop
+continue=1
+while [ $continue -ne 0 ]; do
+  # Sleep
+  sleep $sleep_duration
+  echo ""
+  echo "Checking run status"
+
+  # Check the status of run
+  check_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" https://${address}/api/v2/runs/${run_id})
+
+  # Parse out the run status and is-confirmable
+  run_status=$(echo $check_result | jq -r '.data.attributes.status')
+  echo "Run Status: " $run_status
+  is_confirmable=$(echo $check_result | jq -r '.data.attributes.actions."is-confirmable"')
+  echo "Run can be applied: " $is_confirmable
+
+  # Save plan log in some cases
+  save_plan="false"
+
+  # Apply in some cases
+  applied="false"
+
+  # Run is planning - get the plan
+
+  # planned means plan finished and no Sentinel policy sets
+  # exist or are applicable to the workspace
+  if [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "true" ]] && [[ "$override" == "no" ]]; then
+    continue=0
+    echo ""
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
+    echo "Check the run in Terraform Enterprise UI and apply there if desired."
+    save_plan="true"
+  # cost_estimated means plan finished and costs were estimated
+  # exist or are applicable to the workspace
+  elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "true" ]] && [[ "$override" == "no" ]]; then
+    continue=0
+    echo ""
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
+    echo "Check the run in Terraform Enterprise UI and apply there if desired."
+    save_plan="true"
+  elif [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "true" ]] && [[ "$override" == "yes" ]]; then
+    continue=0
+    echo ""
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
+    echo "Since override was set to \"yes\", we are applying."
+    # Do the apply
+    echo "Doing Apply"
+    apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
+    applied="true"
+  elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "true" ]] && [[ "$override" == "yes" ]]; then
+    continue=0
+    echo ""
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
+    echo "Since override was set to \"yes\", we are applying."
+    # Do the apply
+    echo "Doing Apply"
+    apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
+    applied="true"
+  # policy_checked means all Sentinel policies passed
+  elif [[ "$run_status" == "policy_checked" ]]; then
+    continue=0
+    # Do the apply
+    echo ""
+    echo "Policies passed. Doing Apply"
+    apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
+    applied="true"
+  # policy_override means at least 1 Sentinel policy failed
+  # but since $override is "yes", we will override and then apply
+  elif [[ "$run_status" == "policy_override" ]] && [[ "$override" == "yes" ]]; then
+    continue=0
+    echo ""
+    echo "Some policies failed, but overriding"
+    # Get the policy check ID
+    echo ""
+    echo "Getting policy check ID"
+    policy_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" https://${address}/api/v2/runs/${run_id}/policy-checks)
+    # Parse out the policy check ID
+    policy_check_id=$(echo $policy_result | jq -r '.data[0].id')
+    echo ""
+    echo "Policy Check ID: " $policy_check_id
+    # Override policy
+    echo ""
+    echo "Overriding policy check"
+    override_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --request POST https://${address}/api/v2/policy-checks/${policy_check_id}/actions/override)
+    # Do the apply
+    echo ""
+    echo "Doing Apply"
+    apply_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @apply.json https://${address}/api/v2/runs/${run_id}/actions/apply)
+    applied="true"
+  # policy_override means at least 1 Sentinel policy failed
+  # but since $override is "no", we will not override
+  # and will not apply
+  elif [[ "$run_status" == "policy_override" ]] && [[ "$override" == "no" ]]; then
+    echo ""
+    echo "Some policies failed, but will not override. Check run in Terraform Enterprise UI."
+    save_plan="true"
+    continue=0
+  # errored means that plan had an error or that a hard-mandatory
+  # policy failed
+  elif [[ "$run_status" == "errored" ]]; then
+    echo ""
+    echo "Plan errored or hard-mandatory policy failed"
+    save_plan="true"
+    continue=0
+  elif [[ "$run_status" == "planned_and_finished" ]]; then
+    echo ""
+    echo "Plan indicates no changes to apply."
+    save_plan="true"
+    continue=0
+  elif [[ "run_status" == "canceled" ]]; then
+    echo ""
+    echo "The run was canceled."
+    continue=0
+  elif [[ "run_status" == "force_canceled" ]]; then
+    echo ""
+    echo "The run was canceled forcefully."
+    continue=0
+  elif [[ "run_status" == "discarded" ]]; then
+    echo ""
+    echo "The run was discarded."
+    continue=0
+  else
+    # Sleep and then check status again in next loop
+    echo "We will sleep and try again soon."
+  fi
+done
+
+# Get the plan log if $save_plan is true
+if [[ "$save_plan" == "true" ]]; then
+  echo ""
+  echo "Getting the result of the Terraform Plan."
+  plan_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" https://${address}/api/v2/runs/${run_id}?include=plan)
+  plan_log_url=$(echo $plan_result | jq -r '.included[0].attributes."log-read-url"')
+  echo ""
+  echo "Plan Log:"
+  # Retrieve Plan Log from the URL
+  # and output to shell and file
+  curl -s $plan_log_url | tee ${run_id}.log
+fi
+
+# Get the apply log and state file if an apply was done
+if [[ "$applied" == "true" ]]; then
+
+  echo ""
+  echo "An apply was done."
+  echo "Will download apply log and state file."
+
+  # Get run details including apply information
+  check_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" https://${address}/api/v2/runs/${run_id}?include=apply)
+
+  # Get apply ID
+  apply_id=$(echo $check_result | jq -r '.included[0].id')
+  echo ""
+  echo "Apply ID:" $apply_id
+
+  # Check apply status periodically in loop
+  continue=1
+  while [ $continue -ne 0 ]; do
+
+    sleep $sleep_duration
+    echo ""
+    echo "Checking apply status"
+
+    # Check the apply status
+    check_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" https://${address}/api/v2/applies/${apply_id})
+
+    # Parse out the apply status
+    apply_status=$(echo $check_result | jq -r '.data.attributes.status')
+    echo "Apply Status: ${apply_status}"
+
+    # Decide whether to continue
+    if [[ "$apply_status" == "finished" ]]; then
+      echo "Apply finished."
+      continue=0
+    elif [[ "$apply_status" == "errored" ]]; then
+      echo "Apply errored."
+      continue=0
+    elif [[ "$apply_status" == "canceled" ]]; then
+      echo "Apply was canceled."
+      continue=0
+    else
+      # Sleep and then check apply status again in next loop
+      echo "We will sleep and try again soon."
+    fi
+  done
+
+  # Get apply log URL
+  apply_log_url=$(echo $check_result | jq -r '.data.attributes."log-read-url"')
+  echo ""
+  echo "Apply Log URL:"
+  echo "${apply_log_url}"
+
+  # Retrieve Apply Log from the URL
+  # and output to shell and file
+  echo ""
+  curl -s $apply_log_url | tee ${apply_id}.log
+
+  # Get state version ID from after the apply
+  state_id=$(echo $check_result | jq -r '.data.relationships."state-versions".data[0].id')
+  echo ""
+  echo "State ID:" ${state_id}
+
+  # Call API to get information about the state version including its URL and outputs
+  state_file_url_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" "https://${address}/api/v2/state-versions/${state_id}?include=outputs")
+
+  # Retrieve and echo outputs from state
+  # Note that we retrieved outputs in the last API call by
+  # adding `?include=outputs`
+  # Instead of doing that, we could have retrieved the state version output
+  # IDs from the relationships of the above API call and could have then
+  # called the State Version Output API to retrieve details for each output.
+  # That would have involved URLs like
+  # "https://${address}/api/v2/state-version-outputs/${output_id}"
+  # See `https://www.terraform.io/docs/cloud/api/state-version-outputs.html#show-a-state-version-output`
+  num_outputs=$(echo $state_file_url_result | jq -r '.included | length')
+  echo ""
+  echo "Outputs from State:"
+  for ((output=0;output<$num_outputs;output++))
+  do
+    echo $state_file_url_result | jq -r --arg OUTPUT $output '.included[$OUTPUT|tonumber].attributes'
+  done
+
+  # Get state file URL from the result
+  state_file_url=$(echo $state_file_url_result | jq -r '.data.attributes."hosted-state-download-url"')
+  echo ""
+  echo "URL for state file after apply:"
+  echo ${state_file_url}
+
+  # Retrieve state file from the URL
+  # and output to shell and file
+  echo ""
+  echo "State file after the apply:"
+  curl -s $state_file_url | tee ${apply_id}-after.tfstate
+
+fi
+
+# Remove json files
+rm apply.json
+rm configversion.json
+rm run.template.json
+rm run.json
+rm variable.template.json
+rm variable.json
+rm workspace.template.json
+rm workspace.json
+
+echo "Finished"

--- a/operations/automation-script/loadAndRunWorkspace-python.sh
+++ b/operations/automation-script/loadAndRunWorkspace-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+policy sets#!/bin/bash
 # Script that clones Terraform configuration from a git repository
 # creates a workspace if it does not already exist, uploads the
 # Terraform configuration to it, adds variables to the workspace,
@@ -116,7 +116,7 @@ cat > workspace.template.json <<EOF
   {
     "attributes": {
       "name":"placeholder",
-      "terraform-version": "0.13.6"
+      "terraform-version": "1.0.5"
     },
     "type":"workspaces"
   }
@@ -263,11 +263,11 @@ do
   upload_variable_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --data @variable.json "https://${address}/api/v2/vars?filter%5Borganization%5D%5Bname%5D=${organization}&filter%5Bworkspace%5D%5Bname%5D=${workspace}")
 done < ${variables_file}
 
-# List Sentinel Policies
-sentinel_list_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/policies")
-sentinel_policy_count=$(echo $sentinel_list_result | python -c "import sys, json; print(json.load(sys.stdin)['meta']['pagination']['total-count'])")
+# List Sentinel Policy Sets
+sentinel_list_result=$(curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" "https://${address}/api/v2/organizations/${organization}/policy-sets")
+sentinel_policy_set_count=$(echo $sentinel_list_result | python -c "import sys, json; print(json.load(sys.stdin)['meta']['pagination']['total-count'])")
 echo ""
-echo "Number of Sentinel policies: " $sentinel_policy_count
+echo "Number of Sentinel policy sets: " $sentinel_policy_set_count
 
 # Do a run
 sed "s/workspace_id/$workspace_id/" < run.template.json  > run.json
@@ -305,12 +305,12 @@ while [ $continue -ne 0 ]; do
   # Note that we use "True" rather than "true" because python converts the
   # boolean "true" in json responses to "True" and "false" to "False"
 
-  # planned means plan finished and no Sentinel policies
+  # planned means plan finished and no Sentinel policy sets
   # exist or are applicable to the workspace
   if [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "no" ]]; then
     continue=0
     echo ""
-    echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
     echo "Check the run in Terraform Enterprise UI and apply there if desired."
     save_plan="true"
   # cost_estimated means plan finished and costs were estimated
@@ -318,13 +318,13 @@ while [ $continue -ne 0 ]; do
   elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "no" ]]; then
     continue=0
     echo ""
-    echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
     echo "Check the run in Terraform Enterprise UI and apply there if desired."
     save_plan="true"
   elif [[ "$run_status" == "planned" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "yes" ]]; then
     continue=0
     echo ""
-    echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
     echo "Since override was set to \"yes\", we are applying."
     # Do the apply
     echo "Doing Apply"
@@ -333,7 +333,7 @@ while [ $continue -ne 0 ]; do
   elif [[ "$run_status" == "cost_estimated" ]] && [[ "$is_confirmable" == "True" ]] && [[ "$override" == "yes" ]]; then
     continue=0
     echo ""
-    echo "There are " $sentinel_policy_count "policies, but none of them are applicable to this workspace."
+    echo "There are " $sentinel_policy_set_count "policy sets, but none of them are applicable to this workspace."
     echo "Since override was set to \"yes\", we are applying."
     # Do the apply
     echo "Doing Apply"


### PR DESCRIPTION
I've added a jq version of loadAndRunWorkspace.sh called loadAndRunWorkspace-jq.sh which uses jq instead of python to parse the JSON documents returned by the Terraform Cloud API endpoints. I renamed the original script to loadAndRunWorkspace-python.sh.  I also updated the README.md for the scripts accordingly.  I did this because jq seems more modern than python.  I originally intended to replace python with jq, but then decided to keep the original script and rename it. This way, users have a choice.

I also updated the code that counted Sentinel policies to instead count Sentinel policy sets. This also affects some of the output which now reports how many Sentinel policy sets were found instead of how many policies were found.