### PR TITLE
add use-recent-versions-from-pmr.sentinel

### DIFF
--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -33,7 +33,7 @@ You can find most of the common functions used in the third-generation policies 
   * [tfconfig-functions](./common-functions/tfconfig-functions)
   * [tfrun-functions](./common-functions/tfrun-functions)
 
-There are also some functions that can be used with the AWS and Azure providers in [aws-functions](./aws/aws-functions) and [azure-functions](./azure/azure-functions).
+There are also some functions that can be used with the AWS and Azure providers in [aws-functions](./aws/aws-functions) and [azure-functions](./azure/azure-functions) and some functions that can be used when talking to module registries in [registry-functions](./cloud-agnostic/http-examples/registry-functions).
 
 Unlike the second-generation common functions that were each defined in a separate file, all of the common functions that use any of the 4 Terraform Sentinel imports (tfplan/v2, tfstate/v2, tfconfig/v2, and tfrun) are defined in a single file. This makes it easier to import all of the functions that use one of those imports into the Sentinel CLI test cases and Terraform Cloud policy sets, since those only need a single stanza such as this one for each module:
 ```
@@ -57,8 +57,9 @@ import "tfconfig-functions" as config
 import "tfrun-functions" as run
 import "aws-functions" as aws
 import "azure-functions" as azure
+import "registry-functions" as registry
 ```
-In this case, we are using `plan`, `state`, `config`, `run`, `aws`, and `azure` as aliases for the six imports to keep lines that use their functions shorter. Of course, you only need to import the modules that contain functions that your policy actually calls.
+In this case, we are using `plan`, `state`, `config`, `run`, `aws`, `azure`, and `registry` as aliases for the seven imports to keep lines that use their functions shorter. Of course, you only need to import the modules that contain functions that your policy actually calls.
 
 ### The Functions of the tfplan-functions and tfstate-functions Modules
 We discuss these two modules together because they are essentially identical except for their use of the tfplan/v2 and tfstate/v2 imports.
@@ -109,7 +110,7 @@ Documentation for each individual function can be found in this directory:
   * [tfrun-functions](./common-functions/tfrun-functions/docs)
 
 ### The Functions of the aws-functions Module
-The `aws-functions` module (which is located under in the aws/aws-functions directory) has the following functions:
+The `aws-functions` module (which is located in the aws/aws-functions directory) has the following functions:
   * The `find_resources_with_standard_tags` function finds all AWS resources of specified types that should have tags in the current plan that are not being permanently deleted.
   * The `determine_role_arn` function determines the ARN of a role set in the `role_arn` parameter of an AWS provider. It can only determine the role_arn if it is set to either a hard-coded value or to a reference to a single Terraform variable. It sets the role to "complex" if it finds a single non-variable reference or if it finds multiple references. It sets the role to "none" if no role arn is found.
   * The `get_assumed_roles` function gets all roles assumed by AWS providers in the current Terraform configuration. It calls the `determine_role_arn` function.
@@ -120,11 +121,21 @@ Documentation for each individual function can be found in this directory:
   * [aws-functions](./aws/aws-functions/docs)
 
 ### The Functions of the azure-functions Module
-The `azure-functions` module (which is located under in the azure/azure-functions directory) has the following functions:
+The `azure-functions` module (which is located in the azure/azure-functions directory) has the following functions:
   * The `find_resources_with_standard_tags` function finds all Azure resources of specified types that should have tags in the current plan that are not being permanently deleted.
 
 Documentation for each individual function can be found in this directory:
   * [azure-functions](./azure/azure-functions/docs)
+
+### The Functions of the registry-functions Module
+The `registry-functions` module (which is located in the cloud-agnostic/http-examples/registry-functions directory) has the following functions:
+  * The `get_recent_module_versions` function finds recent versions for private or public modules from a private module registry (PMR).
+  * The `get_recent_module_versions_by_page` function finds recent versions for private or public modules from a private module registry (PMR) one page at a time. It is called by the `get_recent_module_versions` function. Having a separate function that deals with pagination keeps the interface for the `get_recent_module_versions` function cleaner.
+  * The `find_most_recent_version` function finds the most recent versing string from a map of version strings.
+  * The `is_module_in_public_registry` function determines if a module is in the public module registry.
+
+Documentation for each individual function can be found in this directory:
+    * [registry-functions](./cloud-agnostic/http-examples/registry-functions/docs)
 
 ## Mock Files and Test Cases
 Sentinel [mock files](https://www.terraform.io/docs/enterprise/sentinel/mock.html) and [test cases](https://docs.hashicorp.com/sentinel/commands/config#test-cases) have been provided under the test directory of each cloud so that all the policies can be tested with the [Sentinel CLI](https://docs.hashicorp.com/sentinel/commands). The mocks were generated from actual Terraform 0.12 plans run against Terraform code that provisioned resources in these clouds. The pass and fail mock files were edited to respectively pass and fail the associated Sentinel policies. Some policies, including those that have multiple rules, have multiple fail mock files with names that indicate which condition or conditions they fail.

--- a/governance/third-generation/cloud-agnostic/http-examples/README.md
+++ b/governance/third-generation/cloud-agnostic/http-examples/README.md
@@ -4,9 +4,10 @@ This directory contains examples of using the [HTTP import](https://docs.hashico
 Be sure to use Sentinel 0.15.2 or higher with these policies.
 
 ## Policies
-There are currently three example policies in this directory:
+There are currently four example policies in this directory:
 * [check-external-http-api.sentinel](./check-external-http-api.sentinel)
 * [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel)
+* [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel)
 * [asteroids.sentinel](./asteroids.sentinel)
 
 The first policy simply uses the HTTP import to call an external API, https://yesno.wtf/api that randomly returns "yes" or "no" (but sometimes returns "maybe"). It also uses the recently added [case statement](https://docs.hashicorp.com/sentinel/language/spec/#case-statements) that provides a selection control mechanism to conditionally execute different logic based on the value of an argument.
@@ -16,13 +17,22 @@ You can test the first policy from this directory (after forking or cloning the 
 sentinel test -run=check -verbose
 ```
 
-The second policy uses the HTTP import to call the Terraform Registry [List Modules API](https://www.terraform.io/docs/registry/api.html#list-modules) against a Terraform Cloud or Terraform Enterprise server in order to determine the most recent version of each module in the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of an organization on that server or in the [public Terraform registry](https://registry.terraform.io). It then checks that the version constraints used in module calls allow the most recent version. This policy also uses parameters as described below.
+The second policy uses the HTTP import to call the Terraform Registry [List Modules API](https://www.terraform.io/docs/registry/api.html#list-modules) endpoint (`/api/registry/v1/modules`) against a Terraform Cloud or Terraform Enterprise server in order to determine the most recent version of each private module in the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of an organization on that server or in the [public Terraform registry](https://registry.terraform.io). It then checks that the version constraints used in module calls allow the most recent version. Note that this policy does not process publicly curated modules added to a private module registry; but the third policy does. It also does not yet support processing modules from multiple organizations.
 
-Since 9/6/2021, the second policy can retrieve versions of all private modules in a PMR since it uses pagination to keep calling the List Modules API. However, the policy limits the number of modules retrieved from the public registry to 100.
+Since 9/6/2021, the second policy retrieves versions of all private modules in a PMR since it uses pagination to keep calling the List Modules API. However, the policy limits the number of modules retrieved from the public registry to 100.
 
-This policy currently uses the `/api/registry/v1/modules` endpoint for private registries rather than the newer `/organizations/:organization_name/registry-modules` endpoint that can get both private and publicly curated modules. Note that publically curated modules are not available in TFE. The `/organizations/:organization_name/registry-modules` API endpoint is available in TFE since version v202106-1. We expect to create a version of this policy that will use the new API endpoint but we will keep this policy so that customers on older versions of TFE can still use it.
+The second policy uses the `/api/registry/v1/modules` endpoint for private registries rather than the newer `/organizations/:organization_name/registry-modules` endpoint that can get both private and publicly curated modules. Note that publicly curated modules are not available in TFE. The `/organizations/:organization_name/registry-modules` API endpoint is available in TFE since version v202106-1.
 
-The third policy uses the HTTP import to call a [NASA API](https://api.nasa.gov/) that retrieves a list of Near Earth Objects and warns if any of them are too close for comfort. This is based on an example from this HashiCorp [blog](https://www.hashicorp.com/blog/announcing-business-aware-policies-for-terraform-cloud-and-enterprise/) that announced the HTTP import and "Business-aware Policies". This policy also uses parameters as described below.
+The third policy uses the HTTP import to call the newer [List Registry Modules API](https://www.terraform.io/docs/cloud/api/modules.html#list-registry-modules-for-an-organization) endpoint(`/organizations/:organization_name/registry-modules`) of Terraform Cloud that can get both private and publicly curated modules.
+
+This policy requires the Sentinel runtime 0.16.0 or higher since the registry-functions module it calls uses the Sentinel [version](https://docs.hashicorp.com/sentinel/imports/version) import. It requires TFE release v202106-1 or higher if using TFE instead of TFC.
+
+Note that publicly curated modules are not available in TFE.
+
+The fourth policy uses the HTTP import to call a [NASA API](https://api.nasa.gov/) that retrieves a list of Near Earth Objects and warns if any of them are too close for comfort. This is based on an example from this HashiCorp [blog](https://www.hashicorp.com/blog/announcing-business-aware-policies-for-terraform-cloud-and-enterprise/) that announced the HTTP import and "Business-aware Policies". This policy also uses parameters as described below.
+
+## The `registry-functions` Module
+The [registry-functions.sentinel](./registry-function/registry-functions.sentinel) module contains some Sentinel functions used by the [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel) policy. These functions could also be used by other policies in the future.
 
 ## Use of Parameters in use-latest-module-versions.sentinel
 The [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel) policy uses five parameters:
@@ -31,6 +41,13 @@ The [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel)
 * `limit` gives the maximum number of modules to retrieve in a single call to the List Modules API endpoint. It defaults to `100` which is the maximum value that can be set.
 * `organization` gives the name of an [organization](https://www.terraform.io/docs/cloud/users-teams-organizations/organizations.html) on the Terraform Cloud or Terraform Enterprise server specified by `address`. You must always specify a valid organization.
 * `token` gives a valid Terraform Cloud API token which can be a user, team, or organization token. See the [API tokens](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html) document for more information.
+
+## Use of Parameters in use-recent-versions-from-pmr.sentinel
+The [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel) policy uses four parameters:
+* `address` gives the address of the Terraform Cloud or Terraform Enterprise server.  It defaults to `app.terraform.io` which is the address of the multi-tenant Terraform Cloud server that HashiCorp runs. You must specify a value for this if using a Terraform Enterprise server.
+* `organizations` gives the names of one or more [organizations](https://www.terraform.io/docs/cloud/users-teams-organizations/organizations.html) on the Terraform Cloud or Terraform Enterprise server specified by `address`. You must always specify at least one valid organization.
+* `token` gives a valid Terraform Cloud API token which can be a user, team, or organization token. See the [API tokens](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html) document for more information.
+* `version_limit` gives the number of most recent versions to retrieve for each module.
 
 ## Use of Parameters in asteroids.sentinel
 The [asteroids.sentinel](./asteroids.sentinel) policy uses two parameters:
@@ -42,9 +59,9 @@ Before you can test asteroids.sentinel with the provided test cases and mocks, y
 ## Using Parameters with the Sentinel CLI
 While parameters can currently be set with environment variables when using the `sentinel apply` command, they cannot be set with environment variables when using the `sentinel test` command.
 
-Consequently, you **cannot** test the use-latest-module-versions.sentinel policy with the `sentinel test` command using the provided test cases and mocks since you will not have a token allowed to call the API against the specified Cloud-Operations organization.
+Consequently, you **cannot** test the use-latest-module-versions.sentinel or use-recent-versions-from-pmr.sentinel policies with the `sentinel test` command using the provided test cases and mocks since you will not have a token allowed to call the API against the specified Cloud-Operations organization.
 
-You could test the policy with the `sentinel test` command if you edited the mocks to reference modules contained in a PMR in an organization on your own TFC or TFE organization or contained in the public registry and added your own valid API token to the test cases.
+You could test the policies with the `sentinel test` command if you edited the mocks to reference modules contained in a PMR in an organization on your own TFC or TFE organization or contained in the public registry and added your own valid API token to the test cases.
 
 Since many readers won't have modules in their own TFC/TFE organization, we have provided a [use-latest-module-versions.hcl](./use-latest-module-versions.hcl) Sentinel configuration file and an additional mock file [mocks/mock-tfconfig-fail.sentinel](./mocks/mock-tfconfig-fail.sentinel) that references modules from the [public Terraform registry](https://registry.terraform.io). These allow you to run the `sentinel apply` command to use the use-latest-module-versions.sentinel policy.  
 
@@ -54,23 +71,25 @@ sentinel apply -trace -config=use-latest-module-versions.hcl use-latest-module-v
 ```
 You do not need a token when talking to the public registry, so the use-latest-module-versions.hcl file sets `token` to an empty string.
 
-The policy should fail since the mock does not use or allow the most recent versions of the two modules. If you would like to see the policy pass, change the versions of the modules in mocks/mock-tfconfig-fail.sentinel to the most recent versions listed under https://registry.terraform.io/modules/Azure/network/azurerm and https://registry.terraform.io/modules/Azure/compute/azurerm. Currently, those are "3.3.0" and "3.11.0" respectively.
+The policy should fail since the mock does not use or allow the most recent versions of the two modules. If you would like to see the policy pass, change the versions of the modules in mocks/mock-tfconfig-fail.sentinel to the most recent versions listed under https://registry.terraform.io/modules/Azure/network/azurerm and https://registry.terraform.io/modules/Azure/compute/azurerm. Currently, those are "3.5.0" and "3.14.0" respectively.
 
-Note that the `sentinel test` and `sentinel apply` commands for testing/applying the use-latest-module-versions.sentinel policy **really** are making HTTP calls to the API endpoints to retrieve the list of matching modules in the registries. However, the mocks simulate which modules would actually be used by Terraform code.
+Note that the `sentinel test` and `sentinel apply` commands for testing/applying the use-latest-module-versions.sentinel and use-recent-versions-from-pmr.sentinel policies **really** are making HTTP calls to the API endpoints to retrieve the list of matching modules in the registries. However, the mocks simulate which modules would actually be used by Terraform code.
 
 You should **not** edit use-latest-module-versions.hcl unless you also edit mocks/mock-tfconfig-fail.sentinel to reference actual modules in the registry and organization that use-latest-module-versions.hcl refers to.
 
+Unfortunately, since the use-recent-versions-from-pmr.sentinel policy only processes modules from private module registries and needs a valid TFC/E API token, we cannot provide an HCL file to allow you to use `sentinel apply` with it against the public registry.
+
 ## Using Parameters with Terraform Cloud/Enterprise
-If you wish to use the [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel) policy on a Terraform Cloud (TFC) or Terraform Enterprise (TFE) server, you need to specify values for the `organization` and `token` parameters when registering the policy set that contains this policy. Only do this if you have actually created some modules in the Private Module Registry (PMR) in an organization on your server and have Terraform code that uses them.
+If you wish to use the [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel) and [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel) policies on a Terraform Cloud (TFC) or Terraform Enterprise (TFE) server, you need to specify values for the `organization`, `organizations`, and `token` parameters when registering the policy set that contains these policies. Only do this if you have actually created some modules in the Private Module Registry (PMR) in one or more organizations on your server and have Terraform code that uses them.
 
 You can do this as follows:
-1. Copy the files [check-external-http-api.sentinel](./check-external-http-api.sentinel), [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel), and [sentinel.hcl](./sentinel.hcl) into a VCS repository. (Don't copy the file use-latest-module-versions.hcl which is only for use with the Sentinel CLI.)
-1. Optionally edit the copy of sentinel.hcl to set the enforcement_level for the use-latest-module-versions policy to `soft-mandatory`.
+1. Copy the files [check-external-http-api.sentinel](./check-external-http-api.sentinel), [use-latest-module-versions.sentinel](./use-latest-module-versions.sentinel), [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel), and [sentinel.hcl](./sentinel.hcl) into a VCS repository. (Don't copy the file use-latest-module-versions.hcl which is only for use with the Sentinel CLI.)
+1. Optionally edit the copy of sentinel.hcl to set the enforcement_level for the use-latest-module-versions and use-recent-versions-from-pmr.sentinel policies to `soft-mandatory`.
 1. Commit the files to your VCS repository.
 1. [Register a new policy set](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#managing-policy-sets) on your Terraform Cloud or Terraform Enterprise server.
-1. Edit the registered policy sets to specify values for the `organization` and `token` parameters making sure you pick an organization that actually has some modules in its PMR and that the token you give is a valid API token with permission in that organization. (You cannot specify parameters until after creating the policy set.) Parameters are added at the bottom of the Policy Set screen.
+1. Edit the registered policy sets to specify values for the `organization`, `organizations`, and `token` parameters making sure you pick organizations that actually have some modules in their PMRs and that the token you give is a valid API token with permission in these organizations. (You cannot specify parameters until after creating the policy set.) Parameters are added at the bottom of the Policy Set screen.
 1. Be sure to mark your `token` parameter as sensitive so that nobody else can see it in the Terraform Cloud UI.
 1. If using a Terraform Enterprise server, also specify a value for the `address` parameter, using a value like "tfe.example.com".
 1. Save the policy set.
-1. Add a workspace to the policy set that uses Terraform code that references modules in the PMR in the organization you specified.
+1. Add a workspace to the policy set that uses Terraform code that references modules in the PMRs in the organizations you specified.
 1. Queue a plan against that workspace in the Terraform Cloud UI.

--- a/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/find_most_recent_version.md
+++ b/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/find_most_recent_version.md
@@ -1,0 +1,50 @@
+# find_most_recent_version
+This function finds the most recent version from a map of version strings. The `versions` parameter should contain strings, not actual versions from the version import. The keys of the map should be integers ranging from 0 to N-1 where the map has N versions.
+
+It is needed since lists of versions returned by the [Registry Modules API](https://www.terraform.io/docs/cloud/api/modules.html) endpoints are not ordered.
+
+Passing a map instead of a list makes it easier to delete items from the map, allowing us to call this function multiple times to find the X most recent versions.
+
+## Sentinel Module
+This function is contained in the [registry-functions.sentinel](../registry-functions.sentinel) module.
+
+## Declaration
+`find_most_recent_version = func(versions_map)`
+
+## Arguments
+* **versions_map**: the list or map of version strings.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a map with one key/value pair. The key will be the index of the map that had the most recent version while the value will be that version string.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function:
+```
+# Build versions map from versions returned from call to URL like
+# "https://" + address + "/api/registry/v1/modules/" + module + "/versions"
+versions = res2.modules[0].versions
+versions_map = {}
+for versions as index, v {
+  versions_map[index] = v.version
+}
+
+# Extract most recent versions and add to module_versions
+module_versions[module] = []
+for range(version_limit) as rank {
+  if length(versions_map) > 0 {
+    most_recent_version = find_most_recent_version(versions_map)
+    for most_recent_version as index, v {
+      append(module_versions[module], most_recent_version[index])
+      delete(versions_map, keys(most_recent_version)[0])
+    }
+  }
+}
+```
+
+This function is called by the [get_recent_module_versions_by_page](./get_recent_module_versions_by_page.md) function contained in the same Sentinel module. In fact, the above code is extracted from that function. Since the two functions are in the same module, the call to the `find_most_recent_version` function does not include a prefix like `registry` to indicate which module the function is in. But if you were calling it from a policy, you would probably import it with alias `registry` and then call it with `registry.find_most_recent_version(versions_map)`.

--- a/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/get_recent_module_versions.md
+++ b/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/get_recent_module_versions.md
@@ -1,0 +1,42 @@
+# get_recent_module_versions
+This function gets recent versions for private or public modules from a private module registry (PMR). It calls the `get_recent_module_versions_by_page` function which gets those versions one page at a time. It has the same arguments as that function except for the `page` argument.
+
+## Sentinel Module
+This function is contained in the [registry-functions.sentinel](../registry-functions.sentinel) module.
+
+## Declaration
+`get_recent_module_versions = func(address, organization, token,
+                                   registry, version_limit)`
+
+## Arguments
+* **address**: the address of the Terraform Cloud (TFC) or Terraform Enterprise (TFE) server that contains organization that contains the PMR. Use "app.terraform.io" for Terraform Cloud.
+* **organization**: the name of your TFC or TFE organization that contains the PMR.
+* **token**: a valid TFC/E API token for calling the TFC/E API on your TFC or TFE server.
+* **registry**: a string set to "public" or "private". Use "public" if you want to retrieve recent versions for publicly curated modules which are modules in the public Terraform registry made available through a PMR. Use "private" for private modules contained in the PMR. We need this because the API endpoints for private and public modules are different.
+* **version_limit**: an integer giving the number of most recent versions you want to retrieve for each module.
+
+
+## Common Functions Used
+This function calls the [get_recent_module_versions_by_page](./get_recent_module_versions_by_page.md) function.
+
+## What It Returns
+This function returns a map indexed by the namespace/organization, name, and provider of the module with values set to lists of the `version_limit` most recent versions for each module.
+
+## What It Prints
+This function does not print anything.
+
+## Example
+Here is an example of calling this function:
+```
+# Invoke get_public_modules function with empty map and page 1
+newest_public_module_versions = get_recent_module_versions(address, organization,
+                                token, "public", version_limit)
+print("newest public module versions:", newest_public_module_versions)
+
+# Invoke get_private_modules function with empty map and page 1
+newest_private_module_versions = get_recent_module_versions(address, organization,
+                                token, "private", version_limit)
+print("newest private module versions:", newest_private_module_versions)
+```
+
+The above code is from the [use-recent-versions-from-pmr.sentinel](../../use-recent-versions-from-pmr.sentinel) policy which requires that all private and publicly curated modules use the `version_limit` most recent versions of the module.

--- a/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/get_recent_module_versions_by_page.md
+++ b/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/get_recent_module_versions_by_page.md
@@ -1,0 +1,40 @@
+# get_recent_module_versions_by_page
+This function gets recent versions for private or public modules from a private module registry (PMR) one page at a time. It is called by the [get_recent_module_versions](./get_recent_module_versions.md) function.
+
+It calls itself recursively, incrementing the `page` parameter by one until there are no more pages. We use two separate functions to keep the public interface of the `get_recent_module_versions` function cleaner.
+
+## Sentinel Module
+This function is contained in the [registry-functions.sentinel](../registry-functions.sentinel) module.
+
+## Declaration
+`get_recent_module_versions_by_page = func(address, organization, token,
+                                           registry, version_limit, page)`
+
+## Arguments
+* **address**: the address of the Terraform Cloud (TFC) or Terraform Enterprise (TFE) server that contains organization that contains the PMR. Use "app.terraform.io" for Terraform Cloud.
+* **organization**: the name of your TFC or TFE organization that contains the PMR.
+* **token**: a valid TFC/E API token for calling the TFC/E API on your TFC or TFE server.
+* **registry**: a string set to "public" or "private". Use "public" if you want to retrieve recent versions for publicly curated modules which are modules in the public Terraform registry made available through a PMR. Use "private" for private modules contained in the PMR. We need this because the API endpoints for private and public modules are different.
+* **version_limit**: an integer giving the number of most recent versions you want to retrieve for each module.
+* **page**: an integer indicating the page of results to return.  This should always be set to `1` except by the function itself when calling itself recursively.
+
+## Common Functions Used
+This function calls the [find_most_recent_version](./find_most_recent_version.md) function.
+
+## What It Returns
+This function returns a map indexed by the namespace/organization, name, and provider of the module with values set to lists of the `version_limit` most recent versions for each module.
+
+## What It Prints
+This function does not print anything.
+
+## Example
+Here is an example of calling this function:
+```
+get_recent_module_versions = func(address, organization, token,
+                                  registry, version_limit) {
+  return get_recent_module_versions_by_page(address, organization, token,
+                                    registry, version_limit, 1)
+}
+```
+
+This function is called by the [get_recent_module_versions](./get_recent_module_versions.md) function contained in the same Sentinel module. In fact, the above code shows the entire definition of that function. As indicated above, it calls this function with the `page` parameter set to `1`. But the code of `get_recent_module_versions_by_page` then invokes itself with the `page` parameter set to higher page numbers. Since the two functions are in the same module, the call to the `get_recent_module_versions_by_page` function does not include a prefix like `registry` to indicate which module the function is in.

--- a/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/is_module_in_public_registry.md
+++ b/governance/third-generation/cloud-agnostic/http-examples/registry-functions/docs/is_module_in_public_registry.md
@@ -1,0 +1,34 @@
+# is_module_in_public_registry
+This function determines if a module is in the public registry.
+
+## Sentinel Module
+This function is contained in the [registry-functions.sentinel](../registry-functions.sentinel) module.
+
+## Declaration
+`is_module_in_public_registry = func(module)`
+
+## Arguments
+* **module**: the source of a module call.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a boolean that is `true` if the module was found in the public registry and `false` if it was not.
+
+## What It Prints
+This function does not print anything.
+
+## Example
+Here is an example of calling this function assuming that the `registry-functions` module has been imported with alias `registry`:
+```
+source_wo_subs = strings.split(m.source, "//")[0]
+uncurated_public_module =
+  registry.is_module_in_public_registry(source_wo_subs)
+if uncurated_public_module {
+  print("Uncurated public registry module", m.source, "is not allowed.")
+  validated = false
+}
+```
+
+This function is called by the [use-recent-versions-from-pmr.sentinel](../../use-recent-versions-from-pmr.sentinel) policy. In fact, the above code is based on code from that policy. 

--- a/governance/third-generation/cloud-agnostic/http-examples/registry-functions/registry-functions.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/registry-functions/registry-functions.sentinel
@@ -1,0 +1,143 @@
+# Functions to retrive public and private modules from a private module registry
+# and determine recent versions
+
+##### Imports #####
+import "http"
+import "json"
+import "version"
+
+##### Functions #####
+
+### get_recent_module_versions ###
+# Get recent versions for private or public modules from private module registry
+# Pass the address of the TFC/E server, the organization, and a TFE API token.
+# Set `registry` to "public" or "private".
+# Set `version_limit` to the number of most recent versions to get for each
+# module.
+# This function calls `get_recent_module_versions_by_page` (which has the same
+# arguments plus `page`) one or more times, depending on whether there are more
+# than one page of modules.
+get_recent_module_versions = func(address, organization, token,
+                                  registry, version_limit) {
+  return get_recent_module_versions_by_page(address, organization, token,
+                                    registry, version_limit, 1)
+}
+
+### get_recent_module_versions_by_page ###
+# Get recent versions for private or public modules from private module registry
+# one page at a time.
+# This uses the same arguments as `get_recent_module_versions` plus `page`
+get_recent_module_versions_by_page = func(address, organization, token,
+                                  registry, version_limit, page) {
+
+  # Build request to send to Registry Modules API
+  req1 = http.request("https://" + address + "/api/v2/organizations/"  +
+                     organization +
+                     "/registry-modules?filter%5Bregistry_name%5D=" + registry +
+                     "&page%5Bsize%5D=100" +
+                     "&page%5Bnumber%5D=" + string(page))
+  req1 = req1.with_header("Authorization", "Bearer " + token)
+
+  # Call TFE API to get modules and unmarshal results
+  res1 = json.unmarshal(http.get(req1).body)
+
+  # Initialize module_versions to empty map
+  module_versions = {}
+
+  # Make recursive function call if there are more pages of modules
+  if res1.meta.pagination["current-page"] < res1.meta.pagination["total-pages"] {
+    module_versions = get_recent_module_versions_by_page(address, organization,
+              token, registry, version_limit, res1.meta.pagination["next-page"])
+  }
+
+  # Iterate over the modules and extract namespaces, names, and providers
+  for res1.data as m {
+    module = m.attributes.namespace + "/" + m.attributes.name + "/" +
+             m.attributes.provider
+
+    # Get versions for current module
+    if registry is "public" {
+      req2 = http.request("https://" + address +
+                          "/api/registry/public/v1/modules/" + module + "/versions")
+      req2 = req2.with_header("Authorization", "Bearer " + token)
+    } else {
+      # registry is private
+      req2 = http.request("https://" + address + "/api/registry/v1/modules/" +
+                          module + "/versions")
+      req2 = req2.with_header("Authorization", "Bearer " + token)
+    }
+
+    # Call Registry API to get module versions
+    res2 = json.unmarshal(http.get(req2).body)
+
+    # Build versions map
+    versions = res2.modules[0].versions
+    versions_map = {}
+    for versions as index, v {
+      versions_map[index] = v.version
+    }
+
+    # Extract most recent versions and add to module_versions
+    module_versions[module] = []
+    for range(version_limit) as rank {
+      if length(versions_map) > 0 {
+        most_recent_version = find_most_recent_version(versions_map)
+        for most_recent_version as index, v {
+          append(module_versions[module], most_recent_version[index])
+          delete(versions_map, keys(most_recent_version)[0])
+        } // end for most_recent_version
+      } // end if length(versions_map) > 0
+    } // end for range(version_limit)
+
+  } // end for res1.data
+
+  # Return recent module versions
+  return module_versions
+}
+
+### find_most_recent_version ###
+# Finds the most recent version from a map of version strings.
+# The `versions_map` parameter should contain strings, not actual versions
+# from the version import.
+# The keys of the map should be integers ranging from 0 to N-1
+# where the map has N versions.
+find_most_recent_version = func(versions_map) {
+
+  # Initialize newest_version to first version of map
+  newest_index = 0
+  newest_version = "0.0.0"
+
+  # Iterate over versions, looking for newer versions
+  for versions_map as index, v {
+    if version.new(v).greater_than(newest_version) {
+      newest_index = index
+      newest_version = versions_map[index]
+    }
+  }
+
+  # Return newest version including index
+  return {newest_index: newest_version}
+}
+
+### is_module_in_public_registry ###
+# Determine if a module is in the public registry.
+# The `module` parameter is derived from the m.source of a module call.
+is_module_in_public_registry = func(module) {
+
+  # Build URL to call public registry API
+  req = http.request("https://registry.terraform.io/v1/modules/"  +
+                     module)
+
+  # Call public registry API to get modules and unmarshal results
+  # If we get undefined from the http call, we convert it to a
+  # trivial json document.
+  res = json.unmarshal(http.accept_status_codes([200, 403, 404]).get(req).body) else {"public": false}
+
+  # Extract latest version
+  if "name" in keys(res) {
+    return true
+  } else {
+    return false
+  }
+
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/sentinel.hcl
@@ -2,6 +2,10 @@ module "tfconfig-functions" {
     source = "../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
 }
 
+module "registry-functions" {
+    source = "./registry-functions/registry-functions.sentinel"
+}
+
 policy "check-external-http-api" {
     source = "./check-external-http-api.sentinel"
     enforcement_level = "advisory"
@@ -9,5 +13,10 @@ policy "check-external-http-api" {
 
 policy "use-latest-module-versions" {
     source = "./use-latest-module-versions.sentinel"
+    enforcement_level = "advisory"
+}
+
+policy "use-recent-versions-from-pmr.sentinel" {
+    source = "./use-recent-versions-from-pmr.sentinel"
     enforcement_level = "advisory"
 }

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-organization.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-organization.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-invalid-organization.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-private-version-constraint.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-private-version-constraint.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-invalid-private-version-constraint.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-public-version-constraint.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-public-version-constraint.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-invalid-public-version-constraint.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-version-number.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-invalid-version-number.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-invalid-version-number.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-non-registry-module.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-non-registry-module.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-non-registry-module.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-uncurated-public-module.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/fail-uncurated-public-module.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-fail-uncurated-public-module.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-organization.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-organization.sentinel
@@ -1,0 +1,51 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/Cloud-Ops/network/azurerm",
+		"version_constraint": "1.5.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-private-version-constraint.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-private-version-constraint.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": ">= 2.0.0, < 3.0.0",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": ">= 1.0.0, <= 1.1.5",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": "<= 3.0.0",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": "<= 1.1.5",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-public-version-constraint.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-public-version-constraint.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "Azure/network/azurerm",
+		"version_constraint": ">= 2.0.0, < 3.0.0",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "Azure/compute/azurerm",
+		"version_constraint": ">= 1.0.0, <= 1.1.5",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "Azure/network/azurerm",
+		"version_constraint": "<= 3.0.0",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "Azure/compute/azurerm",
+		"version_constraint": "<= 1.1.5",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-version-number.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-invalid-version-number.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": "1.1.1",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "app.terraform.io/Cloud-Operations/network/google//modules/routes",
+		"version_constraint": "2.0.2",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "terraform-aws-modules/vpc/aws//modules/vpc-endpoints",
+		"version_constraint": "3.4.0",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": "1.1.5",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-non-registry-module.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-non-registry-module.sentinel
@@ -1,0 +1,51 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "example",
+		"source":             "git@github.com:hashicorp/example.git",
+		"version_constraint": "1.5.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-uncurated-public-module.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-fail-uncurated-public-module.sentinel
@@ -1,0 +1,51 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "eks",
+		"source":             "terraform-aws-modules/eks/aws",
+		"version_constraint": "17.18.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-no-pmr-modules.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-no-pmr-modules.sentinel
@@ -1,0 +1,79 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "./windows-server",
+		"version_constraint": "",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-shared-org.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-shared-org.sentinel
@@ -1,0 +1,102 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/CarolBerlind/network/azurerm",
+		"version_constraint": "3.2.1",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "app.terraform.io/CarolBerlind/compute/azurerm",
+		"version_constraint": "1.1.6",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-private-constraints.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-private-constraints.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": "> 3.0.0",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": "< 2.0.0",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": ">= 2.0.0, <= 3.2.1",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": "> 1.1.5",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-public-constraints.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-public-constraints.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "Azure/network/azurerm",
+		"version_constraint": "> 3.0.0",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "Azure/compute/azurerm",
+		"version_constraint": "< 3.15.0",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "Azure/network/azurerm",
+		"version_constraint": ">= 2.0.0, <= 3.6.0",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "Azure/compute/azurerm",
+		"version_constraint": "> 3.12.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-versions.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/mock-tfconfig-pass-valid-versions.sentinel
@@ -1,0 +1,176 @@
+import "strings"
+
+module_calls = {
+	"module.windowsserver:os": {
+		"config": {
+			"vm_os_simple": {
+				"references": [
+					"var.vm_os_simple",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.windowsserver",
+		"name":               "os",
+		"source":             "./os",
+		"version_constraint": "",
+	},
+	"network": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "network",
+		"source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+		"version_constraint": "3.2.1",
+	},
+	"windowsserver": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "windowsserver",
+		"source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+		"version_constraint": "1.1.6",
+	},
+	"module.network:network2": {
+		"config": {
+			"allow_ssh_traffic": {
+				"constant_value": true,
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "network2",
+		"source":             "terraform-aws-modules/vpc/aws//modules/vpc-endpoints",
+		"version_constraint": "3.7.0",
+	},
+	"module.network:windowsserver2": {
+		"config": {
+			"admin_password": {
+				"references": [
+					"var.admin_password",
+				],
+			},
+			"location": {
+				"references": [
+					"var.location",
+				],
+			},
+			"public_ip_dns": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"resource_group_name": {
+				"references": [
+					"var.windows_dns_prefix",
+				],
+			},
+			"storage_account_type": {
+				"references": [
+					"var.storage_account_type",
+				],
+			},
+			"vm_hostname": {
+				"constant_value": "demohost",
+			},
+			"vm_os_simple": {
+				"constant_value": "WindowsServer",
+			},
+			"vm_size": {
+				"references": [
+					"var.vm_size",
+				],
+			},
+			"vnet_subnet_id": {
+				"references": [
+					"module.network.vnet_subnets",
+				],
+			},
+		},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "module.network",
+		"name":               "windowsserver2",
+		"source":             "app.terraform.io/Cloud-Operations/network/google//modules/routes",
+		"version_constraint": "2.4.0",
+	},
+}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-no-pmr-modules.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-no-pmr-modules.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-no-pmr-modules.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-shared-org.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-shared-org.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-shared-org.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-private-constraints.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-private-constraints.hcl
@@ -1,0 +1,34 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-valid-private-constraints.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-public-constraints.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-public-constraints.hcl
@@ -1,0 +1,34 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-valid-public-constraints.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-versions.hcl
+++ b/governance/third-generation/cloud-agnostic/http-examples/test/use-recent-versions-from-pmr/pass-valid-versions.hcl
@@ -1,0 +1,35 @@
+param "address" {
+  value = "app.terraform.io"
+}
+
+param "organizations" {
+  value = ["Cloud-Operations", "CarolBerlind"]
+}
+
+param "token" {
+  value = ""
+}
+
+param "version_limit" {
+  value = 3
+}
+
+module "registry-functions" {
+      source = "../../registry-functions/registry-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+      source = "../../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+mock "tfconfig/v2" {
+  module {
+    source = "mock-tfconfig-pass-valid-versions.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/use-latest-module-versions.sentinel
@@ -6,24 +6,29 @@
 # the most recent version allowed by a version constraint, this ensures that
 # the most recent version of the module will be used.
 
-# Note that this policy requires the Sentinel runtime 0.16.0 or higher since it
+# This policy does not prevent use of non-versioned modules from other
+# sources such as local modules, GitHub, Bitbucket, etc. If you want to ensure
+# that all non-root modules come from your private module registry (PMR) use the
+# policy [require-all-resources-from-pmr.sentinel](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel).
+
+# This policy requires the Sentinel runtime 0.16.0 or higher since it
 # uses the Sentinel [version](https://docs.hashicorp.com/sentinel/imports/version) import.
 
-# Additionally, this policy uses Sentinel parameters
-
-# The policy supports pagination to get unlimited number of modules from private
+# This policy supports pagination to get unlimited number of modules from private
 # registries. Since the public registry has a very large number of modules,
 # the policy does not use pagination for it and limits the total number of
 # modules to 100.
 
-# This policy currently uses the /api/registry/v1/modules endpoint for private
+# This policy uses the /api/registry/v1/modules endpoint for private
 # registries rather than the newer /organizations/:organization_name/registry-modules
-# endpoint that can get both private and publicly curated modules. Note that
-# publically curated modules are not available in TFE. The
-# /organizations/:organization_name/registry-modules endpoint is available
-# in TFE since version v202106-1. We expect to create a version of this policy
-# that will use the new API endpoint but we will keep this policy so that
-# customers on older versions of TFE can still use it.
+# endpoint that can get both private and publicly curated modules. If you want
+# to restrict private and publicly curated modules from your PMR, use the
+# [use-recent-versions-from-pmr.sentinel](./use-recent-versions-from-pmr.sentinel)
+# policy. That policy supports restricting versions to the N most recent versions
+# where N is a policy parameter.
+
+# This policy needs modification to support calls to modules in other
+# organizations on the same TFE server.
 
 ##### Imports #####
 
@@ -75,7 +80,7 @@ retrieve_latest_module_versions = func() {
 # But pass the organization parameter
 get_public_registry_modules = func() {
   req = http.request("https://" + address + "/v1/modules/"  +
-                     namespace + "?limit=" + limit + "&verified=true")
+                     organization + "?limit=" + limit + "&verified=true")
 
   # Call TFE API to get modules and unmarshal results
   res = json.unmarshal(http.get(req).body)
@@ -127,7 +132,6 @@ validate_modules = func() {
 
   # Get all module addresses
   allModuleAddresses = config.find_descendant_modules("")
-  #print("Module addresses:", allModuleAddresses)
 
   # Iterate over all modules in the tfconfig/v2 import
   for allModuleAddresses as module_address {
@@ -137,7 +141,11 @@ validate_modules = func() {
       # Check if module is in the PMR
       if strings.has_prefix(m.source, address + "/" + organization) {
         # Check version constraint of module against latest version in PMR
-        org_name_provider = strings.trim_prefix(m.source, address + "/")
+        source_without_address = strings.trim_prefix(m.source, address + "/")
+        # Support nested modules with sources like
+        # app.terraform.io/Cloud-Operations/security-group/aws//modules/cassandra
+        # We assume versions of submodules are same as parent module
+        org_name_provider = strings.split(source_without_address, "//")[0]
         most_recent_version = discovered_modules[org_name_provider]
         if not version.new(most_recent_version).satisfies(m.version_constraint) {
           if length(module_address) == 0 {
@@ -154,9 +162,16 @@ validate_modules = func() {
         } // end version check
       } else {
         # Check version constraint of module against latest version in public registry
-        most_recent_version = discovered_modules[m.source]
-        if m.source in keys(discovered_modules) {
-          most_recent_version = discovered_modules[m.source]
+        # We check if source is in keys of discovered_modules and then check
+        # version constraint against most recent version.  If source is not in
+        # keys of discovered_modules, then it has source that does not support
+        # versioning and is allowed by this policy.
+        # We trim any submodule references off of m.source to support nested
+        # submodules like terraform-aws-modules/security-group/aws//modules/cassandra
+        # We assume versions of submodules are same as parent module
+        source_without_submodules = strings.split(m.source, "//")[0]
+        if source_without_submodules in keys(discovered_modules) {
+          most_recent_version = discovered_modules[source_without_submodules]
           if not version.new(most_recent_version).satisfies(m.version_constraint) {
             if length(module_address) == 0 {
               print("Public registry module", m.source, "used in the root module",
@@ -166,7 +181,7 @@ validate_modules = func() {
             } else {
               print("Public registry module", m.source, "used in module",
                     module_address, "has version constraint", m.version_constraint,
-                    "that does not allow the most version", most_recent_version)
+                    "that does not allow the most recent version", most_recent_version)
               validated = false
             } // end root module check
           } // end version check

--- a/governance/third-generation/cloud-agnostic/http-examples/use-recent-versions-from-pmr.sentinel
+++ b/governance/third-generation/cloud-agnostic/http-examples/use-recent-versions-from-pmr.sentinel
@@ -1,0 +1,198 @@
+# This policy uses the HTTP import to call the TFC API to get a list of all
+# private and publicly curated modules in the private module registries of
+# specified organizations on a specified TFC/E server and then determines their
+# N latest versions. It then uses the tfconfig/v2 import to inspect all non-root
+# modules and validate that those sourced from the PMRs allow the N latest
+# versions based on their version constraints. Since Terraform will always use
+# the most recent version allowed by a version constraint, this ensures that
+# one of the N most recent versions of the module will be used. N can be set
+# with the `version_limit` parameter. It's default value is 3. The policy blocks
+# use of public registry modules that are not curated and non-registry modules
+# except for local sources starting with "./" and ".//".
+
+# This policy requires the Sentinel runtime 0.16.0 or higher since the
+# registry-functions module it calls uses the Sentinel
+# [version](https://docs.hashicorp.com/sentinel/imports/version) import.
+
+# This policy requires TFE release v202106-1 or higher since it uses
+# the [Registry Module APIs](https://www.terraform.io/docs/cloud/api/modules.html)
+# that were added in that release of TFE.
+
+# TFE does not support publicly curated modules. So, restricting
+# their versions is only possible if using Terraform Cloud (TFC).
+
+
+##### Imports #####
+# Import registry-functions/registry-functions.sentinel
+# with alias "config"
+import "registry-functions" as registry
+# Import common-functions/tfconfig-functions/tfconfig-functions.sentinel
+# with alias "config"
+import "tfconfig-functions" as config
+
+import "strings"
+import "version"
+
+##### Parameters #####
+# The address of the Terraform Cloud or Terraform Enterprise server
+param address default "app.terraform.io"
+# The names of the Terraform Cloud or Terraform Enterprise organizations that
+# modules can be sourced from. They should all belong to the same server.
+param organizations
+# A valid Terraform Cloud or Terraform Enterprise API token
+param token
+# The number of most recent versions to return
+param version_limit default 3
+
+# Validate sources of modules in the registry
+validate_modules = func() {
+
+  # Initialize variables
+  validated = true
+  newest_private_module_versions = {}
+  newest_public_module_versions = {}
+
+  # Iterate over all specified organizations
+  for organizations as organization {
+    # Invoke get_recent_module_versions function with "private" to get
+    # most recent versions for private modules in current organization
+    newest_private_module_versions_for_org =
+        registry.get_recent_module_versions(address, organization,
+                                    token, "private", version_limit)
+    for newest_private_module_versions_for_org as module, versions {
+      newest_private_module_versions[module] = versions
+    }
+    #print("newest private module versions:", newest_private_module_versions)
+
+    # Invoke get_recent_module_versions function with "public" to get
+    # most recent versions for publicly curated modules in current organization
+    newest_public_module_versions_for_org =
+        registry.get_recent_module_versions(address, organization,
+                                    token, "public", version_limit)
+    for newest_public_module_versions_for_org as module, versions {
+      newest_public_module_versions[module] = versions
+    }
+    #print("newest public module versions:", newest_public_module_versions)
+  }
+
+  # Get all module addresses in current configuration from the tfconfig/v2 import
+  allModuleAddresses = config.find_descendant_modules("")
+
+  # Iterate over all modules in the tfconfig/v2 import
+  for allModuleAddresses as module_address {
+    moduleCalls = config.find_module_calls_in_module(module_address)
+    # Iterate over modules of the current module
+    for moduleCalls as index, m {
+      # Check if module is a private module in the PMR
+      if any organizations as organization {
+        strings.has_prefix(m.source, address + "/" + organization)
+        } {
+        # Check version constraint of module against recent versions in PMR
+        source_without_address = strings.trim_prefix(m.source, address + "/")
+        # Support nested modules with sources like
+        # app.terraform.io/Cloud-Operations/security-group/aws//modules/cassandra
+        # We assume versions of submodules are same as parent module
+        org_name_provider = strings.split(source_without_address, "//")[0]
+        most_recent_versions = newest_private_module_versions[org_name_provider]
+        if not any most_recent_versions as module, recent_version {
+          version.new(recent_version).satisfies(m.version_constraint)
+        } {
+          if length(module_address) == 0 {
+            print("Private module", m.source, "used in the root module",
+                  "has version constraint", m.version_constraint, "that does not",
+                  "allow any of the", string(version_limit), "most recent versions",
+                  most_recent_versions)
+            validated = false
+          } else {
+            print("Private module", m.source, "used in module", module_address,
+                  "has version constraint", m.version_constraint, "that does not",
+                  "allow any of the", string(version_limit), "most recent versions",
+                  most_recent_versions)
+            validated = false
+          } // end root module check
+        } // end version check
+      # We ignore portion of source starting with "//" in order to support
+      # nested modules like terraform-aws-modules/security-group/aws//modules/cassandra
+      # in the following else if clause.
+      # We assume versions of submodules are same as parent module
+      } else if strings.split(m.source, "//")[0] in keys(newest_public_module_versions) {
+        # Check version constraint of module against recent versions in public registry
+        source_without_submodules = strings.split(m.source, "//")[0]
+        most_recent_versions = newest_public_module_versions[source_without_submodules]
+        if not any most_recent_versions as module, recent_version {
+          version.new(recent_version).satisfies(m.version_constraint)
+        } {
+          if length(module_address) == 0 {
+            print("Curated public registry module", m.source,
+                  "used in the root module has version constraint",
+                  m.version_constraint, "that does not allow any of the",
+                  string(version_limit), "most recent versions", most_recent_versions)
+            validated = false
+          } else {
+            print("Curated public registry module", m.source, "used in module",
+                  module_address, "has version constraint", m.version_constraint,
+                  "that does not allow any of the", string(version_limit),
+                  "most recent versions", most_recent_versions)
+            validated = false
+          } // end root module check
+        } // end version check
+      } else {
+        # Process other modules such as those in public registry that are not
+        # curated and those with non-registry sources. But allow local modules
+        # with source that start with things like "./" or "../"
+        source_without_submodules = strings.split(m.source, "//")[0]
+        if ! strings.has_prefix(source_without_submodules, ".") {
+          uncurated_public_module =
+            registry.is_module_in_public_registry(source_without_submodules)
+          if uncurated_public_module {
+            # Uncurated registry module
+            if length(module_address) == 0 {
+              print("Uncurated public registry module", m.source,
+                    "used in the root module is not allowed.", "Only private",
+                    "and publicly curated modules from these organizations",
+                    organizations, "are allowed and only if their versions",
+                    "are amongst the", string(version_limit), "most recent versions.")
+              validated = false
+            } else {
+              print("Uncurated public registry module", m.source, "used in module",
+                    module_address, "is not allowed.", "Only private",
+                    "and publicly curated modules from these organizations",
+                    organizations, "are allowed and only if their versions",
+                    "are amongst the", string(version_limit), "most recent versions.")
+              validated = false
+            } // end root module check
+          } else {
+            # Non-registry module
+            if length(module_address) == 0 {
+              print("Module", m.source,
+                    "used in the root module is not allowed.", "Only private",
+                    "and publicly curated modules from these organizations",
+                    organizations, "are allowed and only if their versions",
+                    "are amongst the", string(version_limit), "most recent versions.")
+              validated = false
+            } else {
+              print("Module", m.source, "used in module",
+                    module_address, "is not allowed.", "Only private",
+                    "and publicly curated modules from these organizations",
+                    organizations, "are allowed and only if their versions",
+                    "are amongst the", string(version_limit), "most recent versions.")
+              validated = false
+            } // end root module check
+          } // end uncurated public module check
+        }
+      } // end if module is private or curated public module in PMR
+    } // end for module calls
+  } // end modules
+
+  return validated
+}
+
+##### Rules #####
+
+# Call the validation function
+modules_validated = validate_modules()
+
+# Main rule
+main = rule {
+  modules_validated
+}


### PR DESCRIPTION
Adding use-recent-versions-from-pmr.sentinel policy that can check that each private and publicly curated module in Private Module Registries (PMRs) across multiple organizations on a TFC/E server have version constraints that allow at least one of the N most recent versions in the corresponding PMR.  N is a parameter that can be set. It defaults to 3.

Also adding a registry-functions Sentinel module with some functions that the new policy uses.