### PR TITLE
Fix AWS EC2 tags format from block to map and update README

### DIFF
--- a/infrastructure-as-code/aws-ec2-instance/README.md
+++ b/infrastructure-as-code/aws-ec2-instance/README.md
@@ -5,3 +5,50 @@ This Terraform configuration provisions an EC2 instance in AWS.
 By default, this configuration provisions a Ubuntu 14.04 Base Image AMI (with ID ami-2e1ef954) with type t2.micro in the us-east-1 region. The AMI ID, region, and type can all be set as variables. You can also set the name variable to determine the value set for the Name tag.
 
 Note that you need to set environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+
+## Step-by-Step Execution
+
+1. **Install Terraform**: Ensure that Terraform is installed on your machine. You can download it from [Terraform's official website](https://www.terraform.io/downloads.html).
+
+2. **Clone the Repository**: Clone this repository to your local machine.
+    ```sh
+    git clone https://github.com/hashicorp/terraform-guides.git
+    cd terraform-guides/infrastructure-as-code/aws-ec2-instance
+    ```
+
+3. **Set AWS Credentials**: You can either set your AWS credentials as environment variables or configure AWS CLI on your system.
+
+    **Option 1: Set environment variables**
+    ```sh
+    export AWS_ACCESS_KEY_ID=your_access_key_id
+    export AWS_SECRET_ACCESS_KEY=your_secret_access_key
+    ```
+
+    **Option 2: Configure AWS CLI**
+    ```sh
+    aws configure
+    ```
+
+4. **Initialize Terraform**: Initialize the Terraform configuration.
+    ```sh
+    terraform init
+    ```
+
+5. **Plan the Infrastructure**: Generate and review the execution plan.
+    ```sh
+    terraform plan
+    ```
+
+6. **Apply the Configuration**: Apply the Terraform configuration to provision the EC2 instance.
+    ```sh
+    terraform apply
+    ```
+
+7. **Verify the Instance**: After the apply command completes, you can verify the instance in the AWS Management Console.
+
+8. **Destroy the Infrastructure**: When you no longer need the instance, you can destroy the infrastructure.
+    ```sh
+    terraform destroy
+    ```
+
+Make sure to replace `your_access_key_id` and `your_secret_access_key` with your actual AWS credentials.

--- a/infrastructure-as-code/aws-ec2-instance/main.tf
+++ b/infrastructure-as-code/aws-ec2-instance/main.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "ubuntu" {
   instance_type = "${var.instance_type}"
   availability_zone = "${var.aws_region}a"
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }


### PR DESCRIPTION
- Changed AWS EC2 instance `tags` format from block to map (Terraform best practice).
- Updated README documentation with a step-by-step process to run the code.
- Ensures consistency with Terraform syntax.
