### PR TITLE
improve no-op processing

### DIFF
--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-no-op.sentinel
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/mock-tfplan-pass-no-op.sentinel
@@ -1,0 +1,405 @@
+terraform_version = "0.12.13"
+
+planned_values = {
+	"outputs": {
+		"sse": {
+			"name":      "sse",
+			"sensitive": false,
+			"value":     "AES256",
+		},
+	},
+	"resources": {
+		"aws_s3_bucket.bucket": {
+			"address":        "aws_s3_bucket.bucket",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "bucket",
+			"provider_name":  "aws",
+			"tainted":        false,
+			"type":           "aws_s3_bucket",
+			"values": {
+				"acl":            "public-read",
+				"bucket":         "roger-012-test",
+				"bucket_prefix":  null,
+				"cors_rule":      [],
+				"force_destroy":  false,
+				"grant":          [],
+				"lifecycle_rule": [],
+				"logging": [
+					{
+						"target_bucket": "roger-tf",
+						"target_prefix": "",
+					},
+				],
+				"object_lock_configuration": [],
+				"policy":                    null,
+				"replication_configuration": [],
+				"server_side_encryption_configuration": [
+					{
+						"rule": [
+							{
+								"apply_server_side_encryption_by_default": [
+									{
+										"kms_master_key_id": null,
+										"sse_algorithm":     "AES256",
+									},
+								],
+							},
+						],
+					},
+				],
+				"tags": {
+					"Owner": "roger@hashicorp.com",
+					"name":  "Roger Test Bucket",
+				},
+				"website": [
+					{
+						"error_document":           null,
+						"index_document":           "index.html",
+						"redirect_all_requests_to": null,
+						"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {
+	"aws_region": {
+		"name":  "aws_region",
+		"value": "us-east-1",
+	},
+	"bucket_acl": {
+		"name":  "bucket_acl",
+		"value": "public-read",
+	},
+	"bucket_name": {
+		"name":  "bucket_name",
+		"value": "roger-012-test",
+	},
+}
+
+resource_changes = {
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"change": {
+			"actions": [
+				"no-op",
+			],
+			"after": null,
+			"after_unknown": {},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "bucket",
+		"provider_name":  "aws",
+		"type":           "aws_s3_bucket",
+	},
+}
+
+output_changes = {
+	"sse": {
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after":         "AES256",
+			"after_unknown": false,
+			"before":        null,
+		},
+		"name": "sse",
+	},
+}
+
+raw = {
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"references": [
+							"var.aws_region",
+						],
+					},
+				},
+				"name": "aws",
+			},
+		},
+		"root_module": {
+			"outputs": {
+				"sse": {
+					"expression": {
+						"references": [
+							"aws_s3_bucket.bucket",
+						],
+					},
+				},
+			},
+			"resources": [
+				{
+					"address": "aws_s3_bucket.bucket",
+					"expressions": {
+						"acl": {
+							"references": [
+								"var.bucket_acl",
+							],
+						},
+						"bucket": {
+							"references": [
+								"var.bucket_name",
+							],
+						},
+						"logging": [
+							{
+								"target_bucket": {
+									"constant_value": "roger-tf",
+								},
+							},
+						],
+						"server_side_encryption_configuration": [
+							{
+								"rule": [
+									{
+										"apply_server_side_encryption_by_default": [
+											{
+												"kms_master_key_id": {
+													"constant_value": null,
+												},
+												"sse_algorithm": {
+													"constant_value": "AES256",
+												},
+											},
+										],
+									},
+								],
+							},
+						],
+						"tags": {
+							"constant_value": {
+								"Owner": "roger@hashicorp.com",
+								"name":  "Roger Test Bucket",
+							},
+						},
+						"website": [
+							{
+								"index_document": {
+									"constant_value": "index.html",
+								},
+								"routing_rules": {
+									"constant_value": "[{\n    \"Condition\": {\n        \"KeyPrefixEquals\": \"docs/\"\n    },\n    \"Redirect\": {\n        \"ReplaceKeyPrefixWith\": \"documents/\"\n    }\n}]\n",
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "bucket",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_s3_bucket",
+				},
+			],
+			"variables": {
+				"aws_region": {
+					"default":     "us-east-1",
+					"description": "AWS region",
+				},
+				"bucket_acl": {
+					"default":     "private",
+					"description": "ACL for S3 bucket: private, public-read, public-read-write, etc",
+				},
+				"bucket_name": {
+					"description": "Name of the bucket to create",
+				},
+			},
+		},
+	},
+	"format_version": "0.1",
+	"output_changes": {
+		"sse": {
+			"actions": [
+				"create",
+			],
+			"after":         "AES256",
+			"after_unknown": false,
+			"before":        null,
+		},
+	},
+	"planned_values": {
+		"outputs": {
+			"sse": {
+				"sensitive": false,
+				"value":     "AES256",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_s3_bucket.bucket",
+					"mode":           "managed",
+					"name":           "bucket",
+					"provider_name":  "aws",
+					"schema_version": 0,
+					"type":           "aws_s3_bucket",
+					"values": {
+						"acl":            "public-read",
+						"bucket":         "roger-012-test",
+						"bucket_prefix":  null,
+						"cors_rule":      [],
+						"force_destroy":  false,
+						"grant":          [],
+						"lifecycle_rule": [],
+						"logging": [
+							{
+								"target_bucket": "roger-tf",
+								"target_prefix": "",
+							},
+						],
+						"object_lock_configuration": [],
+						"policy":                    null,
+						"replication_configuration": [],
+						"server_side_encryption_configuration": [
+							{
+								"rule": [
+									{
+										"apply_server_side_encryption_by_default": [
+											{
+												"kms_master_key_id": null,
+												"sse_algorithm":     "AES256",
+											},
+										],
+									},
+								],
+							},
+						],
+						"tags": {
+							"Owner": "roger@hashicorp.com",
+							"name":  "Roger Test Bucket",
+						},
+						"website": [
+							{
+								"error_document":           null,
+								"index_document":           "index.html",
+								"redirect_all_requests_to": null,
+								"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_s3_bucket.bucket",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"acl":            "public-read",
+					"bucket":         "roger-012-test",
+					"bucket_prefix":  null,
+					"cors_rule":      [],
+					"force_destroy":  false,
+					"grant":          [],
+					"lifecycle_rule": [],
+					"logging": [
+						{
+							"target_bucket": "roger-tf",
+							"target_prefix": "",
+						},
+					],
+					"object_lock_configuration": [],
+					"policy":                    null,
+					"replication_configuration": [],
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{
+											"kms_master_key_id": null,
+											"sse_algorithm":     "AES256",
+										},
+									],
+								},
+							],
+						},
+					],
+					"tags": {
+						"Owner": "roger@hashicorp.com",
+						"name":  "Roger Test Bucket",
+					},
+					"website": [
+						{
+							"error_document":           null,
+							"index_document":           "index.html",
+							"redirect_all_requests_to": null,
+							"routing_rules":            "[{\"Condition\":{\"KeyPrefixEquals\":\"docs/\"},\"Redirect\":{\"ReplaceKeyPrefixWith\":\"documents/\"}}]",
+						},
+					],
+				},
+				"after_unknown": {
+					"acceleration_status": true,
+					"arn":                         true,
+					"bucket_domain_name":          true,
+					"bucket_regional_domain_name": true,
+					"cors_rule":                   [],
+					"grant":                       [],
+					"hosted_zone_id":              true,
+					"id":                          true,
+					"lifecycle_rule":              [],
+					"logging": [
+						{},
+					],
+					"object_lock_configuration": [],
+					"region":                    true,
+					"replication_configuration": [],
+					"request_payer":             true,
+					"server_side_encryption_configuration": [
+						{
+							"rule": [
+								{
+									"apply_server_side_encryption_by_default": [
+										{},
+									],
+								},
+							],
+						},
+					],
+					"tags":       {},
+					"versioning": true,
+					"website": [
+						{},
+					],
+					"website_domain":   true,
+					"website_endpoint": true,
+				},
+				"before": null,
+			},
+			"mode":          "managed",
+			"name":          "bucket",
+			"provider_name": "aws",
+			"type":          "aws_s3_bucket",
+		},
+	],
+	"terraform_version": "0.12.13",
+	"variables": {
+		"aws_region": {
+			"value": "us-east-1",
+		},
+		"bucket_acl": {
+			"value": "public-read",
+		},
+		"bucket_name": {
+			"value": "roger-012-test",
+		},
+	},
+}

--- a/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/pass-no-op.hcl
+++ b/governance/third-generation/aws/test/require-private-acl-and-kms-for-s3-buckets/pass-no-op.hcl
@@ -1,0 +1,15 @@
+module "tfplan-functions" {
+  source = "../../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "mock-tfplan-pass-no-op.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources.md
@@ -1,5 +1,5 @@
 # find_datasources
-This function finds all data source instances of a specific type that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included.
+This function finds all data source instances of a specific type that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
 
 When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
 

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
@@ -1,5 +1,5 @@
 # find_datasources_by_provider
-This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included.
+This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
 
 When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
 

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources.md
@@ -1,5 +1,5 @@
 # find_resources
-This function finds all resource instances of a specific type in the current plan that are being created, modified or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included.
+This function finds all resource instances of a specific type in the current plan that are being created, modified or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
 
 ## Sentinel Module
 This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.

--- a/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
+++ b/governance/third-generation/common-functions/tfplan-functions/docs/find_resources_by_provider.md
@@ -1,5 +1,5 @@
 # find_resources_by_provider
-This function finds all resource instances for a specific provider in the current plan that are being created, modified, or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included.
+This function finds all resource instances for a specific provider in the current plan that are being created, modified, or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
 
 If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
 

--- a/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -27,7 +27,8 @@ find_resources = func(type) {
   	rc.type is type and
   	rc.mode is "managed" and
   	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-     rc.change.actions contains "read" or rc.change.actions contains "no-op")
+     rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+     rc.change.after is not null))
   }
 
   return resources
@@ -53,7 +54,8 @@ find_resources_by_provider = func(provider) {
       rc.provider_name is provider and
     	rc.mode is "managed" and
     	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-       rc.change.actions contains "read" or rc.change.actions contains "no-op")
+       rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+       rc.change.after is not null))
     }
   } else {
     # v_major must be higher than 12 since v2 imports being used
@@ -65,7 +67,8 @@ find_resources_by_provider = func(provider) {
         strings.split(rc.provider_name, "/")[2] is provider and
       	rc.mode is "managed" and
       	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+         rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+         rc.change.after is not null))
       }
     } else {
       # Function was passed long form, so we use full rc.provider_name
@@ -73,7 +76,8 @@ find_resources_by_provider = func(provider) {
         rc.provider_name is provider and
       	rc.mode is "managed" and
       	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+         rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+         rc.change.after is not null))
       }
     } // end segment_count
   } // end v_major
@@ -92,7 +96,7 @@ find_datasources = func(type) {
   	(rc.change.actions contains "create" or
     rc.change.actions contains "update" or
     rc.change.actions contains "read" or
-    rc.change.actions contains "no-op")
+    (rc.change.actions contains "no-op" and rc.change.after is not null))
   }
 
   return datasources
@@ -118,7 +122,8 @@ find_datasources_by_provider = func(provider) {
       rc.provider_name is provider and
     	rc.mode is "data" and
     	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-       rc.change.actions contains "read" or rc.change.actions contains "no-op")
+       rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+       rc.change.after is not null))
     }
   } else {
     # v_major must be higher than 12 since v2 imports being used
@@ -130,7 +135,8 @@ find_datasources_by_provider = func(provider) {
         strings.split(rc.provider_name, "/")[2] is provider and
       	rc.mode is "data" and
       	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+         rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+         rc.change.after is not null))
       }
     } else {
       # Function was passed long form, so we use full rc.provider_name
@@ -138,7 +144,8 @@ find_datasources_by_provider = func(provider) {
         rc.provider_name is provider and
       	rc.mode is "data" and
       	(rc.change.actions contains "create" or rc.change.actions contains "update" or
-         rc.change.actions contains "read" or rc.change.actions contains "no-op")
+         rc.change.actions contains "read" or (rc.change.actions contains "no-op" and
+         rc.change.after is not null))
       }
     } // end segment_count
   } // end v_major


### PR DESCRIPTION
Improve filters in find functions of tfplan-functions module to do better processing of `no-op` action.  Specifically, resources with the no-op action are only included if change.after is not null.  This is intended to cover the situation in which a resource is deleted outside of Terraform. In this case, the state is updated during the refresh operation done by the terraform plan command and the data presented to Sentinel has the no-op action instead of the delete action even though the plan is deleting the state associated with the resource.  One could argue that the action should be delete, but since it is currently no-op, changing the filter prevents policy failures against resources that have already been deleted.

Keeping the no-op action in the filter allows policies to apply new policies to existing resources that are not being changed.  So, we do want to keep it in the filter.