### PR TITLE
Deprecate governance

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -1,6 +1,6 @@
 # Governance with Terraform Sentinel Policies
 
-** Note: The Third-Generation Policies Now Live in [terraform-sentinel-policies](https://github.com/hashicorp/terraform-sentinel-policies). Please add and edit policies in that repository.**
+**Note: The Third-Generation Policies Now Live in [terraform-sentinel-policies](https://github.com/hashicorp/terraform-sentinel-policies). Please add and edit policies in that repository.**
 
 Sentinel gives operations teams the governance capabilities they need to ensure that all infrastructure provisioned with Terraform Enterprise complies with their organization's provisioning rules. The files under this directory and its sub-directories provide some sample Sentinel policies for AWS, Microsoft Azure, Google Cloud Platform (GCP), and VMware as well as some cloud-agnostic policies.
 

--- a/governance/third-generation/README.md
+++ b/governance/third-generation/README.md
@@ -1,6 +1,6 @@
 # Third-Generation Sentinel Policies
 
-** Note: The Third-Generation Policies Now Live in [terraform-sentinel-policies](https://github.com/hashicorp/terraform-sentinel-policies). Please add and edit policies in that repository.**
+**Note: The Third-Generation Policies Now Live in [terraform-sentinel-policies](https://github.com/hashicorp/terraform-sentinel-policies). Please add and edit policies in that repository.**
 
 This directory and its sub-directories contain third-generation Sentinel policies and associated [Sentinel CLI](https://docs.hashicorp.com/sentinel/intro/getting-started/install) test cases and mocks which were created in 2020 for AWS, Microsoft Azure, Google Cloud Platform (GCP), and VMware. It also contains some some common, re-usable functions.
 


### PR DESCRIPTION
Had space after `**` in boldface in both README.md files I edited in previous PR