### PR TITLE
multiple orgs in require-all-resources-from-pmr.sentinel

### DIFF
--- a/governance/third-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
+++ b/governance/third-generation/cloud-agnostic/require-all-resources-from-pmr.sentinel
@@ -14,19 +14,21 @@ import "strings"
 ### Parameters ###
 # The address of the TFC or TFE server
 param address default "app.terraform.io"
-# The organization on the TFC or TFE server
-param organization
+# The organizations on the TFC or TFE server that modules can some from
+param organizations
 
 # Fnd modules called from root module that are not in the desired PMR
 violatingMCs = filter tfconfig.module_calls as index, mc {
   mc.module_address is "" and
-  not strings.has_prefix(mc.source, address + "/" + organization)
+  not any organizations as organization {
+    strings.has_prefix(mc.source, address + "/" + organization)
+  }
 }
 
 # Print violation messages for invalid modules
 if length(violatingMCs) > 0 and not tfrun.is_destroy {
-  print("All modules called from the root module must come from the",
-        "private module registry", address + "/" + organization)
+  print("All modules called from the root module must come from a",
+        "private module registry in one of these organizations:", organizations, " on server", address)
   for violatingMCs as address, mc {
     print("The module", mc.name, "called from the root module has source",
           mc.source)

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/fail.hcl
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/fail.hcl
@@ -2,8 +2,8 @@ param "address" {
   value = "app.terraform.io"
 }
 
-param "organization" {
-  value = "Cloud-Operations"
+param "organizations" {
+  value = ["Cloud-Operations", "App-Operations"]
 }
 
 mock "tfconfig/v2" {

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-fail.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-fail.sentinel
@@ -184,13 +184,31 @@ outputs = {
 }
 
 module_calls = {
-	"nested": {
+	"nested-local": {
 		"config":             {},
 		"count":              {},
 		"for_each":           {},
 		"module_address":     "",
-		"name":               "nested",
+		"name":               "nested-local",
 		"source":             "./module",
+		"version_constraint": "",
+	},
+	"nested-pmr": {
+		"config":             {},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested-pmr",
+		"source":             "app.terraform.io/Operations/compute/aws",
+		"version_constraint": "",
+	},
+	"nested-public-registry": {
+		"config":             {},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested-public-registry",
+		"source":             "terraform-aws-modules/compute/aws",
 		"version_constraint": "",
 	},
 }

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass-destroy.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass-destroy.sentinel
@@ -122,6 +122,15 @@ module_calls = {
 		"source":             "app.terraform.io/Cloud-Operations/compute/aws",
 		"version_constraint": "",
 	},
+	"nested-local": {
+		"config":             {},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested-local",
+		"source":             "./module",
+		"version_constraint": "",
+	},
 }
 
 strip_index = func(addr) {

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass.sentinel
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/mock-tfconfig-pass.sentinel
@@ -113,13 +113,22 @@ outputs = {
 }
 
 module_calls = {
-	"nested": {
+	"nested-cloud": {
 		"config":             {},
 		"count":              {},
 		"for_each":           {},
 		"module_address":     "",
-		"name":               "nested",
-		"source":             "app.terraform.io/Cloud-Operations/compute/aws",
+		"name":               "nested-cloud",
+		"source":             "app.terraform.io/Cloud-Operations/network/aws",
+		"version_constraint": "",
+	},
+	"nested-app": {
+		"config":             {},
+		"count":              {},
+		"for_each":           {},
+		"module_address":     "",
+		"name":               "nested-app",
+		"source":             "app.terraform.io/App-Operations/compute/aws",
 		"version_constraint": "",
 	},
 }

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass-destroy.hcl
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass-destroy.hcl
@@ -2,8 +2,8 @@ param "address" {
   value = "app.terraform.io"
 }
 
-param "organization" {
-  value = "Cloud-Operations"
+param "organizations" {
+  value = ["Cloud-Operations", "App-Operations"]
 }
 
 mock "tfconfig/v2" {

--- a/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass.hcl
+++ b/governance/third-generation/cloud-agnostic/test/require-all-resources-from-pmr/pass.hcl
@@ -2,8 +2,8 @@ param "address" {
   value = "app.terraform.io"
 }
 
-param "organization" {
-  value = "Cloud-Operations"
+param "organizations" {
+  value = ["Cloud-Operations", "App-Operations"]
 }
 
 mock "tfconfig/v2" {


### PR DESCRIPTION
I've updated require-all-resources-from-pmr.sentinel to support multiple organizations instead of a single organization. This is desired since TFE customers can share modules between organizations.