### PR TITLE
Bring GCP label enforcement up to parity with Azure tag enforcement

### DIFF
--- a/governance/third-generation/gcp/enforce-mandatory-labels.sentinel
+++ b/governance/third-generation/gcp/enforce-mandatory-labels.sentinel
@@ -1,25 +1,40 @@
 # This policy uses the Sentinel tfplan/v2 import to require that
-# all GCE compute instances have all mandatory labels
-
-# Note that the comparison is case-sensitive but also that GCE labels are only
-# allowed to contain lowercase letters, numbers, hypens, and underscores.
+# specified GCP resources have all mandatory labels
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan
 
+# Import gcp-functions/gcp-functions.sentinel
+# with alias "gcp"
+import "gcp-functions" as gcp
+
+# List of GCP resources that are required to have name/value labels.
+param resource_types default [
+  "google_project",
+  "google_compute_instance",
+  "google_storage_bucket",
+]
+
 # List of mandatory labels
-mandatory_labels = ["name", "ttl", "owner"]
+param mandatory_labels default [
+  "name",
+  "ttl",
+  "owner",
+]
 
-# Get all GCE compute instances
-allGCEInstances = plan.find_resources("google_compute_instance")
+# Get all GCP Resources with standard labels
+allGCPResourcesWithStandardLabels =
+                        gcp.find_resources_with_standard_labels(resource_types)
 
-# Filter to GCE compute instances with violations
+# Filter to GCP resources with violations using list of resources
 # Warnings will be printed for all violations since the last parameter is true
-violatingGCEInstances = plan.filter_attribute_not_contains_list(allGCEInstances,
-                        "labels", mandatory_labels, true)
+violatingGCPResources =
+      plan.filter_attribute_not_contains_list(allGCPResourcesWithStandardLabels,
+                    "labels", mandatory_labels, true)
+
 
 # Main rule
 main = rule {
-  length(violatingGCEInstances["messages"]) is 0
+  length(violatingGCPResources["messages"]) is 0
 }

--- a/governance/third-generation/gcp/gcp-functions/docs/find_resources_with_standard_tags.md
+++ b/governance/third-generation/gcp/gcp-functions/docs/find_resources_with_standard_tags.md
@@ -1,0 +1,44 @@
+# find_resources_with_standard_labels
+
+This function finds all GCP resource instances of specified types in the current plan that are not being permanently deleted using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+This function works with both the short name of the GCP provider, "google", and fully-qualfied provider names that match the regex, `(.*)google$`. The latter is required because Terraform 0.13 and above returns the fully-qualified names of providers such as "registry.terraform.io/providers/hashicorp/google" to Sentinel. Older versions of Terraform only return the short-form such as "google".
+
+## Sentinel Module
+
+This function is contained in the [gcp-functions.sentinel](../gcp-functions.sentinel) module.
+
+## Declaration
+
+`find_resources_with_standard_labels = func(resource_types)`
+
+## Arguments
+
+* **resource_types**: a list of GCP resource types that should have specified tags defined.
+
+## Common Functions Used
+
+None
+
+## What It Returns
+
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+
+This function does not print anything.
+
+## Examples
+
+Here is an example of calling this function, assuming that the gcp-functions.sentinel file that contains it has been imported with the alias `gcp`:
+```
+resource_types = [
+  "google_compute_instance",
+  "google_storage_bucket",
+]
+
+allGCPSResourcesWithStandardTags =  
+                        azure.find_resources_with_standard_labels(resource_types)
+```
+
+This function is used by the [enforce-mandatory-labels.sentinel](../../enforce-mandatory-labels.sentinel) policy.

--- a/governance/third-generation/gcp/gcp-functions/gcp-functions.sentinel
+++ b/governance/third-generation/gcp/gcp-functions/gcp-functions.sentinel
@@ -1,0 +1,19 @@
+# Common functions for use with the GCP provider
+
+##### Imports #####
+import "tfplan/v2" as tfplan
+
+##### Functions #####
+
+### find_resources_with_standard_labels ###
+find_resources_with_standard_labels = func(resource_types) {
+  resources = filter tfplan.resource_changes as address, rc {
+    rc.provider_name matches "(.*)google$" and
+    rc.type in resource_types and
+  	rc.mode is "managed" and
+  	(rc.change.actions contains "create" or rc.change.actions contains "update" or
+     rc.change.actions contains "read" or rc.change.actions contains "no-op")
+  }
+
+  return resources
+}

--- a/governance/third-generation/gcp/sentinel.hcl
+++ b/governance/third-generation/gcp/sentinel.hcl
@@ -16,7 +16,7 @@ module "gcp-functions" {
 
 policy "enforce-mandatory-labels" {
     source = "./enforce-mandatory-labels.sentinel"
-    enforcement_level = "soft-mandatory"
+    enforcement_level = "advisory"
 }
 
 policy "restrict-egress-firewall-destination-ranges" {

--- a/governance/third-generation/gcp/sentinel.hcl
+++ b/governance/third-generation/gcp/sentinel.hcl
@@ -10,9 +10,13 @@ module "tfconfig-functions" {
     source = "../common-functions/tfconfig-functions/tfconfig-functions.sentinel"
 }
 
+module "gcp-functions" {
+    source = "./gcp-functions/gcp-functions.sentinel"
+}
+
 policy "enforce-mandatory-labels" {
     source = "./enforce-mandatory-labels.sentinel"
-    enforcement_level = "advisory"
+    enforcement_level = "soft-mandatory"
 }
 
 policy "restrict-egress-firewall-destination-ranges" {


### PR DESCRIPTION
Add GCP function to facilitate enforcing labels on multiple resources.  This is similar to the way its handled in the Azure function.