### PR TITLE
use pagination in use-latest-module-versions policy

### DIFF
--- a/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.hcl
@@ -6,6 +6,10 @@ param "address" {
   value = "registry.terraform.io"
 }
 
+param "limit" {
+  value = 100
+}
+
 param "organization" {
   value = "Azure"
 }

--- a/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
@@ -11,6 +11,20 @@
 
 # Additionally, this policy uses Sentinel parameters
 
+# The policy supports pagination to get unlimited number of modules from private
+# registries. Since the public registry has a very large number of modules,
+# the policy does not use pagination for it and limits the total number of
+# modules to 100.
+
+# This policy currently uses the /api/registry/v1/modules endpoint for private
+# registries rather than the newer /organizations/:organization_name/registry-modules
+# endpoint that can get both private and publicly curated modules. Note that
+# publically curated modules are not available in TFE. The
+# /organizations/:organization_name/registry-modules endpoint is available
+# in TFE since version v202106-1. We expect to create a version of this policy
+# that will use the new API endpoint but we will keep this policy so that
+# customers on older versions of TFE can still use it.
+
 ##### Imports #####
 
 # Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -28,6 +42,9 @@ import "version"
 param public_registry default false
 # The address of the Terraform Cloud or Terraform Enterprise server
 param address default "app.terraform.io"
+# The limit to use when retrieving modules from a registry
+# This cannot be greater than 100
+param limit default 100
 # The name of the Terraform Cloud or Terraform Enterprise organization
 param organization
 # A valid Terraform Cloud or Terraform Enterprise API token
@@ -36,21 +53,34 @@ param token
 ##### Functions #####
 
 # Retrieve modules from a module registry and give their paths and latest versions
-retrieve_latest_module_versions = func(public_registry, address, organization, token) {
+retrieve_latest_module_versions = func() {
+
+  modules = {}
 
   # Call the TFC Modules API and extract the response
+  # Treat public registry and private registry differently
   if public_registry {
-    # We are limiting the request to 20 verified modules for the
-    # namespace in the public registry matching the organzation parameter
-    req = http.request("https://" + address + "/v1/modules/"  +
-                       organization + "?limit=20&verified=true")
+    modules = get_public_registry_modules()
   } else {
-    req = http.request("https://" + address + "/api/registry/v1/modules/"  +
-                       organization)
-    req = req.with_header("Authorization", "Bearer " + token)
+    # private registry
+    # Pass the empty modules map and offset=0
+    modules = get_private_registry_modules(modules, 0)
   }
+
+  # modules is indexed by <name>/<provider> and contains most recent version
+  return modules
+}
+
+# Get up to `limit` verified modules from the public registry for a namespace
+# But pass the organization parameter
+get_public_registry_modules = func() {
+  req = http.request("https://" + address + "/v1/modules/"  +
+                     namespace + "?limit=" + limit + "&verified=true")
+
+  # Call TFE API to get modules and unmarshal results
   res = json.unmarshal(http.get(req).body)
 
+  # Initialize modules map
   modules = {}
 
   # Iterate over the modules and extract names, providers, and latest versions
@@ -59,18 +89,41 @@ retrieve_latest_module_versions = func(public_registry, address, organization, t
     modules[index] = m.version
   }
 
-  # modules is indexed by <name>/<provider> and contains most recent version
+  return modules
+}
+
+# Get all modules from the private registry by calling itself recursively
+# Start by calling with modules = {}, and offset = 0
+get_private_registry_modules = func(modules, offset) {
+  req = http.request("https://" + address + "/api/registry/v1/modules/"  +
+                    organization + "?limit=" + string(limit) +
+                    "&offset=" + string(offset))
+  req = req.with_header("Authorization", "Bearer " + token)
+
+  # Call TFE API to get modules and unmarshal results
+  res = json.unmarshal(http.get(req).body)
+
+  # Iterate over the modules and extract names, providers, and latest versions
+  for res.modules as m {
+    index = m.namespace + "/" + m.name + "/" + m.provider
+    modules[index] = m.version
+  }
+
+  # Make recursive function call if there are more modules
+  if res.meta.next_offset else 0 > 0 {
+    return get_private_registry_modules(modules, res.meta.next_offset)
+  }
+
   return modules
 }
 
 # Validate sources of modules in the registry
-validate_modules = func(public_registry, address, organization, token) {
+validate_modules = func() {
 
   validated = true
 
   # Get latest module versions from registry
-  discovered_modules = retrieve_latest_module_versions(public_registry, address,
-                       organization, token)
+  discovered_modules = retrieve_latest_module_versions()
 
   # Get all module addresses
   allModuleAddresses = config.find_descendant_modules("")
@@ -128,7 +181,7 @@ validate_modules = func(public_registry, address, organization, token) {
 ##### Rules #####
 
 # Call the validation function
-modules_validated = validate_modules(public_registry, address, organization, token)
+modules_validated = validate_modules()
 
 # Main rule
 main = rule {


### PR DESCRIPTION
We now use pagination to retrieve the latest version from all private modules in the specified private registry (PMR).  We still limit the number of modules from the public registry since we don't think users should really be retrieving all modules from it. But we have increased the limit from 20 to 100.

Note that when retrieving versions of modules from a PMR, the API that is used only retrieves private modules.  It does not yet retrieve publically curated modules that actually live in the public registry but have been cross-referenced in the PMR.  See https://learn.hashicorp.com/tutorials/terraform/module-private-registry-add?in=terraform/modules